### PR TITLE
metaconfig: Restart daemons in Solaris, too

### DIFF
--- a/ncm-metaconfig/src/main/perl/metaconfig.pm
+++ b/ncm-metaconfig/src/main/perl/metaconfig.pm
@@ -32,7 +32,7 @@ our $NoActionSupported = 1;
 
 # Restart any daemon that has seen its configuration changed by the
 # component.
-sub restart_daemon {
+sub restart_linux {
     my ($self, $daemon) = @_;
     CAF::Process->new(["/sbin/service", $daemon, "restart"],
                       log => $self)->run();
@@ -41,6 +41,25 @@ sub restart_daemon {
         return;
     }
     return 1;
+}
+
+sub restart_solaris
+{
+    my ($self, $daemon) = @_;
+
+    CAF::Process->new([qw(svcadm restart), $daemon],
+                      log => $self)->run();
+    if ($?) {
+        $self->error("Impossible to restart $daemon");
+        return;
+    }
+    return 1;
+}
+
+if ($^O eq 'linux') {
+    *restart_daemon = \&restart_linux;
+} else {
+    *restart_daemon = \&restart_solaris;
 }
 
 sub load_module

--- a/ncm-metaconfig/src/test/perl/restart.t
+++ b/ncm-metaconfig/src/test/perl/restart.t
@@ -22,7 +22,7 @@ Test that a daemon gets restarted if needed.
 
 my $cmp = NCM::Component::metaconfig->new('metaconfig');
 
-ok($cmp->restart_daemon("foo"), "Successful restart_daemon returns true");
+ok($cmp->restart_linux("foo"), "Successful restart_daemon returns true");
 set_command_status("/sbin/service foo restart", 1);
-ok(!$cmp->restart_daemon("foo"), "Failed restart_daemon returns false");
+ok(!$cmp->restart_linux("foo"), "Failed restart_daemon returns false");
 is($cmp->{ERROR}, 1, "Failed restart_daemon triggers an error message");

--- a/ncm-metaconfig/src/test/perl/solaris-restart.t
+++ b/ncm-metaconfig/src/test/perl/solaris-restart.t
@@ -1,0 +1,29 @@
+#!/usr/bin/perl
+# -*- mode: cperl -*-
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Test::Quattor;
+use NCM::Component::metaconfig;
+use CAF::Object;
+
+
+$CAF::Object::NoAction = 1;
+
+
+=pod
+
+=head1 DESCRIPTION
+
+Test that a daemon gets restarted if needed, the Solaris way
+
+=cut
+
+
+my $cmp = NCM::Component::metaconfig->new('metaconfig');
+
+ok($cmp->restart_solaris("foo"), "Successful restart_daemon returns true");
+ok(get_command("svcadm restart foo"), "The expected command was run");
+set_command_status("svcadm restart foo", 1);
+ok(!$cmp->restart_solaris("foo"), "Failed restart_daemon returns false");
+is($cmp->{ERROR}, 1, "Failed restart_daemon triggers an error message");


### PR DESCRIPTION
As discussed during the workshop, metaconfig should restart daemons in Solaris, too.

This brings feature parity to Solaris.  New features, especially the validate-restart-rollback workflow that we discussed during the workshop will take a little bit longer.
