### PR TITLE
add clear_warnings before running tests and then check for warnings

### DIFF
--- a/ncm-accounts/src/test/perl/andrea.t
+++ b/ncm-accounts/src/test/perl/andrea.t
@@ -8,6 +8,8 @@ use NCM::Component::accounts;
 use Readonly;
 use CAF::Object;
 
+Test::NoWarnings::clear_warnings();
+
 $CAF::Object::NoAction = 1;
 
 Readonly my $PASSWD => << 'EOF';
@@ -119,7 +121,6 @@ daemon:*:15209:0:99999:7:::
 adm:*:15209:0:99999:7:::
 lp:*:15209:0:99999:7:::
 EOF
-
 
 =pod
 

--- a/ncm-accounts/src/test/perl/cnaf.t
+++ b/ncm-accounts/src/test/perl/cnaf.t
@@ -8,6 +8,8 @@ use NCM::Component::accounts;
 use Readonly;
 use CAF::Object;
 
+Test::NoWarnings::clear_warnings();
+
 =pod
 
 =head1 SYNOPSIS

--- a/ncm-accounts/src/test/perl/commits.t
+++ b/ncm-accounts/src/test/perl/commits.t
@@ -9,6 +9,8 @@ use Test::MockModule;
 use CAF::Object;
 require Test::NoWarnings;
 
+Test::NoWarnings::clear_warnings();
+
 $CAF::Object::NoAction = 1;
 
 use constant GROUP => <<EOF;


### PR DESCRIPTION
Merge @stdweird's changes that I missed somehow.
