### PR TITLE
Escape hostgroup names in the validation.

### DIFF
--- a/ncm-icinga/src/main/pan/components/icinga/schema.pan
+++ b/ncm-icinga/src/main/pan/components/icinga/schema.pan
@@ -14,7 +14,7 @@ include {'quattor/schema'};
 type hoststring =  string with exists ("/software/components/icinga/hosts/" + SELF) ||
 	SELF=="*" || SELF == 'dummy';
 
-type hostgroupstring = string with exists ("/software/components/icinga/hostgroups/" + SELF) || SELF=="*";
+type hostgroupstring = string with exists ("/software/components/icinga/hostgroups/" + escape(SELF)) || SELF=="*";
 
 type commandstrings = string [] with exists ("/software/components/icinga/commands/" + SELF[0]);
 


### PR DESCRIPTION
The component expects the hostgroup name to be escaped.

This change may be backwards-incompatible.  However, AFAIK, we are the
only users of this component.
