### PR TITLE
Correct example smear from string to long

### DIFF
--- a/ncm-cron/src/main/perl/cron.pod
+++ b/ncm-cron/src/main/perl/cron.pod
@@ -165,7 +165,7 @@ Default : root
       "timing", nlist(
           "minute", "0",
           "hour", "1",
-          "smear", "180"),
+          "smear", 180),
       "command", "/bin/date")
     );
 


### PR DESCRIPTION
Schema specifies long, but documented example shows a string.