### PR TITLE
Detect even more Yum errors

### DIFF
--- a/ncm-spma/src/main/perl/spma.pm
+++ b/ncm-spma/src/main/perl/spma.pm
@@ -169,8 +169,9 @@ sub execute_yum_command
 
     $cmd->execute();
 
-    if ($? || $err =~ m{^(Error|Failed|Could not match)}m ||
-	    (@missing = ($out =~ m{^No package (.*) available}mg))) {
+    if ($? ||
+	$err =~ m{^(?:Error|Failed|(?:Could not match)|(?:Transaction encountered.*error))}mi ||
+	(@missing = ($out =~ m{^No package (.*) available}mg))) {
         $self->error("Failed $why: $err");
 	if (@missing) {
 	    $self->error("Missing packages: ", join(" ", @missing));

--- a/ncm-spma/src/test/perl/execute-yum-cmd.t
+++ b/ncm-spma/src/test/perl/execute-yum-cmd.t
@@ -60,6 +60,15 @@ set_desired_err($CMD, "Error in PREIN scriptlet");
 is($cmp->execute_yum_command([$CMD], $WHY), undef,
    "Errors in scriptlet execution detected, see issue #42");
 
+set_desired_err($CMD, "ERROR foo bar");
+is($cmp->execute_yum_command([$CMD], $WHY), undef,
+   "Yet another error string is detected");
+
+set_desired_err($CMD, "Transaction encountered a serious error");
+
+is($cmp->execute_yum_command([$CMD], $WHY), undef,
+   "Yet another Yum error is correctly diagnosed");
+
 set_desired_err($CMD, "");
 set_desired_output($CMD, "No package foo available");
 
@@ -68,7 +77,5 @@ is($cmp->execute_yum_command([$CMD], $WHY), undef,
 
 set_command_status($CMD, 1);
 is($cmp->execute_yum_command([$CMD], $WHY), undef, "Errors in execution detected");
-
-
 
 done_testing();


### PR DESCRIPTION
Today we had a funny transaction that reported missing files and looked like this:

```
ERROR
<list of files> Transaction encountered a serious error
```

And it didn't match our regular expression.  So here comes yet another attempt to detect every possible error that Yum hides from us.
