### PR TITLE
Fix ncm-aiiserver

### DIFF
--- a/ncm-aiiserver/src/main/pan/components/aiiserver/config-rpm.pan
+++ b/ncm-aiiserver/src/main/pan/components/aiiserver/config-rpm.pan
@@ -14,19 +14,27 @@ include {'components/aiiserver/schema'};
 "/software/components/aiiserver/dispatch" ?= true;
 
 "/software/components/aiiserver/aii-shellfe/ca_file" ?= {
-	if (is_defined ("/software/components/ccm/ca_file" + "")) {
-		value ("/software/components/ccm/ca_file");
-	};
+    if ( path_exists("/software/components/ccm/ca_file") && is_defined("/software/components/ccm/ca_file") ) {
+        value ("/software/components/ccm/ca_file");
+    } else {
+        null;
+    };
 };
 
 "/software/components/aiiserver/aii-shellfe/key_file" ?= {
- 	if (is_defined ("/software/components/ccm/key_file" + "")) {
-		value ("/software/components/ccm/key_file");
-	};
+    if ( path_exists("/software/components/ccm/key_file") && is_defined("/software/components/ccm/key_file") ) {
+        value ("/software/components/ccm/key_file");
+    } else {
+        null;
+    };
 };
 
+
 "/software/components/aiiserver/aii-shellfe/cert_file" ?= {
- 	if (is_defined ("/software/components/ccm/cert_file" + "")) {
-		value ("/software/components/ccm/cert_file");
-	};
+    if ( path_exists("/software/components/ccm/cert_file") && is_defined("/software/components/ccm/cert_file") ) {
+        value ("/software/components/ccm/cert_file");
+    } else {
+        null;
+    };
 };
+

--- a/ncm-aiiserver/src/main/pan/components/aiiserver/schema.pan
+++ b/ncm-aiiserver/src/main/pan/components/aiiserver/schema.pan
@@ -19,6 +19,8 @@ type structure_aiishellfe = {
 	"key_file"	? string
 	"cert_file"	? string
 	"profile_format" : string = "xml"
+        "osinstalldir"  ? string
+        "nbpdir"        ? string
 };
 
 type structure_aiidhcp = {


### PR DESCRIPTION
 missing osinstalldir and nbpdir, retrieval of some information from ncm-ccm
(backported from master branch)
