### PR TITLE
Re-create the managed_files directory in ncm-profile

### DIFF
--- a/ncm-profile/pom.xml
+++ b/ncm-profile/pom.xml
@@ -44,4 +44,24 @@
     </contributor>
   </contributors>
 
+  <build>
+    <plugins>
+      <plugin>
+	<groupId>org.codehaus.mojo</groupId>
+	<artifactId>rpm-maven-plugin</artifactId>
+	<configuration>
+	  <mappings combine.children="append">
+	    <mapping>
+	      <directory>/usr/lib/ncm/config/profile/managed_files/</directory>
+	      <filemode>755</filemode>
+		<username>root</username>
+		<groupname>root</groupname>
+		<directoryIncluded>true</directoryIncluded>
+	      </mapping>
+	    </mappings>
+	</configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Fixes #34. Thanks to @nowack73 for the bug report.

Includes some POM makeup.
