### PR TITLE
Add ncm-libvirtd and ncm-ganglia to the parent POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@
     <module>ncm-icinga</module>
     <module>ncm-sudo</module>
     <module>ncm-useraccess</module>
+    <module>ncm-ganglia</module>
+    <module>ncm-libvirtd</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This is the last missing piece to get the Jenkins tests passing again.  These components will be part of the next release.
