### PR TITLE
Activate NoAction support on multiple components

### DIFF
--- a/ncm-ccm/src/main/perl/ccm.pm
+++ b/ncm-ccm/src/main/perl/ccm.pm
@@ -16,6 +16,8 @@ use EDG::WP4::CCM::Fetch qw(NOQUATTOR);
 
 our $EC = LC::Exception::Context->new->will_store_all;
 
+our $NoActionSupported = 1;
+
 use constant TEST_COMMAND => qw(/usr/sbin/ccm-fetch -cfgfile /proc/self/fd/0);
 
 # simple private method to test NOQUATTOR (allows mocking)

--- a/ncm-cdp/src/main/perl/cdp.pm
+++ b/ncm-cdp/src/main/perl/cdp.pm
@@ -17,6 +17,7 @@ local(*DTA);
 
 use constant BASE => "/software/components/cdp";
 
+our $NoActionSupported = 1;
 
 sub Configure
 {

--- a/ncm-hostsfile/src/main/perl/hostsfile.pm
+++ b/ncm-hostsfile/src/main/perl/hostsfile.pm
@@ -19,6 +19,7 @@ use strict;
 use base 'NCM::Component';
 
 our $EC = LC::Exception::Context->new->will_store_all;
+our $NoActionSupported = 1;
 
 use LC::Check;
 use LC::File;

--- a/ncm-interactivelimits/src/main/perl/interactivelimits.pm
+++ b/ncm-interactivelimits/src/main/perl/interactivelimits.pm
@@ -18,6 +18,7 @@ use NCM::Component;
 use vars qw(@ISA $EC);
 @ISA = qw(NCM::Component);
 $EC=LC::Exception::Context->new->will_store_all;
+our $NoActionSupported = 1;
 
 use NCM::Check;
 

--- a/ncm-modprobe/src/main/perl/modprobe.pm
+++ b/ncm-modprobe/src/main/perl/modprobe.pm
@@ -14,6 +14,7 @@ use warnings;
 use NCM::Component;
 our @ISA = qw(NCM::Component);
 our $EC  = LC::Exception::Context->new->will_store_all;
+our $NoActionSupported = 1;
 
 use EDG::WP4::CCM::Configuration;
 use CAF::Process;

--- a/ncm-ssh/src/main/perl/ssh.pm
+++ b/ncm-ssh/src/main/perl/ssh.pm
@@ -16,6 +16,7 @@ use strict;
 use base qw(NCM::Component);
 
 our $EC = LC::Exception::Context->new->will_store_all;
+our $NoActionSupported = 1;
 
 use CAF::Process;
 use CAF::FileEditor;


### PR DESCRIPTION
An audit of the code showed that the following components were capable
of running in NoAction mode, but were not flagged as being able to do so.
- ccm
- cdp
- hostsfile
- interactivelimits
- modprobe
- ssh
