### PR TITLE
Add --show-duplicates to repoquery invocations.

### DIFF
--- a/ncm-spma/src/main/perl/spma.pm
+++ b/ncm-spma/src/main/perl/spma.pm
@@ -35,7 +35,7 @@ use constant YUM_EXPIRE => qw(yum clean expire-cache);
 
 use constant YUM_CONF_FILE => "/etc/yum.conf";
 use constant CLEANUP_ON_REMOVE => "clean_requirements_on_remove";
-use constant REPOQUERY => qw(repoquery --envra);
+use constant REPOQUERY => qw(repoquery --show-duplicates --envra);
 use constant YUM_COMPLETE_TRANSACTION => "yum-complete-transaction";
 use constant OBSOLETE => "obsoletes";
 


### PR DESCRIPTION
Allows to lock multiple versions of the same package (f.i, the kernel
or the JRE), fixing #10.
