### PR TITLE
Make `artifactId` consistent with other configuration module repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.quattor</groupId>
-  <artifactId>ncm-components</artifactId>
+  <artifactId>configuration-modules-core</artifactId>
   <packaging>pom</packaging>
 
   <version>14.6.1-SNAPSHOT</version>


### PR DESCRIPTION
Fixes quattor/release#34
