### PR TITLE
Validate the SSHD configurations.

### DIFF
--- a/ncm-ssh/src/main/perl/ssh.pm
+++ b/ncm-ssh/src/main/perl/ssh.pm
@@ -28,15 +28,35 @@ use CAF::Process;
 use CAF::FileEditor;
 use constant SSHD_CONFIG => "/etc/ssh/sshd_config";
 use constant SSH_CONFIG => "/etc/ssh/ssh_config";
+use constant SSH_VALIDATE => qw(sshd -t -f /proc/self/fd/0);
 
+# Returns true if $file is a valid SSHD configuration file.
+sub valid_sshd_file
+{
+    my ($self, $file) = @_;
+
+    my $cmd = CAF::Process->new([SSH_VALIDATE], log => $self, stdin => "$file",
+				stderr => \my $err, keeps_state => 1);
+
+    $cmd->execute();
+
+    if ($?) {
+	$self->error("Invalid configuration file: $err");
+	return 0;
+    }
+    $self->warn("Non-fatal issues in the configuration file: $err") if $err;
+    return 1;
+}
 
 #
 # Process options for SSH daemon and client: processing is almost
 # identical for both.  Returns whether or not the file changed, so
 # that the caller may restart the daemon.
+#
+# Takes an optional parameter to validate the generated file.
 sub handle_config_file
 {
-    my ($self, $filename, $mode, $cfg) = @_;
+    my ($self, $filename, $mode, $cfg, $validate) = @_;
 
     my $fh = CAF::FileEditor->new($filename, log => $self, mode => $mode,
 				  backup => '.old');
@@ -63,6 +83,11 @@ sub handle_config_file
 	    }
 	}
     }
+
+    if ($validate && !$validate->($self, $fh)) {
+	$fh->cancel();
+    }
+
     return $fh->close();
 }
 
@@ -77,7 +102,8 @@ sub Configure
     my $ok = 1;
 
     if ($ssh_config->{daemon}) {
-	if ($self->handle_config_file(SSHD_CONFIG, 0600, $ssh_config->{daemon})) {
+	if ($self->handle_config_file(SSHD_CONFIG, 0600, $ssh_config->{daemon},
+				      \&valid_sshd_file)) {
 	    CAF::Process->new([qw(/sbin/service sshd condrestart)], log => $self)->run();
 	    if ($?) {
 		$self->error("Unable to restart the sshd daemon");

--- a/ncm-ssh/src/test/perl/handle_files.t
+++ b/ncm-ssh/src/test/perl/handle_files.t
@@ -7,6 +7,18 @@ use CAF::Object;
 use NCM::Component::ssh;
 use Readonly;
 use CAF::FileWriter;
+use Test::MockModule;
+
+my $mock = Test::MockModule->new("CAF::FileWriter");
+
+# Mock the cancel method to know if it was actually called.  Since we
+# use NoAction here it will always be called once.  The component may
+# call it as a second time.
+$mock->mock("cancel", sub {
+                my $self = shift;
+                *$self->{CANCELLED}++;
+                *$self->{save} = 0;
+            });
 
 Readonly my $SSH_FILE => "target/test/sshd";
 Readonly my $SSH_CONTENTS => "Foo bar baz\n";
@@ -15,12 +27,12 @@ my $fh = CAF::FileWriter->new($SSH_FILE);
 print $fh $SSH_CONTENTS;
 $fh->close();
 
-
 =pod
 
 =head1 DESCRIPTION
 
-Basic test that ensures the component runs.
+Test how the config files are handled.  Exercises the
+C<handle_config_file> method.
 
 The component requires some heavy refactoring, but first we need some
 basic tests to ensure we don't break the old behaviour.
@@ -36,5 +48,16 @@ my $t = $cfg->getElement("/software/components/ssh/daemon")->getTree();
 $cmp->handle_config_file($SSH_FILE, 0600, $t);
 $fh = get_file($SSH_FILE);
 like($fh, qr{^AllowGroups\s+a b c$}m, "Multiword option accepted");
+
+is(*$fh->{CANCELLED}, 1, "File with no validation is written");
+
+$cmp->handle_config_file($SSH_FILE, 0600, $t, sub { return 1; });
+
+$fh = get_file($SSH_FILE);
+is(*$fh->{CANCELLED}, 1, "File with successful validation is written");
+
+$cmp->handle_config_file($SSH_FILE, 0600, $t, sub { return 0; });
+$fh = get_file($SSH_FILE);
+is(*$fh->{CANCELLED}, 2, "Invalid file is not written");
 
 done_testing();

--- a/ncm-ssh/src/test/perl/valid.t
+++ b/ncm-ssh/src/test/perl/valid.t
@@ -1,0 +1,29 @@
+# -*- mode: cperl -*-
+use strict;
+use warnings;
+use Test::More;
+use Test::Quattor;
+use CAF::Object;
+use NCM::Component::ssh;
+use Readonly;
+
+Readonly my $CMD => join(" ", NCM::Component::ssh::SSH_VALIDATE);
+
+my $cmp = NCM::Component::ssh->new("ssh");
+
+=pod
+
+=head1 DESCRIPTION
+
+Test for the C<valid_ssh_file> predicate.
+
+=cut
+
+set_command_status($CMD, 0);
+ok($cmp->valid_sshd_file("foo"), "Success upon valid file");
+
+set_command_status($CMD, 1);
+set_desired_err($CMD, "Error");
+ok(!$cmp->valid_sshd_file("foo"), "Invalid file is detected");
+
+done_testing();


### PR DESCRIPTION
If the configuration is invalid we discard the file and don't restart (i.e, bring down) the daemon.

Fix #43.
