### PR TITLE
ncm-metaconfig: remove perl dependencies, now via CAF::TextRender

### DIFF
--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -40,25 +40,4 @@
       </roles>
     </contributor>
   </contributors>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-	<plugin>
-	  <groupId>org.codehaus.mojo</groupId>
-	  <artifactId>rpm-maven-plugin</artifactId>
-	  <configuration>
-            <requires>
-              <require>perl(Config::Tiny)</require>
-              <require>perl(Config::General)</require>
-              <require>perl(JSON::XS)</require>
-              <require>perl(YAML::XS)</require>
-              <require>perl(Template)</require>
-              <require>perl(Config::Properties)</require>
-            </requires>
-	  </configuration>
-	</plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>


### PR DESCRIPTION
also part of https://github.com/quattor/CAF/issues/61
