### PR TITLE
Relax the repository-specific proxy field.

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/schema.pan
+++ b/ncm-spma/src/main/pan/components/spma/schema.pan
@@ -45,7 +45,7 @@ type SOFTWARE_REPOSITORY = {
     "includepkgs" ? string[]
     "excludepkgs" ? string[]
     "skip_if_unavailable" : boolean = false
-    "proxy" ? type_absoluteURI
+    "proxy" ? string with SELF == '' || is_absoluteURI(SELF)
 };
 
 type component_spma_type = {


### PR DESCRIPTION
Having empty strings allows to disable the global proxy if some repository
shouldn't have any.
