### PR TITLE
Fix RPM queries.

### DIFF
--- a/ncm-gpfs/src/main/perl/gpfs.pm
+++ b/ncm-gpfs/src/main/perl/gpfs.pm
@@ -226,7 +226,7 @@ sub Configure {
     sub remove_existing_rpms {
         my $ret = 1;
         my $tr;
-        my $allrpms = runrpm($tr,"-q","-a","gpfs.*","--qf","%{NAME} %{NAME}-%{VERSION}-%{rpm.release}\\n");
+        my $allrpms = runrpm($tr,"-q","-a","gpfs.*","--qf","%{NAME} %{NAME}-%{VERSION}-%{RELEASE}\\n");
         return if (!$allrpms);
 
         my @removerpms;


### PR DESCRIPTION
Fixes #37.

The bug was introduced while trying to generate the -SNAPSHOT<date> in the RPM release field.  It affected this Perl file by mistake.
