### PR TITLE
ncm-spma: fix buggy config-rpm.pan (wrong prefix)

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/config-rpm.pan
+++ b/ncm-spma/src/main/pan/components/spma/config-rpm.pan
@@ -5,12 +5,14 @@
 
 unique template components/spma/config-rpm;
 
-# Set prefix to root of component configuration.
-prefix '/software/components/${project.artifactId}';
-"/software/groups" ?= nlist();
-
+# Prefix for packages/groups
+prefix '/software';
+'groups' ?= nlist();
 # Package to install
 'packages' = pkg_repl("ncm-${project.artifactId}", "${no-snapshot-version}-${rpm.release}", "noarch");
+
+# Set prefix to root of component configuration.
+prefix '/software/components/${project.artifactId}';
 
 'packager' = 'yum';
 'register_change' ?= list("/software/packages",


### PR DESCRIPTION
Required for 14.5 (current version doesn't compile) and https://github.com/quattor/template-library-core/issues/43.
