### PR TITLE
ncm-nss: Add to top-level POM file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <module>ncm-cups</module>
     <module>ncm-puppet</module>
     <module>ncm-ceph</module>
+    <module>ncm-nss</module>
   </modules>
 
   <build>
@@ -126,4 +127,3 @@
   </build>
 
 </project>
-


### PR DESCRIPTION
Needed to fix Jenkins job.

The Jenkins job for configuration-modules-core also extracts junit-style and coverage reports.  If a module is not present, it won't have any such data, the job will not find the appropriate files and it will fail.
