### PR TITLE
ncm-pam: only add the option key if the boolean is true

### DIFF
--- a/ncm-pam/src/main/perl/pam.pm
+++ b/ncm-pam/src/main/perl/pam.pm
@@ -92,7 +92,7 @@ sub Configure {
 		  my @o = ();
 		  foreach my $kv (sort keys %{$spec->{options}}) {
 		      if ($config->getElement("$prefix/services/$service/$type/$pos/options/$kv")->isType(BOOLEAN)) {
-			  push(@o, $kv) if $config->getElement("$prefix/services/$service/$type/$pos/options/$kv");
+			  push(@o, $kv) if $spec->{options}->{$kv};
 		      } else {
 			  push(@o, "$kv=$spec->{options}->{$kv}");
 		      }


### PR DESCRIPTION
Looks like a bug in ncm-pam. Is anyone using this component (or this version of the component)?
