### PR TITLE
Add use_ssl

### DIFF
--- a/ncm-ccm/src/main/pan/components/ccm/schema.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/schema.pan
@@ -30,6 +30,7 @@ type component_ccm = {
     'world_readable'   : long(0..1) = 0
     'base_url'         ? type_absoluteURI
     'dbformat'         ? string with match(SELF, "^(DB_File|CDB_File|GDBM_File)$")
+    'use_ssl'         : boolean = false
 };
 
 bind '/software/components/ccm' = component_ccm;


### PR DESCRIPTION
Add 'use_ssl' boolean to match with the freeipa_cert_fix in AII (see quattor/aii#81)
When set to true, will extract certificates from the IPA database on the host 
