### PR TITLE
ncm-sendmail: quote SMART_HOST to allow brackets.

### DIFF
--- a/ncm-sendmail/src/main/perl/sendmail.pm
+++ b/ncm-sendmail/src/main/perl/sendmail.pm
@@ -198,9 +198,10 @@ sub Configure {
     ## Set the outgoing mail server
     if($config->elementExists($cfgpathsmtpserver)) {
       my $cfgvaluesmtpserver=$config->getValue($cfgpathsmtpserver);
+      my $quotedsmtpserver=quotemeta($cfgvaluesmtpserver);
       NCM::Check::lines($cfgfilemc,
 			linere => ".*define.*SMART_HOST.*",
-			goodre => "^define.\`SMART_HOST',`".$cfgvaluesmtpserver."\'.dnl",
+			goodre => "^define.\`SMART_HOST',`".$quotedsmtpserver."\'.dnl",
 			good   => "define(`SMART_HOST',`".$cfgvaluesmtpserver."')dnl",
 		       );
       $self->info("using smarthost:  $cfgvaluesmtpserver");


### PR DESCRIPTION
I was trying to set the SMART_HOST parameter with something like "[smtp.server.net]". This configuration make it possible to directly use the IP instead of using the "MX" record to retrieve the IP...

The component refuses to make the change because the square brackets are considered as part of the regexp. So, i've done a tiny change to quote the SMART_HOST value before use it.
