### PR TITLE
ncm-named: clear warnings before unittesting

### DIFF
--- a/ncm-named/src/test/perl/configure.t
+++ b/ncm-named/src/test/perl/configure.t
@@ -7,6 +7,7 @@ use Test::Quattor qw(client server);
 use NCM::Component::named;
 use Readonly;
 use CAF::Object;
+Test::NoWarnings::clear_warnings();
 
 
 # $RESOLV_CONF_CONTENTS_1 is the expected file.

--- a/ncm-named/src/test/perl/get_named_root_dir.t
+++ b/ncm-named/src/test/perl/get_named_root_dir.t
@@ -7,6 +7,7 @@ use Test::Quattor;
 use NCM::Component::named;
 use Readonly;
 use CAF::Object;
+Test::NoWarnings::clear_warnings();
 
 # This is the content of the default file on SL6 (with single quote removed in the text)
 use constant TEST_SYSCONFIG_HEADER => '# BIND named process options


### PR DESCRIPTION
Fixes unittests on fedora
