### PR TITLE
ncm-fstab: log removed entries

### DIFF
--- a/ncm-fstab/src/main/perl/fstab.pm
+++ b/ncm-fstab/src/main/perl/fstab.pm
@@ -92,7 +92,7 @@ sub delete_outdated
     }
 
     foreach my $outdated (@rm) {
-    	$self->debug(5, "Removing line $outdated");
+    	$self->info("Removing line $outdated");
     	$fstab->replace_lines (qr{$outdated}, qr{^$}, "");
     }
 }


### PR DESCRIPTION
Use info loglevel when removing lines from fstab. This way, the removed lines typically end up in a log file (preferably on remote server) in case you want to recover them (e.g. when the UUID are removed, rebooting might become tricky when the UUID are replaced with with the device names and multiple disks are in the system).
