### PR TITLE
Fix bug in smear calculations and added test

### DIFF
--- a/ncm-cron/src/main/perl/cron.pm
+++ b/ncm-cron/src/main/perl/cron.pm
@@ -386,7 +386,7 @@ sub addtime {
                 $from += $step;
             }
         } else {
-            push(@list, $range % $max);
+            push(@list, $range);
         }
     }
     # unique the list....

--- a/ncm-cron/src/test/perl/component.t
+++ b/ncm-cron/src/test/perl/component.t
@@ -33,6 +33,16 @@ like($fh, qr/root/m, "Check user");
 # check for logging
 like($fh, qr/ >> .*? 2>&1/m, "Check for log redirection in default log");
 
+# Check smear is rounding correctly
+$fh = get_file("/etc/cron.d/test_smear_max_items.ncm-cron.cron");
+isa_ok($fh,"CAF::FileWriter","This is a CAF::FileWriter smeared cron file written");
+
+# check smear rounding boundary case
+# If smear is 0 the smear code isn't used, so we have to leave room for
+# something to be smeared. Hence don't check the minutes but set the other
+# items to maximu.
+like($fh, qr/23 31 12 6/m, "Check smear rounding");
+
 # check the logfile if it's empty
 $fh = get_file("/var/log/test_default_log.ncm-cron.log");
 isa_ok($fh,"CAF::FileWriter","This is a CAF::FileWriter default log file written");

--- a/ncm-cron/src/test/resources/cron_syslog.pan
+++ b/ncm-cron/src/test/resources/cron_syslog.pan
@@ -7,6 +7,22 @@ object template cron_syslog;
     "frequency", "1 2 3 4 5",
     "command", "some command"));
 
+# Check the smear boundary case.
+# If smear is 0 the smear code isn't used, so we have to leave room for
+# something to be smeared. Hence set the minutes to zero but everything else
+# to maximum.
+"/software/components/cron/entries" =
+  append(nlist(
+    "name","test_smear_max_items",
+    "user","root",
+    "timing", nlist("minute", "0",
+                    "hour", "23",
+                    "day", "31",
+                    "month", "12",
+                    "weekday", "6",
+                    "smear", 10),
+    "command", "smeared command"));
+
 "/software/components/cron/entries" =
   append(nlist(
     "name","test_nolog",


### PR DESCRIPTION
If a cron item (not a list) is to be smeared, and is the biggest item allowed
in the range (59m, Sat, etc) it is incorrectly rounded to the next
value. For example this causes anything that is to be smeared on a
Saturday to be set to a Sunday.

Also add a test to exercise the smear bug.
