### PR TITLE
ncm-puppet: fix tests

### DIFF
--- a/ncm-puppet/src/test/perl/apply.t
+++ b/ncm-puppet/src/test/perl/apply.t
@@ -33,11 +33,16 @@ Tests that the node files are written properly by the nodefiles function. Also c
 
 =cut
 
+my $fh;
+
 set_file_contents("$FILES_DIR/foo1.pp",$WRONG);
 set_file_contents("$FILES_DIR/foo2.pp",$WRONG);
-$comp->nodefiles({'foo1_2epp' => {'contents'=>$GOOD},'foo2_2epp' => {'contents'=>$GOOD}});
-is(get_file("$FILES_DIR/foo1.pp"),$GOOD,"checkfile function puts the correct content in the node files");
-is(get_file("$FILES_DIR/foo2.pp"),$GOOD,"checkfile function puts the correct content in the node files");
+$comp->nodefiles({'foo1_2epp' => {'contents'=>$GOOD},
+                  'foo2_2epp' => {'contents'=>$GOOD}});
+$fh = get_file("$FILES_DIR/foo1.pp");
+is("$fh", $GOOD, "checkfile function puts the correct content in the node files");
+$fh = get_file("$FILES_DIR/foo2.pp");
+is("$fh", $GOOD, "checkfile function puts the correct content in the node files");
 
 =pod
 

--- a/ncm-puppet/src/test/perl/functions.t
+++ b/ncm-puppet/src/test/perl/functions.t
@@ -7,7 +7,7 @@
 
 =head1 Testing base functions
 
-Tests the functionality of the lower function of the puppet component: 
+Tests the functionality of the lower function of the puppet component:
 
 =over 4
 
@@ -96,20 +96,20 @@ cmp_deeply($comp->unescape_keys(\%HASH_IN),\%HASH_EXP,"The unescape_keys functio
 #
 set_file_contents($TESTFILE,$WRONG);
 $comp->checkfile($TESTFILE,$GOOD);
-is(get_file($TESTFILE),$GOOD,"checkfile function puts the correct content in the file");
+my $fh = get_file($TESTFILE);
+is("$fh", $GOOD, "checkfile function puts the correct content in the file");
 
 #Testing yaml
 #
 set_file_contents($TESTFILE,$WRONG);
 $comp->yaml(\%HASH_IN,$TESTFILE);
-is(get_file($TESTFILE),$YAML,"yaml function writes a good yaml file");
+
+$fh = get_file($TESTFILE);
+is("$fh", $YAML, "yaml function writes a good yaml file");
 
 #Testing tiny
 #
 set_file_contents($TESTFILE,$WRONG);
 $comp->tiny(\%HASH_TINY,$TESTFILE);
-is(get_file($TESTFILE),$TINY,"tiny function writes a good tiny file");
-
-
-
-
+$fh = get_file($TESTFILE);
+is("$fh", $TINY, "tiny function writes a good tiny file");


### PR DESCRIPTION
For "is" to work properly we must pass a string to it. So we just convert to
string our files.

Fixes #189.

@sartiran, please review this code before. I'd like to merge it ASAP.
