### PR TITLE
Make ncm-metaconfig depend on the modules it uses for rendering.

### DIFF
--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -50,13 +50,20 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.quattor.pan</groupId>
-          <artifactId>panc-maven-plugin</artifactId>
-          <version>9.0.0-RC3</version>
-        </plugin>
+	<plugin>
+	  <groupId>org.codehaus.mojo</groupId>
+	  <artifactId>rpm-maven-plugin</artifactId>
+	  <configuration>
+            <requires>
+              <require>perl(Config::Tiny)</require>
+              <require>perl(Config::General)</require>
+              <require>perl(JSON::XS)</require>
+              <require>perl(YAML::XS)</require>
+              <require>perl(Template)</require>
+            </requires>
+	  </configuration>
+	</plugin>
       </plugins>
     </pluginManagement>
   </build>
-
 </project>


### PR DESCRIPTION
As requested by @jrha and @iancollier .

It's surprising and annoying when the user declares a file and the component fails because it couldn't load the correct module.

The dependencies are small enough, so it's better to have them there and ease the users' lifes.
