### PR TITLE
ncm-chkconfig : fix documentation syntax and add examples

### DIFF
--- a/ncm-chkconfig/src/main/perl/chkconfig.pod
+++ b/ncm-chkconfig/src/main/perl/chkconfig.pod
@@ -35,37 +35,37 @@ Not available.
 
 =over
 
-=item /software/components/chkconfig/active : boolean
+=item C<< /software/components/chkconfig/active : boolean >>
 
 activates/deactivates the component.
 
-=item /software/components/chkconfig/default : string ("off", "ignore")
+=item C<< /software/components/chkconfig/default : string ("off", "ignore") >>
 
 says what happens if no explicit configuration is found for the
 service. Certain services (like C<network, messagebus, haldaemon,
 sshd>) are protected from being turned off via the default setting,
 but please do not rely on this.
 
-=item /software/components/chkconfig/service/<service>/off : string ("[0-7]*")
+=item C<< /software/components/chkconfig/service/<service>/off : string ("[0-7]*") >>
 
-=item /software/components/chkconfig/service/<service>/on : string ("[0-7]*")
+=item C<< /software/components/chkconfig/service/<service>/on : string ("[0-7]*") >>
 
 Sets the service <service> on/off on specified run levels. The run
 levels are specified as string of numbers, the same way as with
 C<chkconfig>-command. If the string is empty, system default is taken
 (see C<man chkconfig(8)> for exact details).
 
-=item /software/components/chkconfig/service/<service>/name : string 
+=item C<< /software/components/chkconfig/service/<service>/name : string >>
 
 If set, the value is used as the name of the service instead of using the 
 <service> path as a name. 
 
-=item /software/components/chkconfig/service/<service>/reset : string ("[0-7]*")
+=item C<< /software/components/chkconfig/service/<service>/reset : string ("[0-7]*") >>
 
 Resets the service on defined run levels. Reset with no run levels specified 
 affects every run level. 
 
-=item /software/components/chkconfig/service/<service>/add : boolean
+=item C<< /software/components/chkconfig/service/<service>/add : boolean >>
 
 If the value is true, adds service for management by chkconfig (if not
 already the case), otherwise the option is ignored. Please note that
@@ -76,13 +76,13 @@ If service has value 'add', and is already known to chkconfig, 'reset'
 will be run. This will restore service runlevel to its default values
 and protect from any manual changes of runlevels by /sbin/chkconfig.
 
-=item /software/components/chkconfig/service/<service>/del : boolean
+=item C<< /software/components/chkconfig/service/<service>/del : boolean >>
 
 If the value is true, removes service from management by chkconfig, otherwise
 the option is ignored. 
 
 
-=item /software/components/chkconfig/service/<service>/startstop : boolean
+=item C<< /software/components/chkconfig/service/<service>/startstop : boolean >>
 
 If true, the service is also started/stopped when the service is
 added, removed or turned off/on. The component tries to check whether
@@ -91,6 +91,26 @@ action, but this relies on the service's init script correctly
 reporting current state.
 
 =back
+
+=head1 EXAMPLES
+
+The following example will start named on system default runlevels:
+
+    include { 'components/chkconfig/config' };
+    "/software/components/chkconfig/service/named/add" = true;
+    "/software/components/chkconfig/service/named/on" = "";
+    "/software/components/chkconfig/service/named/startstop" = true;
+
+The shorter way of writing this (assuming named is known to chkconfig):
+
+    include { 'components/chkconfig/config' };
+    "/software/components/chkconfig/service/named" =
+         nlist("on","","startstop",true);
+
+
+Disable and stop xinetd:
+
+    "/software/components/chkconfig/service/xinetd" = nlist("off", "", "startstop", true); 
 
 =head1 DEPENDENCIES
 


### PR DESCRIPTION
- Fixed the markdown issues by encapsulating it in code blocks.
- added some basic examples

see #258
