### PR TITLE
Add yet another error class to the Yum diagnostics

### DIFF
--- a/ncm-spma/src/main/perl/spma.pm
+++ b/ncm-spma/src/main/perl/spma.pm
@@ -168,14 +168,16 @@ sub execute_yum_command
     my $cmd = CAF::Process->new($command, %opts);
 
     $cmd->execute();
-
     if ($? ||
-	$err =~ m{^(?:Error|Failed|(?:Could not match)|(?:Transaction encountered.*error))}mi ||
-	(@missing = ($out =~ m{^No package (.*) available}mg))) {
+        $err =~ m{^(?:Error|Failed|
+                      (?:Could \s+ not \s+ match)|
+                      (?:Transaction \s+ encountered.*error)|
+                      (?:.*requested \s+ URL \s+ returned \s+ error))}oxmi ||
+        (@missing = ($out =~ m{^No package (.*) available}omg))) {
         $self->error("Failed $why: $err");
-	if (@missing) {
-	    $self->error("Missing packages: ", join(" ", @missing));
-	}
+        if (@missing) {
+            $self->error("Missing packages: ", join(" ", @missing));
+        }
         $self->warn("Command output: $out");
         return undef;
     }

--- a/ncm-spma/src/test/perl/execute-yum-cmd.t
+++ b/ncm-spma/src/test/perl/execute-yum-cmd.t
@@ -69,6 +69,11 @@ set_desired_err($CMD, "Transaction encountered a serious error");
 is($cmp->execute_yum_command([$CMD], $WHY), undef,
    "Yet another Yum error is correctly diagnosed");
 
+set_desired_err($CMD,
+                join(" ", qw{https://foobar.xml: [Errno 14] PYCURL ERROR 22 -
+                             "The requested URL returned error: 403 Forbidden"}),
+                "Unreachable repositories detected");
+
 set_desired_err($CMD, "");
 set_desired_output($CMD, "No package foo available");
 


### PR DESCRIPTION
This one appears when an enabled repository is unavailable and we cannot reach any of its mirrors.
