### PR TITLE
Adjust the POM for ncm-openvpn.

### DIFF
--- a/ncm-openvpn/pom.xml
+++ b/ncm-openvpn/pom.xml
@@ -9,20 +9,13 @@
   <artifactId>openvpn</artifactId>
 
   <packaging>pom</packaging>
-  <version>13.9.1-SNAPSHOT</version>
+  <version>13.6.1-SNAPSHOT</version>
   <name>Component configuring the OpenVPN.</name>
-
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://lapp-repo01.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
 
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.21</version>
+    <version>1.31</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
It was trying to access the obsoleted LAPP repositories, and causing failures
in Jenkins.
