### PR TITLE
Fix typo in metaconfig documentation

### DIFF
--- a/ncm-metaconfig/src/main/perl/metaconfig.pod
+++ b/ncm-metaconfig/src/main/perl/metaconfig.pod
@@ -83,7 +83,7 @@ similar to this one:
     <nlist>
       <another nlist>
         scalar value
-        another scalar value>
+        another scalar value
       </another nlist>
     </nlist>
     list_element 0


### PR DESCRIPTION
Thanks to @jouvin for the report.

Fixes #161.
