### PR TITLE
Hardcode the locales.

### DIFF
--- a/ncm-spma/src/main/perl/spma.pm
+++ b/ncm-spma/src/main/perl/spma.pm
@@ -400,6 +400,11 @@ sub Configure
 {
     my ($self, $config) = @_;
 
+    # We are parsing some outputs in this component.  We must set a
+    # locale that we can understand.
+    local $ENV{LANG} = 'C';
+    local $ENV{LC_ALL} = 'C';
+
     my $repos = $config->getElement(REPOS_TREE)->getTree();
     my $t = $config->getElement(CMP_TREE)->getTree();
     # Convert these crappily-defined fields into real Perl booleans.

--- a/ncm-spma/src/test/perl/configure.t
+++ b/ncm-spma/src/test/perl/configure.t
@@ -227,6 +227,17 @@ foreach my $f (qw(generate_repos cleanup_old_repos initialize_repos_dir)) {
     $mock->set_true($f);
 }
 
+=pod
+
+=item * The LANG environment variable is kept
+
+=cut
+
+$mock->mock('generate_repos', sub {
+		    is($ENV{LANG}, "C", "LANG environment variable kept");
+		    return 1;
+	    });
+
 done_testing();
 
 __END__


### PR DESCRIPTION
We have to do our error handling by parsing the stderr and stdout.
The locales must _not_ get in our way.
