### PR TITLE
Skip tests if the rendering module doesn't exist

### DIFF
--- a/ncm-metaconfig/src/test/perl/json.t
+++ b/ncm-metaconfig/src/test/perl/json.t
@@ -7,7 +7,7 @@ use Test::Quattor;
 use NCM::Component::metaconfig;
 use CAF::Object;
 
-eval {use JSON::Any};
+eval "use JSON::Any";
 plan skip_all => "JSON::Any not found" if $@;
 
 $CAF::Object::NoAction = 1;

--- a/ncm-metaconfig/src/test/perl/properties.t
+++ b/ncm-metaconfig/src/test/perl/properties.t
@@ -7,7 +7,7 @@ use Test::Quattor;
 use NCM::Component::metaconfig;
 use CAF::Object;
 
-eval {use Config::Properties};
+eval "use Config::Properties";
 plan skip_all => "Config::Properties not found" if $@;
 
 $CAF::Object::NoAction = 1;

--- a/ncm-metaconfig/src/test/perl/tt.t
+++ b/ncm-metaconfig/src/test/perl/tt.t
@@ -7,7 +7,7 @@ use Test::Quattor;
 use NCM::Component::metaconfig;
 use CAF::Object;
 
-eval {use Template};
+eval "use Template";
 
 use Readonly;
 


### PR DESCRIPTION
Some tests were crashing because eval{} doesn't capture failed use statements.  Awesome Perl.
