### PR TITLE
Remove old-style template names from comments.

### DIFF
--- a/ncm-sudo/src/main/pan/components/sudo/config-rpm.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/config-rpm.pan
@@ -2,8 +2,6 @@
 # ${developer-info}
 # ${author-info}
 
-# template pro_software_component_sudo
-
 unique template components/sudo/config-rpm;
 include {'components/sudo/schema'};
 include {'components/sudo/functions'};

--- a/ncm-sudo/src/main/pan/components/sudo/schema.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/schema.pan
@@ -2,11 +2,6 @@
 # ${developer-info}
 # ${author-info}
 
-# Type definition pro_declaration_component_sudo
-#
-#
-#
-#
 # Data structures modelling the whole sudo behaviour.
 # See ncm-sudo man page for more details.
 

--- a/ncm-useraccess/src/main/pan/components/useraccess/config-rpm.pan
+++ b/ncm-useraccess/src/main/pan/components/useraccess/config-rpm.pan
@@ -2,8 +2,6 @@
 # ${developer-info}
 # ${author-info}
 
-# template pro_software_component_useraccess
-
 unique template components/useraccess/config-rpm;
 include {'components/useraccess/schema'};
 


### PR DESCRIPTION
Unneeded/wrong comments may mislead readers.
