### PR TITLE
Add 'log' to the permissible targets of the nat table

### DIFF
--- a/ncm-iptables/src/main/perl/iptables.pm
+++ b/ncm-iptables/src/main/perl/iptables.pm
@@ -41,7 +41,7 @@ my %iptables_totality = (); # hash of tables, chains & targets
 @{$iptables_totality{filter}{commands}} = ('-A', '-D', '-I', '-R', '-N');
 
 @{$iptables_totality{nat}{chains}}   = ('prerouting', 'output', 'postrouting');
-@{$iptables_totality{nat}{targets}}  = ('dnat', 'snat', 'masquerade', 'redirect');
+@{$iptables_totality{nat}{targets}}  = ('dnat', 'snat', 'masquerade', 'redirect', 'log');
 @{$iptables_totality{nat}{commands}} = ('-A', '-D', '-I', '-R', '-N');
 
 @{$iptables_totality{mangle}{chains}}   = ('prerouting', 'input', 'output', 'forward', 'postrouting');


### PR DESCRIPTION
otherwise rules that have log as a target will result in a broken iptables configuration.
In particular, instead of the rules appearing in /etc/sysconfig/iptables under

```
:POSTROUTING ACCEPT
```

we get

```
-N LOG
```

which is not correct, and iptables-restore complains that a chain must not have the same name as a target.

The fix is really simple, and runs in production at our site. So please apply this!
