### PR TITLE
ncm-sudo: add support for secure_path

### DIFF
--- a/ncm-sudo/src/main/pan/components/sudo/schema.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/schema.pan
@@ -95,6 +95,7 @@ type structure_sudo_default_options = {
     "exempt_group"          ? string
     "verifypw"              ? string
     "listpw"                ? string
+    "secure_path"           ? string
     # List syntax would be too complex for this purposes! Will be
     # added just under request.
 };


### PR DESCRIPTION
First commit is whitespace changes, and the second one is the real one-line change.
