### PR TITLE
Keep users and groups for DHCP daemons

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/sysgroups.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/sysgroups.pan
@@ -15,6 +15,8 @@ unique template components/accounts/sysgroups;
     'bin', '',
     'daemon' ,'',
     'sys' ,'',
+    'dhcpd', '',
+    'dhcp', '',
     'adm' ,'',
     'tty' ,'',
     'disk' ,'',

--- a/ncm-accounts/src/main/pan/components/accounts/sysusers.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/sysusers.pan
@@ -14,6 +14,8 @@ unique template components/accounts/sysusers;
 '/software/components/accounts/kept_users' ?= nlist(
     'bin' ,'',
     'daemon' ,'',
+    'dhcpd', '',
+    'dhcp', '',
     'adm' ,'',
     'lp' ,'',
     'sync' ,'',


### PR DESCRIPTION
We don't want ncm-accounts to remove these by default.  They may break DHCP daemons.
