### PR TITLE
ncm-grub: do not return an error but a warning if kernel version is a magic value

### DIFF
--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -26,6 +26,12 @@ use vars qw(@ISA $EC);
 $EC=LC::Exception::Context->new->will_store_all;
 $NCM::Component::grub::NoActionSupported = 1;
 
+# Magic version used to work around the fact this component
+# is not properly handling an undefined version value.
+# FIXME: to be removed as soon as this component has been fixed
+#        and the template library has been updated
+use constant KERNEL_MAGIC_VERSION => 'YUM-managed';
+
 Readonly::Scalar my $GRUBCONF => '/boot/grub/grub.conf';
 
 sub parseKernelArgs {
@@ -450,11 +456,11 @@ sub Configure {
       return;
   }
   unless (-e $fulldefaultkernelpath) {
-      # Empty string and 'YUM-managed' are 2 magic values used as a quirk and dirty workaround
+      # Empty string and 'YUM-managed' are 2 magic values used as a quick and dirty workaround
       # to avoid unnecessarily breaking configurations (having ncm-grub returns an error).
       # Note that in this case ncm-grub does essentially nothing useful: in particular Grub
       # arguments are not processed.
-      if ( !$kernelversion || $kernelversion eq '' || ($kernelversion =~ /YUM-managed$/) ) {
+      if ( !$kernelversion || $kernelversion eq '' || ($kernelversion eq  KERNEL_MAGIC_VERSION) ) {
           $self->warn ("No kernel version defined: no action done");
       } else {
           $self->error ("Kernel $fulldefaultkernelpath not found");


### PR DESCRIPTION
Valid magic values are empty string or 'YUM-managed' (backward compatibility with the template library).

Minimalistic change to avoid ncm-grub triggering a rerun of ncm-ncd at every new
profile received. Note that in this case, ncm-grub does essentially nothing.

This fix is mainly intended to make https://github.com/quattor/ncm-cdispd/pull/6 usable before a major rewrite of `ncm-grub` (#232). This is an alternative to #231 to suplly a minimalistic fix to #158. Choose one or the other!
