### PR TITLE
Fix Perl errors.

### DIFF
--- a/ncm-cron/src/main/perl/cron.pm
+++ b/ncm-cron/src/main/perl/cron.pm
@@ -94,7 +94,7 @@ sub Configure($$@) {
         }
 
         my $fname = $name;
-	$file =~ s{[/\s]}{_}g;
+	$fname =~ s{[/\s]}{_}g;
 	my $file = "$crond/$fname.ncm-cron.cron";
         $self->info("Checking cron entry $name ($file)...");
 


### PR DESCRIPTION
The filename was done against the variable `$file` instead of
`$fname`, which lead to Perl failing under `strict` mode.

Fixed now.
