### PR TITLE
Remove panc-maven-plugin configuration from configuration module pom files

### DIFF
--- a/ncm-accounts/pom.xml
+++ b/ncm-accounts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-afsclt/pom.xml
+++ b/ncm-afsclt/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-aiiserver/pom.xml
+++ b/ncm-aiiserver/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-altlogrotate/pom.xml
+++ b/ncm-altlogrotate/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-amandaserver/pom.xml
+++ b/ncm-amandaserver/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-authconfig/pom.xml
+++ b/ncm-authconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-autofs/pom.xml
+++ b/ncm-autofs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ccm/pom.xml
+++ b/ncm-ccm/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-cdp/pom.xml
+++ b/ncm-cdp/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ceph/pom.xml
+++ b/ncm-ceph/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-chkconfig/pom.xml
+++ b/ncm-chkconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-cron/pom.xml
+++ b/ncm-cron/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-cups/pom.xml
+++ b/ncm-cups/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-directoryservices/pom.xml
+++ b/ncm-directoryservices/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-dirperm/pom.xml
+++ b/ncm-dirperm/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-download/pom.xml
+++ b/ncm-download/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
   <licenses>

--- a/ncm-etcservices/pom.xml
+++ b/ncm-etcservices/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-filecopy/pom.xml
+++ b/ncm-filecopy/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-filesystems/pom.xml
+++ b/ncm-filesystems/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-fmonagent/pom.xml
+++ b/ncm-fmonagent/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-fsprobe/pom.xml
+++ b/ncm-fsprobe/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-fstab/pom.xml
+++ b/ncm-fstab/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ganglia/pom.xml
+++ b/ncm-ganglia/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-gmetad/pom.xml
+++ b/ncm-gmetad/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-gmond/pom.xml
+++ b/ncm-gmond/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-gpfs/pom.xml
+++ b/ncm-gpfs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-grub/pom.xml
+++ b/ncm-grub/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-hostsaccess/pom.xml
+++ b/ncm-hostsaccess/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-hostsfile/pom.xml
+++ b/ncm-hostsfile/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-icinga/pom.xml
+++ b/ncm-icinga/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-interactivelimits/pom.xml
+++ b/ncm-interactivelimits/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ipmi/pom.xml
+++ b/ncm-ipmi/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-iptables/pom.xml
+++ b/ncm-iptables/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ldconf/pom.xml
+++ b/ncm-ldconf/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-libvirtd/pom.xml
+++ b/ncm-libvirtd/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-mcx/pom.xml
+++ b/ncm-mcx/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-modprobe/pom.xml
+++ b/ncm-modprobe/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-mysql/pom.xml
+++ b/ncm-mysql/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-nagios/pom.xml
+++ b/ncm-nagios/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-named/pom.xml
+++ b/ncm-named/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-network/pom.xml
+++ b/ncm-network/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
   <licenses>

--- a/ncm-nfs/pom.xml
+++ b/ncm-nfs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-nrpe/pom.xml
+++ b/ncm-nrpe/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-nsca/pom.xml
+++ b/ncm-nsca/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-nscd/pom.xml
+++ b/ncm-nscd/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ntpd/pom.xml
+++ b/ncm-ntpd/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-ofed/pom.xml
+++ b/ncm-ofed/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-openldap/pom.xml
+++ b/ncm-openldap/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-openvpn/pom.xml
+++ b/ncm-openvpn/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-pam/pom.xml
+++ b/ncm-pam/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-pnp4nagios/pom.xml
+++ b/ncm-pnp4nagios/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-postfix/pom.xml
+++ b/ncm-postfix/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-postgresql/pom.xml
+++ b/ncm-postgresql/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-profile/pom.xml
+++ b/ncm-profile/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-puppet/pom.xml
+++ b/ncm-puppet/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-resolver/pom.xml
+++ b/ncm-resolver/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-sendmail/pom.xml
+++ b/ncm-sendmail/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-shorewall/pom.xml
+++ b/ncm-shorewall/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-spma/pom.xml
+++ b/ncm-spma/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
   <licenses>

--- a/ncm-ssh/pom.xml
+++ b/ncm-ssh/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-sudo/pom.xml
+++ b/ncm-sudo/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-symlink/pom.xml
+++ b/ncm-symlink/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-sysconfig/pom.xml
+++ b/ncm-sysconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-sysctl/pom.xml
+++ b/ncm-sysctl/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-syslog/pom.xml
+++ b/ncm-syslog/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-syslogng/pom.xml
+++ b/ncm-syslogng/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 

--- a/ncm-useraccess/pom.xml
+++ b/ncm-useraccess/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.39</version>
+    <version>1.40</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
.use definition in parent pom.xml, from maven build tools.

Contributes to https://github.com/quattor/maven-tools/issues/29.
