### PR TITLE
ncm-pam: only add the option key if the boolean is true

### DIFF
--- a/ncm-pam/src/main/perl/pam.pm
+++ b/ncm-pam/src/main/perl/pam.pm
@@ -72,7 +72,7 @@ sub Configure {
                   my @o = ();
                   foreach my $kv (sort keys %{$spec->{options}}) {
                       if ($config->getElement("$prefix/services/$service/$type/$pos/options/$kv")->isType(BOOLEAN)) {
-                          push(@o, $kv);
+                          push(@o, $kv) if $spec->{options}->{$kv};
                       } else {
                           push(@o, "$kv=$spec->{options}->{$kv}");
                       }


### PR DESCRIPTION
This is a PR created on what was discussed in PR #139
