### PR TITLE
ncm-metaconfig: Bump build tools to 1.36

### DIFF
--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.35</version>
+    <version>1.36</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
Seems to be required for #222.
