### PR TITLE
ncm-mysql: option for support of other mysql servicenames

### DIFF
--- a/ncm-mysql/src/main/pan/components/mysql/schema.pan
+++ b/ncm-mysql/src/main/pan/components/mysql/schema.pan
@@ -68,7 +68,7 @@ type component_mysql = {
 
   'databases'    ? component_mysql_db_options{}
   'servers'      : component_mysql_server_options{}
-  'servicename'  : string = 'mysqld' with match(SELF, '^(mysql|mysqld|mariadb)$')
+  'serviceName'  : string = 'mysqld' with match(SELF, '^(mysql|mysqld|mariadb)$')
 } with component_mysql_valid(SELF);
 
 bind '/software/components/mysql' = component_mysql;

--- a/ncm-mysql/src/main/perl/mysql.pm
+++ b/ncm-mysql/src/main/perl/mysql.pm
@@ -59,7 +59,7 @@ sub Configure {
   my $confighash = $config->getElement($base)->getTree();
   $databases = $confighash->{databases};
   $servers = $confighash->{servers};
-  my $servicename = $confighash->{servicename};
+  my $serviceName = $confighash->{serviceName};
 
   # Loop over all servers (even if no db in the configuration uses them)
 
@@ -74,19 +74,19 @@ sub Configure {
 
     if ( ($server->{host} eq $this_host_full) || ($server->{host} eq 'localhost') ) {
       my $cmd;
-      $self->info("Checking if MySQL service ($servicename) is enabled and started...");
-      $cmd = CAF::Process->new([$chkconfig, $servicename, "on"], log => $self);
+      $self->info("Checking if MySQL service ($serviceName) is enabled and started...");
+      $cmd = CAF::Process->new([$chkconfig, $serviceName, "on"], log => $self);
       $cmd->output();      # Also execute the command
       if ( $? ) {
           $self->error("Error enabling MySQL server on local node");
           return(1);
       }
 
-      $cmd = CAF::Process->new([$servicecmd, $servicename, "status"], log => $self);
+      $cmd = CAF::Process->new([$servicecmd, $serviceName, "status"], log => $self);
       $cmd->output();      # Also execute the command
       if ( $? ) {
         $self->info("Starting MySQL server...");
-        $cmd = CAF::Process->new([$servicecmd, $servicename, "start"], log => $self);
+        $cmd = CAF::Process->new([$servicecmd, $serviceName, "start"], log => $self);
         my $cmd_output = $cmd->output();      # Also execute the command
         $status = $?;
         if ( $? ) {

--- a/ncm-mysql/src/main/perl/mysql.pod
+++ b/ncm-mysql/src/main/perl/mysql.pod
@@ -50,7 +50,7 @@ Value is a nlist with the following possible keys :
 
 =back
 
-=head1 servicename option
+=head1 serviceName option
 
 Name of the mysql service. Valid values are 'mysql', 'mysqld' and 'mariadb'. Defaults to 'mysqld'.
 

--- a/ncm-mysql/src/test/perl/servicename.t
+++ b/ncm-mysql/src/test/perl/servicename.t
@@ -7,7 +7,7 @@
 
 =head1 DESCRIPTION
 
-Test the servicename option
+Test the serviceName option
 
 =cut
 

--- a/ncm-mysql/src/test/resources/basic_service.pan
+++ b/ncm-mysql/src/test/resources/basic_service.pan
@@ -1,7 +1,7 @@
 object template basic_service;
 
 prefix "/software/components/mysql";
-"servicename" = "mariadb";
+"serviceName" = "mariadb";
 prefix "/software/components/mysql/servers/one";
 "host" = 'localhost';
 "adminpwd" = 'r00t';


### PR DESCRIPTION
option `servicename` added, which make other servicenames possible, and disables `chkconfig` for EL7
