### PR TITLE
Correct LogLevel validation in ncm-ssh schema

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -18,7 +18,7 @@ type ssh_core_options_type = {
     "GSSAPICleanupCredentials"          ? ssh_yesnostring
     "GatewayPorts"                      ? ssh_yesnostring
     "HostbasedAuthentication"           ? ssh_yesnostring
-    "LogLevel"                          ? string with match (SELF, '^(DEBUG|INFO|NOTICE|WARNING|ERR|CRIT|ALERT|EMERG)$')
+    "LogLevel"                          ? string with match (SELF, '^(QUIET|FATAL|ERROR|INFO|VERBOSE|DEBUG|DEBUG1|DEBUG2|DEBUG3)$')
     "MACs"                              ? string
     "PasswordAuthentication"            ? ssh_yesnostring
     "Protocol"                          ? string


### PR DESCRIPTION
The schema for ssh LogLevel was following standard SYSLOG levels rather than
the correct ssh options, correct this from the schema as used at RAL.

This partially addresses issue #43.
