### PR TITLE
ncm-accounts: define gid as a mandatory property for groups

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/schema.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/schema.pan
@@ -24,7 +24,7 @@ type structure_userinfo = {
 
 type structure_groupinfo = {
     'comment'    ? string
-    'gid'        ? long(1..)
+    'gid'        : long(1..)
 };
 
 type structure_login_defs = {


### PR DESCRIPTION
Fixes #244
