### PR TITLE
config.pan should include the common config

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/config.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/config.pan
@@ -6,6 +6,7 @@ unique template components/accounts/config;
 
 include { 'components/${project.artifactId}/schema' };
 include { 'components/${project.artifactId}/functions' };
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };
 
 # Package to install

--- a/ncm-afsclt/src/main/pan/components/afsclt/config.pan
+++ b/ncm-afsclt/src/main/pan/components/afsclt/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-aiiserver/src/main/pan/components/aiiserver/config.pan
+++ b/ncm-aiiserver/src/main/pan/components/aiiserver/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-alternatives/src/main/pan/components/alternatives/config.pan
+++ b/ncm-alternatives/src/main/pan/components/alternatives/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-altlogrotate/src/main/pan/components/altlogrotate/config.pan
+++ b/ncm-altlogrotate/src/main/pan/components/altlogrotate/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-amandaserver/src/main/pan/components/amandaserver/config.pan
+++ b/ncm-amandaserver/src/main/pan/components/amandaserver/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-authconfig/src/main/pan/components/authconfig/config.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-autofs/src/main/pan/components/autofs/config.pan
+++ b/ncm-autofs/src/main/pan/components/autofs/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ccm/src/main/pan/components/ccm/config.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-cdp/src/main/pan/components/cdp/config.pan
+++ b/ncm-cdp/src/main/pan/components/cdp/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-chkconfig/src/main/pan/components/chkconfig/config.pan
+++ b/ncm-chkconfig/src/main/pan/components/chkconfig/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-cron/src/main/pan/components/cron/config.pan
+++ b/ncm-cron/src/main/pan/components/cron/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-cups/src/main/pan/components/cups/config.pan
+++ b/ncm-cups/src/main/pan/components/cups/config.pan
@@ -4,4 +4,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include {'components/${project.artifactId}/config-rpm'};

--- a/ncm-directoryservices/src/main/pan/components/directoryservices/config.pan
+++ b/ncm-directoryservices/src/main/pan/components/directoryservices/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-dirperm/src/main/pan/components/dirperm/config.pan
+++ b/ncm-dirperm/src/main/pan/components/dirperm/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-diskless_server/src/main/pan/components/diskless_server/config.pan
+++ b/ncm-diskless_server/src/main/pan/components/diskless_server/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-download/src/main/pan/components/download/config.pan
+++ b/ncm-download/src/main/pan/components/download/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-drbd/src/main/pan/components/drbd/config.pan
+++ b/ncm-drbd/src/main/pan/components/drbd/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-etcservices/src/main/pan/components/etcservices/config.pan
+++ b/ncm-etcservices/src/main/pan/components/etcservices/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-filecopy/src/main/pan/components/filecopy/config.pan
+++ b/ncm-filecopy/src/main/pan/components/filecopy/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-filesystems/src/main/pan/components/filesystems/config.pan
+++ b/ncm-filesystems/src/main/pan/components/filesystems/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-fmonagent/src/main/pan/components/fmonagent/config.pan
+++ b/ncm-fmonagent/src/main/pan/components/fmonagent/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-fsprobe/src/main/pan/components/fsprobe/config.pan
+++ b/ncm-fsprobe/src/main/pan/components/fsprobe/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-fstab/src/main/pan/components/fstab/config.pan
+++ b/ncm-fstab/src/main/pan/components/fstab/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ganglia/src/main/pan/components/ganglia/config.pan
+++ b/ncm-ganglia/src/main/pan/components/ganglia/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/ganglia/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/ganglia/config-rpm' };

--- a/ncm-gmetad/src/main/pan/components/gmetad/config.pan
+++ b/ncm-gmetad/src/main/pan/components/gmetad/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-gmond/src/main/pan/components/gmond/config.pan
+++ b/ncm-gmond/src/main/pan/components/gmond/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-gpfs/src/main/pan/components/gpfs/config.pan
+++ b/ncm-gpfs/src/main/pan/components/gpfs/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-grub/src/main/pan/components/grub/config.pan
+++ b/ncm-grub/src/main/pan/components/grub/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-hostsaccess/src/main/pan/components/hostsaccess/config.pan
+++ b/ncm-hostsaccess/src/main/pan/components/hostsaccess/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-hostsfile/src/main/pan/components/hostsfile/config.pan
+++ b/ncm-hostsfile/src/main/pan/components/hostsfile/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-icinga/src/main/pan/components/icinga/config.pan
+++ b/ncm-icinga/src/main/pan/components/icinga/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-interactivelimits/src/main/pan/components/interactivelimits/config.pan
+++ b/ncm-interactivelimits/src/main/pan/components/interactivelimits/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ipmi/src/main/pan/components/ipmi/config.pan
+++ b/ncm-ipmi/src/main/pan/components/ipmi/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-iptables/src/main/pan/components/iptables/config.pan
+++ b/ncm-iptables/src/main/pan/components/iptables/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-iscsitarget/src/main/pan/components/iscsitarget/config.pan
+++ b/ncm-iscsitarget/src/main/pan/components/iscsitarget/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-krb5clt/src/main/pan/components/krb5clt/config.pan
+++ b/ncm-krb5clt/src/main/pan/components/krb5clt/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ldconf/src/main/pan/components/ldconf/config.pan
+++ b/ncm-ldconf/src/main/pan/components/ldconf/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-linuxha/src/main/pan/components/linuxha/config.pan
+++ b/ncm-linuxha/src/main/pan/components/linuxha/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-mailaliases/src/main/pan/components/mailaliases/config.pan
+++ b/ncm-mailaliases/src/main/pan/components/mailaliases/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-mcx/src/main/pan/components/mcx/config.pan
+++ b/ncm-mcx/src/main/pan/components/mcx/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-metaconfig/src/main/pan/components/metaconfig/config.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-modprobe/src/main/pan/components/modprobe/config.pan
+++ b/ncm-modprobe/src/main/pan/components/modprobe/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-mysql/src/main/pan/components/mysql/config.pan
+++ b/ncm-mysql/src/main/pan/components/mysql/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-nagios/src/main/pan/components/nagios/config.pan
+++ b/ncm-nagios/src/main/pan/components/nagios/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-named/src/main/pan/components/named/config.pan
+++ b/ncm-named/src/main/pan/components/named/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-network/src/main/pan/components/network/config.pan
+++ b/ncm-network/src/main/pan/components/network/config.pan
@@ -7,4 +7,5 @@
 unique template components/network/config;
 
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-networkupstools/src/main/pan/components/networkupstools/config.pan
+++ b/ncm-networkupstools/src/main/pan/components/networkupstools/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-nfs/src/main/pan/components/nfs/config.pan
+++ b/ncm-nfs/src/main/pan/components/nfs/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-nrpe/src/main/pan/components/nrpe/config.pan
+++ b/ncm-nrpe/src/main/pan/components/nrpe/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-nsca/src/main/pan/components/nsca/config.pan
+++ b/ncm-nsca/src/main/pan/components/nsca/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-nscd/src/main/pan/components/nscd/config.pan
+++ b/ncm-nscd/src/main/pan/components/nscd/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ntpd/src/main/pan/components/ntpd/config.pan
+++ b/ncm-ntpd/src/main/pan/components/ntpd/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ofed/src/main/pan/components/ofed/config.pan
+++ b/ncm-ofed/src/main/pan/components/ofed/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-openldap/src/main/pan/components/openldap/config.pan
+++ b/ncm-openldap/src/main/pan/components/openldap/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-openvpn/src/main/pan/components/openvpn/config.pan
+++ b/ncm-openvpn/src/main/pan/components/openvpn/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-oramonserver/src/main/pan/components/oramonserver/config.pan
+++ b/ncm-oramonserver/src/main/pan/components/oramonserver/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-pacemaker/src/main/pan/components/pacemaker/config.pan
+++ b/ncm-pacemaker/src/main/pan/components/pacemaker/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-pakiti/src/main/pan/components/pakiti/config.pan
+++ b/ncm-pakiti/src/main/pan/components/pakiti/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-pam/src/main/pan/components/pam/config.pan
+++ b/ncm-pam/src/main/pan/components/pam/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-php/src/main/pan/components/php/config.pan
+++ b/ncm-php/src/main/pan/components/php/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-pine/src/main/pan/components/pine/config.pan
+++ b/ncm-pine/src/main/pan/components/pine/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-pnp4nagios/src/main/pan/components/pnp4nagios/config.pan
+++ b/ncm-pnp4nagios/src/main/pan/components/pnp4nagios/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-portmap/src/main/pan/components/portmap/config.pan
+++ b/ncm-portmap/src/main/pan/components/portmap/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-postfix/src/main/pan/components/postfix/config.pan
+++ b/ncm-postfix/src/main/pan/components/postfix/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/postfix/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/postfix/config-rpm' };

--- a/ncm-postgresql/src/main/pan/components/postgresql/config.pan
+++ b/ncm-postgresql/src/main/pan/components/postgresql/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-profile/src/main/pan/components/profile/config.pan
+++ b/ncm-profile/src/main/pan/components/profile/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-pvss/src/main/pan/components/pvss/config.pan
+++ b/ncm-pvss/src/main/pan/components/pvss/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-raidman/src/main/pan/components/raidman/config.pan
+++ b/ncm-raidman/src/main/pan/components/raidman/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-resolver/src/main/pan/components/resolver/config.pan
+++ b/ncm-resolver/src/main/pan/components/resolver/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-rproxy/src/main/pan/components/rproxy/config.pan
+++ b/ncm-rproxy/src/main/pan/components/rproxy/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-runlevel/src/main/pan/components/runlevel/config.pan
+++ b/ncm-runlevel/src/main/pan/components/runlevel/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-selinux/src/main/pan/components/selinux/config.pan
+++ b/ncm-selinux/src/main/pan/components/selinux/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-sendmail/src/main/pan/components/sendmail/config.pan
+++ b/ncm-sendmail/src/main/pan/components/sendmail/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-serialclient/src/main/pan/components/serialclient/config.pan
+++ b/ncm-serialclient/src/main/pan/components/serialclient/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-shorewall/src/main/pan/components/shorewall/config.pan
+++ b/ncm-shorewall/src/main/pan/components/shorewall/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-sindes_getcert/src/main/pan/components/sindes_getcert/config.pan
+++ b/ncm-sindes_getcert/src/main/pan/components/sindes_getcert/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-slocate/src/main/pan/components/slocate/config.pan
+++ b/ncm-slocate/src/main/pan/components/slocate/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-spma/src/main/pan/components/spma/config.pan
+++ b/ncm-spma/src/main/pan/components/spma/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-squid/src/main/pan/components/squid/config.pan
+++ b/ncm-squid/src/main/pan/components/squid/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-srvtab/src/main/pan/components/srvtab/config.pan
+++ b/ncm-srvtab/src/main/pan/components/srvtab/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-ssh/src/main/pan/components/ssh/config.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-sshkeys/src/main/pan/components/sshkeys/config.pan
+++ b/ncm-sshkeys/src/main/pan/components/sshkeys/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-state/src/main/pan/components/state/config.pan
+++ b/ncm-state/src/main/pan/components/state/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-sudo/src/main/pan/components/sudo/config.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-symlink/src/main/pan/components/symlink/config.pan
+++ b/ncm-symlink/src/main/pan/components/symlink/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-sysconfig/src/main/pan/components/sysconfig/config.pan
+++ b/ncm-sysconfig/src/main/pan/components/sysconfig/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-sysctl/src/main/pan/components/sysctl/config.pan
+++ b/ncm-sysctl/src/main/pan/components/sysctl/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-syslog/src/main/pan/components/syslog/config.pan
+++ b/ncm-syslog/src/main/pan/components/syslog/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-syslogng/src/main/pan/components/syslogng/config.pan
+++ b/ncm-syslogng/src/main/pan/components/syslogng/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-tftpd/src/main/pan/components/tftpd/config.pan
+++ b/ncm-tftpd/src/main/pan/components/tftpd/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-tomcat/src/main/pan/components/tomcat/config.pan
+++ b/ncm-tomcat/src/main/pan/components/tomcat/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-useraccess/src/main/pan/components/useraccess/config.pan
+++ b/ncm-useraccess/src/main/pan/components/useraccess/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-xen/src/main/pan/components/xen/config.pan
+++ b/ncm-xen/src/main/pan/components/xen/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };

--- a/ncm-zephyrclt/src/main/pan/components/zephyrclt/config.pan
+++ b/ncm-zephyrclt/src/main/pan/components/zephyrclt/config.pan
@@ -5,4 +5,5 @@
 
 unique template components/${project.artifactId}/config;
 
+include { 'components/${project.artifactId}/config-common' };
 include { 'components/${project.artifactId}/config-rpm' };


### PR DESCRIPTION
It was observed that config-common was only being included by
config-xml.pan and not config.pan or config-rpm.pan which led to a
regression when upgrading components from before the xml/rpm split was
introduced.

The fix is to make config.pan always include config-common.pan. The
templates are unique so including them twice should not cause any
problems.
