### PR TITLE
ncm-metaconfig: add support for a preamble

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -16,6 +16,7 @@ type ${project.artifactId}_config =  {
      'daemon' ? string[]
      'module' : string
      'backup' ? string
+     'preamble' ? string
      'contents' : ${project.artifactId}_extension
 } = nlist();
 

--- a/ncm-metaconfig/src/main/perl/metaconfig.pm
+++ b/ncm-metaconfig/src/main/perl/metaconfig.pm
@@ -199,6 +199,7 @@ sub handle_service
     $opts{backup} = $srv->{backup} if exists($srv->{backup});
 
     my $fh = CAF::FileWriter->new($file, %opts);
+    print $fh "$srv->{preamble}\n" if $srv->{preamble};
     print $fh "$str\n";
     if ($self->needs_restarting($fh, $srv)) {
         foreach my $d (@{$srv->{daemon}}) {

--- a/ncm-metaconfig/src/main/perl/metaconfig.pod
+++ b/ncm-metaconfig/src/main/perl/metaconfig.pod
@@ -49,6 +49,17 @@ Daemon to restart if the file changes.
 Even if multiple C<services> are associated to the same daemon, the
 daemon will be restarted at most once.
 
+=item * preamble ? string
+
+Text to place at start of file.
+
+It can be useful to include context in a configuration file, in the form of
+a comment, such as how it was generated. Most of the formats that can be
+output by this component support "comment" lines, but none of the modules that
+it uses will generate them. The preamble attribute will be written out
+verbatim, before the contents is generated. No comment character is added,
+the user must specify this as part of the preamble string.
+
 =item * contents
 
 A free-form structure describing the valid entries for the


### PR DESCRIPTION
Add support for including a preamble at the start of a file written by
ncm-metaconfig. This can be used to include contextual information in
the form of a comment since none of the modules supported by
ncm-metaconfig allow the insertion of comments into the files they
generate.
