### PR TITLE
Bump the build tools used.

### DIFF
--- a/ncm-afsclt/pom.xml
+++ b/ncm-afsclt/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-aiiserver/pom.xml
+++ b/ncm-aiiserver/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-alternatives/pom.xml
+++ b/ncm-alternatives/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-altlogrotate/pom.xml
+++ b/ncm-altlogrotate/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-amandaserver/pom.xml
+++ b/ncm-amandaserver/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-authconfig/pom.xml
+++ b/ncm-authconfig/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-autofs/pom.xml
+++ b/ncm-autofs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-ccm/pom.xml
+++ b/ncm-ccm/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-cdp/pom.xml
+++ b/ncm-cdp/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-chkconfig/pom.xml
+++ b/ncm-chkconfig/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-cron/pom.xml
+++ b/ncm-cron/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-directoryservices/pom.xml
+++ b/ncm-directoryservices/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-dirperm/pom.xml
+++ b/ncm-dirperm/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-diskless_server/pom.xml
+++ b/ncm-diskless_server/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-download/pom.xml
+++ b/ncm-download/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-drbd/pom.xml
+++ b/ncm-drbd/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-etcservices/pom.xml
+++ b/ncm-etcservices/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-filecopy/pom.xml
+++ b/ncm-filecopy/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-filesystems/pom.xml
+++ b/ncm-filesystems/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-fmonagent/pom.xml
+++ b/ncm-fmonagent/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-fsprobe/pom.xml
+++ b/ncm-fsprobe/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-fstab/pom.xml
+++ b/ncm-fstab/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-gmetad/pom.xml
+++ b/ncm-gmetad/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-gmond/pom.xml
+++ b/ncm-gmond/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-gpfs/pom.xml
+++ b/ncm-gpfs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-grub/pom.xml
+++ b/ncm-grub/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-hostsaccess/pom.xml
+++ b/ncm-hostsaccess/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-hostsfile/pom.xml
+++ b/ncm-hostsfile/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-icinga/pom.xml
+++ b/ncm-icinga/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-interactivelimits/pom.xml
+++ b/ncm-interactivelimits/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-ipmi/pom.xml
+++ b/ncm-ipmi/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-iptables/pom.xml
+++ b/ncm-iptables/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-iscsitarget/pom.xml
+++ b/ncm-iscsitarget/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-krb5clt/pom.xml
+++ b/ncm-krb5clt/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-ldconf/pom.xml
+++ b/ncm-ldconf/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-linuxha/pom.xml
+++ b/ncm-linuxha/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-mailaliases/pom.xml
+++ b/ncm-mailaliases/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-mcx/pom.xml
+++ b/ncm-mcx/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-modprobe/pom.xml
+++ b/ncm-modprobe/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-mysql/pom.xml
+++ b/ncm-mysql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-nagios/pom.xml
+++ b/ncm-nagios/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-named/pom.xml
+++ b/ncm-named/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-network/pom.xml
+++ b/ncm-network/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-networkupstools/pom.xml
+++ b/ncm-networkupstools/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-nfs/pom.xml
+++ b/ncm-nfs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-nrpe/pom.xml
+++ b/ncm-nrpe/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-nsca/pom.xml
+++ b/ncm-nsca/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-nscd/pom.xml
+++ b/ncm-nscd/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-ntpd/pom.xml
+++ b/ncm-ntpd/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-ofed/pom.xml
+++ b/ncm-ofed/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-openldap/pom.xml
+++ b/ncm-openldap/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-openvpn/pom.xml
+++ b/ncm-openvpn/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-oramonserver/pom.xml
+++ b/ncm-oramonserver/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-pacemaker/pom.xml
+++ b/ncm-pacemaker/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-pakiti/pom.xml
+++ b/ncm-pakiti/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-pam/pom.xml
+++ b/ncm-pam/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-php/pom.xml
+++ b/ncm-php/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-pine/pom.xml
+++ b/ncm-pine/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-pnp4nagios/pom.xml
+++ b/ncm-pnp4nagios/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-portmap/pom.xml
+++ b/ncm-portmap/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-postfix/pom.xml
+++ b/ncm-postfix/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-postgresql/pom.xml
+++ b/ncm-postgresql/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-profile/pom.xml
+++ b/ncm-profile/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-pvss/pom.xml
+++ b/ncm-pvss/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-raidman/pom.xml
+++ b/ncm-raidman/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-resolver/pom.xml
+++ b/ncm-resolver/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-rproxy/pom.xml
+++ b/ncm-rproxy/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-runlevel/pom.xml
+++ b/ncm-runlevel/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-selinux/pom.xml
+++ b/ncm-selinux/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-sendmail/pom.xml
+++ b/ncm-sendmail/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-serialclient/pom.xml
+++ b/ncm-serialclient/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-shorewall/pom.xml
+++ b/ncm-shorewall/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-sindes_getcert/pom.xml
+++ b/ncm-sindes_getcert/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-slocate/pom.xml
+++ b/ncm-slocate/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-spma/pom.xml
+++ b/ncm-spma/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-squid/pom.xml
+++ b/ncm-squid/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-srvtab/pom.xml
+++ b/ncm-srvtab/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-ssh/pom.xml
+++ b/ncm-ssh/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-sshkeys/pom.xml
+++ b/ncm-sshkeys/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-state/pom.xml
+++ b/ncm-state/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-sudo/pom.xml
+++ b/ncm-sudo/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-symlink/pom.xml
+++ b/ncm-symlink/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-sysconfig/pom.xml
+++ b/ncm-sysconfig/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-sysctl/pom.xml
+++ b/ncm-sysctl/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-syslog/pom.xml
+++ b/ncm-syslog/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-syslogng/pom.xml
+++ b/ncm-syslogng/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-tftpd/pom.xml
+++ b/ncm-tftpd/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-tomcat/pom.xml
+++ b/ncm-tomcat/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-useraccess/pom.xml
+++ b/ncm-useraccess/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-xen/pom.xml
+++ b/ncm-xen/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>

--- a/ncm-zephyrclt/pom.xml
+++ b/ncm-zephyrclt/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.28</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
Build tools 1.31 are needed to run the tests on SL5. Fixes #29 .
