### PR TITLE
Make ncm-network depend on bridge-utils

### DIFF
--- a/ncm-network/pom.xml
+++ b/ncm-network/pom.xml
@@ -44,13 +44,18 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.quattor.pan</groupId>
-          <artifactId>panc-maven-plugin</artifactId>
-          <version>9.0.0-RC3</version>
-        </plugin>
+	<plugin>
+	  <groupId>org.codehaus.mojo</groupId>
+	  <artifactId>rpm-maven-plugin</artifactId>
+	  <configuration>
+	    <requires>
+	      <require>bridge-utils</require>
+	    </requires>
+	  </configuration>
+	</plugin>
       </plugins>
     </pluginManagement>
   </build>
+
 
 </project>


### PR DESCRIPTION
We need very often brctl, and on minimal installations we may forget about it.
