### PR TITLE
Fix tests in ncm-authconfig.

### DIFF
--- a/ncm-authconfig/src/main/perl/authconfig.pm
+++ b/ncm-authconfig/src/main/perl/authconfig.pm
@@ -362,29 +362,29 @@ sub restart_nscd
     # try a restart first. This is more reliable, as a stop/start
     # may fail to remove /var/lock/subsys/nscd
     my $cmd = CAF::Process->new([qw(service nscd restart)], log => $self,
-				timeout => 30)->execute();
+                                timeout => 30)->execute();
 
-    if ($?>0) {
+    if ($?) {
       $cmd = CAF::Process->new([qw(service nscd stop)], log => $self,
-			       timeout => 30)->execute();
+                               timeout => 30)->execute();
       sleep(1);
       $cmd = CAF::Process->new([qw(killall nscd)], log => $self,
-			       timeout => 30)->execute();
+                               timeout => 30)->execute();
       sleep(2);
       unlink(NSCD_LOCK) if -e NSCD_LOCK;
       $cmd = CAF::Process->new([qw(service nscd start)],
-			       log => $self,
-			       timeout => 30)->execute();
+                               log => $self,
+                               timeout => 30)->execute();
 
     }
 
     sleep(1);
     $? = 0;
     $cmd = CAF::Process->new([qw(nscd -i passwd)],
-			     log => $self)->run();
+                             log => $self)->run();
 
     if ($?) {
-	$self->error("Failed to restart NSCD");
+        $self->error("Failed to restart NSCD");
     }
 }
 

--- a/ncm-authconfig/src/test/perl/restart-nscd.t
+++ b/ncm-authconfig/src/test/perl/restart-nscd.t
@@ -28,8 +28,20 @@ my $cmp = NCM::Component::authconfig->new("authconfig");
 $cmp->restart_nscd();
 
 foreach my $cmd (("service nscd stop", "service nscd start",
-                  "killall nscd", "nscd -i passwd")) {
-    ok(get_command($cmd), "Command $cmd is executed");
+                  "killall nscd")) {
+    ok(!get_command($cmd), "Command $cmd is not executed if restart succeeds");
+}
+
+ok(get_command("service nscd restart"), "NSCD is always restarted");
+ok(get_command("nscd -i passwd"), "NSCD cache is always cleaned");
+
+set_command_status("service nscd restart", 1);
+
+$cmp->restart_nscd();
+
+foreach my $cmd (("service nscd stop", "service nscd start",
+                  "killall nscd")) {
+    ok(get_command($cmd), "Command $cmd is executed if restart fails");
 }
 
 done_testing();


### PR DESCRIPTION
The complicated sleep path is only executed if the restart fails.
