### PR TITLE
ncm-grub: fix configuration module definition (suppress snapshot id)

### DIFF
--- a/ncm-grub/src/main/pan/components/grub/config.pan
+++ b/ncm-grub/src/main/pan/components/grub/config.pan
@@ -13,7 +13,7 @@ include { 'components/${project.artifactId}/schema' };
 # Set prefix to root of component configuration.
 prefix '/software/components/${project.artifactId}';
 
-'version' = '${project.version}';
+'version' = '${no-snapshot-version}';
 'active' ?= true;
 'dispatch' ?= true;
 'dependencies/pre' = append('spma');


### PR DESCRIPTION
The previous definition is not compliant with the schema...
