### PR TITLE
ncm-chkconfig add should become a synonym for reset

### DIFF
--- a/ncm-chkconfig/src/main/perl/chkconfig.pm
+++ b/ncm-chkconfig/src/main/perl/chkconfig.pm
@@ -100,7 +100,8 @@ sub Configure {
                     }
                     $self->info($msg);
                 } else {
-                    $self->debug(2, "$service is already known to chkconfig, no need to 'add'");
+	      $self->debug(2, "$service is already known to chkconfig, but running 'reset'");
+	      push(@cmdlist, [$chkconfigcmd, $service, "reset"]);
                 }
             } elsif ($optname eq 'del' && $optval) {
                 if ($currentservices{$service} ) {

--- a/ncm-chkconfig/src/main/perl/chkconfig.pod
+++ b/ncm-chkconfig/src/main/perl/chkconfig.pod
@@ -72,6 +72,10 @@ already the case), otherwise the option is ignored. Please note that
 some services do not turn themselves on, and so in addition need an
 explicit I<on> for the appropriate runlevels.
 
+If service has value 'add', and is already known to chkconfig, 'reset'
+will be run. This will restore service runlevel to its default values
+and protect from any manual changes of runlevels by /sbin/chkconfig.
+
 =item /software/components/chkconfig/service/<service>/del : boolean
 
 If the value is true, removes service from management by chkconfig, otherwise


### PR DESCRIPTION
If service has a value 'add' then adding a code to ncm-chkconfig to run
'reset'. This will restore service runlevel to its default values and protect
from any manual changes of runlevels by /sbin/chkconfig.

Addresses-Issue: #97

Conflicts:
ncm-chkconfig/src/main/perl/chkconfig.pm
