### PR TITLE
ncm-spma: yum-complete-transaction requires -y option to run without interruption

### DIFF
--- a/ncm-spma/src/main/perl/spma/yum.pm
+++ b/ncm-spma/src/main/perl/spma/yum.pm
@@ -38,7 +38,7 @@ use constant YUM_DISTRO_SYNC => qw(yum -y distro-sync);
 use constant YUM_CONF_FILE => "/etc/yum.conf";
 use constant CLEANUP_ON_REMOVE => "clean_requirements_on_remove";
 use constant REPOQUERY => qw(repoquery --show-duplicates --envra);
-use constant YUM_COMPLETE_TRANSACTION => "yum-complete-transaction";
+use constant YUM_COMPLETE_TRANSACTION => qw(yum-complete-transaction -y);
 use constant OBSOLETE => "obsoletes";
 use constant REPO_DEPS => qw(repoquery --requires --resolve --plugins
                              --qf %{NAME};%{ARCH});

--- a/ncm-spma/src/test/perl/yum-transaction-complete.t
+++ b/ncm-spma/src/test/perl/yum-transaction-complete.t
@@ -25,7 +25,7 @@ use NCM::Component::spma::yum;
 use CAF::Object;
 use Test::MockModule;
 
-Readonly my $CMD => NCM::Component::spma::yum::YUM_COMPLETE_TRANSACTION;
+Readonly my $CMD => join(" ", NCM::Component::spma::yum::YUM_COMPLETE_TRANSACTION);
 
 set_desired_err($CMD, "");
 set_desired_output($CMD, "");


### PR DESCRIPTION
Fixes #294.
