### PR TITLE
ncm-ceph: fix documentation issue which breaks pod2markdown.

### DIFF
--- a/ncm-ceph/src/main/perl/ceph.pod
+++ b/ncm-ceph/src/main/perl/ceph.pod
@@ -55,6 +55,7 @@ The implementation keeps safety as top priority. Therefore:
 
 
 To set up the initial cluster, some steps should be taken:
+
 =over 
 
 =item 1. First create a ceph user on all the hosts.
@@ -85,6 +86,7 @@ be described in this section.
 The component is tested with Ceph version 0.80 and ceph-deploy version 1.5.1. 
 
 Following package dependencies should be installed to run the component:
+
 =over
 
 =item * perl-Data-Structure-Util 


### PR DESCRIPTION
Apparently pod2markdown is quite sensitive.

podchecker brings more readable output to find the error.

```
[wdpypere@scyther src]$ podchecker main/perl/ceph.pod
*** ERROR: Apparent command =over not preceded by blank line at line 58 in file main/perl/ceph.pod
*** ERROR: =item without previous =over at line 60 in file main/perl/ceph.pod
*** ERROR: Apparent command =over not preceded by blank line at line 88 in file main/perl/ceph.pod
*** ERROR: =item without previous =over at line 90 in file main/perl/ceph.pod
main/perl/ceph.pod has 4 pod syntax errors.
```

The first and third are the actual errors.

Should fix #256
