### PR TITLE
Simpler version of pkg_repl()

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/functions.pan
+++ b/ncm-spma/src/main/pan/components/spma/functions.pan
@@ -323,7 +323,7 @@ function pkg_repl = {
             } else {
                 existing_versions = list();
                 foreach (k;v;SELF[e_name]) {
-                    existing_versions = append(unescape(k));
+                    existing_versions[length(existing_versions)] = unescape(k);
                 };
             };
             error(format('Package %s is already part of the profile (existing version=%s, requested version=%s)',ARGV[0],to_string(existing_versions),to_string(version)));


### PR DESCRIPTION
A preliminary implementation of pkg_repl() to help with discussion in #67... This is to illustrate what could be a simplified pkg_repl() that will retain the main features of existing pkg_repl(), including ability to define package versions in a nlist (package_default).
To help the discussion I submit this proposal before really testing it. It has at least one flaw: you cannot add a second arch for an existing package, this should be easy to fix.
If/when there is a consensus on what should be done, I could rewrite other pkg_xxx functions that are currently broken as they were calling pkg_repl() in a way not supported by the new function.
