### PR TITLE
filecopy: cast perms string to oct

### DIFF
--- a/ncm-filecopy/src/main/perl/filecopy.pm
+++ b/ncm-filecopy/src/main/perl/filecopy.pm
@@ -87,7 +87,8 @@ sub Configure($$@) {
 
     my %file_opts;
     if ( $file_config->{perms} ) {
-      $file_opts{'mode'} = $file_config->{perms};
+      # LC::Check::status expects the mode to be an octal string
+      $file_opts{'mode'} = oct($file_config->{perms});
     }
     if ( $file_config->{group} ) {
       $file_opts{'group'} = $file_config->{group};


### PR DESCRIPTION
c95b33d0362f37caf10273efbcb06e0481a28eb7 dropped the call to oct() on
the file mode. The change was not called out in the release notes and
can break systems upgrading from older code. This restores the explicit
cast to octal before passing the file mode to LC::Check.

Closes #165
