### PR TITLE
ncm-network: fix documentation bonding example

### DIFF
--- a/ncm-network/src/main/perl/network.pod
+++ b/ncm-network/src/main/perl/network.pod
@@ -3,8 +3,8 @@
 ################################################################################
 #
 # VERSION:    1.2.10, 21/06/10 15:26
-# AUTHOR:     Stijn De Weirdt 
-# MAINTAINER: Stijn De Weirdt 
+# AUTHOR:     Stijn De Weirdt
+# MAINTAINER: Stijn De Weirdt
 # LICENSE:    http://cern.ch/eu-datagrid/license.html
 #
 ################################################################################
@@ -21,10 +21,12 @@ Working type definitions can be found in the README file.
 
 The I<network> component sets the network settings through /etc/sysconfig/network and the various files in /etc/sysconfig/network-scripts. Currently only support eth* devices.
 
-For restarting, a sleep value of 15 is used to make sure the restarted network is fully restarted (routing may need some time to come up completely). Because of this, adding/changing lots of things may cause some slowdown. 
+For restarting, a sleep value of 15 is used to make sure the restarted network is fully restarted (routing may need some time to come up completely). Because of this, adding/changing lots of things may cause some slowdown.
 New/changed settings are first tested by probing the CDB server on the port where the profile should be found. If this fails, the previous settings are reused.
 
 =head1 RESOURCES
+
+=over
 
 =item /system/network/realhostname
 
@@ -96,6 +98,8 @@ Set the ethernet transmit or receive buffer ring counts.  See ethtool --show-rin
 Set the wake-on-lan parameter.  See ethtool for more details of the choices.  "d" disables the
 wake-on LAN.
 
+=back
+
 =head1 NOZEROCONF
 
 Setting nozeroconf to true stops an interface from being assigned an automatic address in the 169.254. subnet.
@@ -103,6 +107,8 @@ Setting nozeroconf to true stops an interface from being assigned an automatic a
 =head1 HWADDR
 
 Explicitly set the MAC address for the interfaces in the configuration files. The MAC address is taken from /hardware/cards/nic/eth[i]/hwaddr.
+
+=over
 
 =item /system/network/set_hwaddr : boolean
 
@@ -112,6 +118,7 @@ Set the default behaviour for all interfaces. The component default is false.
 
 Set the behaviour for interface eth[i]. This overrides the default setting.
 
+=back
 
 =head1 CHANNEL BONDING
 
@@ -120,7 +127,7 @@ Set the behaviour for interface eth[i]. This overrides the default setting.
 To enable channel bonding with quattor using devices eth0 and eth1 to form bond0, proceed as follows:
 
 include pro_software_component_network;
-                                                                             
+
 "/system/network/interfaces/eth0/bootproto"="none";
 "/system/network/interfaces/eth0/master"="bond0";
 
@@ -129,9 +136,9 @@ include pro_software_component_network;
 
 "/system/network/interfaces/bond0" = NETWORK_PARAMS;
 "/system/network/interfaces/bond0/driver" = "bonding";
-                                                                             
+
 include pro_software_component_modprobe;
-"/software/components/modprobe/modules" = push(nlist("name","bonding","alias","bond0")); 
+"/software/components/modprobe/modules" = push(nlist("name","bonding","alias","bond0"));
 "/software/components/modprobe/modules" =
 push(nlist("name","bonding","options","mode=6 miimon=100"));
 
@@ -139,9 +146,9 @@ push(nlist("name","bonding","options","mode=6 miimon=100"));
 
 =head1 VLAN support
 
-Use the vlan[0-9]{0-4} interface devices and set the the explicit device name and physdev. 
-The VLAN ID is the number of the '.' in the device name. Physdev is mandatory for vlan[0-9]{0-4} device. 
-An example: 
+Use the vlan[0-9]{0-4} interface devices and set the the explicit device name and physdev.
+The VLAN ID is the number of the '.' in the device name. Physdev is mandatory for vlan[0-9]{0-4} device.
+An example:
 "/system/network/interfaces/vlan0" = VLAN_NETWORK_PARAMS;
 "/system/network/interfaces/vlan0/device" = "eth0.3";
 "/system/network/interfaces/vlan0/physdev" = "eth0";

--- a/ncm-network/src/main/perl/network.pod
+++ b/ncm-network/src/main/perl/network.pod
@@ -19,7 +19,7 @@ network: Configure Network Settings
 
 Working type definitions can be found in the README file.
 
-The I<network> component sets the network settings through /etc/sysconfig/network and the various files in /etc/sysconfig/network-scripts. Currently only support eth* devices.
+The I<network> component sets the network settings through C<< /etc/sysconfig/network >>and the various files in C<< /etc/sysconfig/network-scripts >>. Currently only support eth* devices.
 
 For restarting, a sleep value of 15 is used to make sure the restarted network is fully restarted (routing may need some time to come up completely). Because of this, adding/changing lots of things may cause some slowdown.
 New/changed settings are first tested by probing the CDB server on the port where the profile should be found. If this fails, the previous settings are reused.
@@ -28,77 +28,105 @@ New/changed settings are first tested by probing the CDB server on the port wher
 
 =over
 
-=item /system/network/realhostname
+=item C<< /system/network/realhostname >>
 
-=item /system/network/hostname
+=item C<< /system/network/hostname >>
 
-=item /system/network/domainname
+=item C<< /system/network/domainname >>
 
-=item /system/network/default_gateway
+=item C<< /system/network/default_gateway >>
 
-=item /system/network/guess_default_gateway
+=item C<< /system/network/guess_default_gateway >>
 
-=item /system/network/gatewaydev
+=item C<< /system/network/gatewaydev >>
 
-=item /system/network/nisdomain
+=item C<< /system/network/nisdomain >>
 
-=item /system/network/nozeroconf
+=item C<< /system/network/nozeroconf >>
+
+=back
 
 These values are used to generate the /etc/sysconfig/network file. ("realhostname", "guess_default_gateway", "default_gateway", "gatewaydev", "nisdomain" and "nozeroconf" are optional).
 By setting guess_default_gateway, when default_gateway is not set, the component will try to guess the default gateway using the first configured gateway set on an interface (old style network config). (The default is true for backward compatible behaviour.)
 
-=item /system/network/interfaces/[dev][i]/ip
+=over
 
-=item /system/network/interfaces/[dev][i]/netmask
+=item C<< /system/network/interfaces/[dev][i]/ip >>
 
-=item /system/network/interfaces/[dev][i]/broadcast
+=item C<< /system/network/interfaces/[dev][i]/netmask >>
 
-=item /system/network/interfaces/[dev][i]/bootproto
+=item C<< /system/network/interfaces/[dev][i]/broadcast >>
 
-=item /system/network/interfaces/[dev][i]/onboot
+=item C<< /system/network/interfaces/[dev][i]/bootproto >>
 
-=item /system/network/interfaces/[dev][i]/type
+=item C<< /system/network/interfaces/[dev][i]/onboot >>
 
-=item /system/network/interfaces/[dev][i]/device
+=item C<< /system/network/interfaces/[dev][i]/type >>
 
-=item /system/network/interfaces/[dev][i]/master
+=item C<< /system/network/interfaces/[dev][i]/device >>
 
-These values are used to generate the /etc/sysconfig/network-scripts/ifcfg-[dev][i] files. ( "onboot", "bootproto", "master", "type" and "device" are optional; by default bootproto = static, onboot = yes, type = ethernet and device is the name of the interface used in the templates.)
+=item C<< /system/network/interfaces/[dev][i]/master >>
 
-=item /system/network/interfaces/eth[i]/route/[j]/gateway
+=back
 
-=item /system/network/interfaces/eth[i]/route/[j]/address
+These values are used to generate the C<< /etc/sysconfig/network-scripts/ifcfg-[dev][i] >> files. ( "onboot", "bootproto", "master", "type" and "device" are optional; by default bootproto = static, onboot = yes, type = ethernet and device is the name of the interface used in the templates.)
 
-=item /system/network/interfaces/eth[i]/route/[j]/netmask
+=over
 
-These values are used to generate the /etc/sysconfig/network-scripts/route-eth[i] files as used by ifup-routes. gateway and address should contain numerical values only. If no netmask value is given, 255.255.255.255 is used.
+=item C<< /system/network/interfaces/eth[i]/route/[j]/gateway >>
 
-=item /system/network/interfaces/eth[i]/aliases/[name]/ip
+=item C<< /system/network/interfaces/eth[i]/route/[j]/address >>
 
-=item /system/network/interfaces/eth[i]/aliases/[name]/netmask
+=item C<< /system/network/interfaces/eth[i]/route/[j]/netmask >>
 
-=item /system/network/interfaces/eth[i]/aliases/[name]/broadcast
+=back
 
-These values are used to generate the /etc/sysconfig/network-scripts/ifcfg-eth[i]:[name] files as used by ifup-aliases.
+These values are used to generate the C<< /etc/sysconfig/network-scripts/route-eth[i] >> files as used by ifup-routes. gateway and address should contain numerical values only. If no netmask value is given, 255.255.255.255 is used.
 
-=item /system/network/interfaces/eth[i]/aliases/[name]/name
+=over
+
+=item C<< /system/network/interfaces/eth[i]/aliases/[name]/ip >>
+
+=item C<< /system/network/interfaces/eth[i]/aliases/[name]/netmask >>
+
+=item C<< /system/network/interfaces/eth[i]/aliases/[name]/broadcast >>
+
+=back
+
+These values are used to generate the C<< /etc/sysconfig/network-scripts/ifcfg-eth[i]:[name] >> files as used by ifup-aliases.
+
+=over
+
+=item C<< /system/network/interfaces/eth[i]/aliases/[name]/name >>
+
+=back
 
 This value will be used to name the alias instead of [name]
 
-=item /system/network/interfaces/eth[i]/offload/tso
+=over
+
+=item C<< /system/network/interfaces/eth[i]/offload/tso >>
+
+=back
 
 Set the TCP segment offload parameter to "off" or "on"
 
-=item /system/network/interfaces/eth[i]/ring/[rt]x
+=over
+
+=item C<< /system/network/interfaces/eth[i]/ring/[rt]x >>
+
+=back
 
 Set the ethernet transmit or receive buffer ring counts.  See ethtool --show-ring for the values.
 
-=item /system/network/interfaces/eth[i]/ethtool/wol
+=over
+
+=item C<< /system/network/interfaces/eth[i]/ethtool/wol >>
+
+=back
 
 Set the wake-on-lan parameter.  See ethtool for more details of the choices.  "d" disables the
 wake-on LAN.
-
-=back
 
 =head1 NOZEROCONF
 
@@ -106,15 +134,15 @@ Setting nozeroconf to true stops an interface from being assigned an automatic a
 
 =head1 HWADDR
 
-Explicitly set the MAC address for the interfaces in the configuration files. The MAC address is taken from /hardware/cards/nic/eth[i]/hwaddr.
+Explicitly set the MAC address for the interfaces in the configuration files. The MAC address is taken from C<< /hardware/cards/nic/eth[i]/hwaddr >>.
 
 =over
 
-=item /system/network/set_hwaddr : boolean
+=item C<< /system/network/set_hwaddr : boolean >>
 
 Set the default behaviour for all interfaces. The component default is false.
 
-=item /system/network/interfaces/eth[i]/set_hwaddr : boolean
+=item C<< /system/network/interfaces/eth[i]/set_hwaddr : boolean >>
 
 Set the behaviour for interface eth[i]. This overrides the default setting.
 
@@ -122,36 +150,37 @@ Set the behaviour for interface eth[i]. This overrides the default setting.
 
 =head1 CHANNEL BONDING
 
-(see <kernel>/Documentation/networking/bonding.txt for more info on the driver options)
+(see C<< <kernel>/Documentation/networking/bonding.txt >> for more info on the driver options)
 
 To enable channel bonding with quattor using devices eth0 and eth1 to form bond0, proceed as follows:
 
-include pro_software_component_network;
+    include pro_software_component_network;
 
-"/system/network/interfaces/eth0/bootproto"="none";
-"/system/network/interfaces/eth0/master"="bond0";
+    "/system/network/interfaces/eth0/bootproto"="none";
+    "/system/network/interfaces/eth0/master"="bond0";
 
-"/system/network/interfaces/eth1/bootproto"="none";
-"/system/network/interfaces/eth1/master"="bond0";
+    "/system/network/interfaces/eth1/bootproto"="none";
+    "/system/network/interfaces/eth1/master"="bond0";
 
-"/system/network/interfaces/bond0" = NETWORK_PARAMS;
-"/system/network/interfaces/bond0/driver" = "bonding";
+    "/system/network/interfaces/bond0" = NETWORK_PARAMS;
+    "/system/network/interfaces/bond0/driver" = "bonding";
 
-include pro_software_component_modprobe;
-"/software/components/modprobe/modules" = push(nlist("name","bonding","alias","bond0"));
-"/software/components/modprobe/modules" =
-push(nlist("name","bonding","options","mode=6 miimon=100"));
+    include pro_software_component_modprobe;
+    "/software/components/modprobe/modules" = push(nlist("name","bonding","alias","bond0"));
+    "/software/components/modprobe/modules" =
+    push(nlist("name","bonding","options","mode=6 miimon=100"));
 
-"/software/components/network/dependencies/pre" = push("modprobe");
+    "/software/components/network/dependencies/pre" = push("modprobe"); 
 
 =head1 VLAN support
 
-Use the vlan[0-9]{0-4} interface devices and set the the explicit device name and physdev.
-The VLAN ID is the number of the '.' in the device name. Physdev is mandatory for vlan[0-9]{0-4} device.
+Use the C<< vlan[0-9]{0-4} >> interface devices and set the the explicit device name and physdev.
+The VLAN ID is the number of the '.' in the device name. C< Physdev > is mandatory for C<< vlan[0-9]{0-4} >> device.
 An example:
-"/system/network/interfaces/vlan0" = VLAN_NETWORK_PARAMS;
-"/system/network/interfaces/vlan0/device" = "eth0.3";
-"/system/network/interfaces/vlan0/physdev" = "eth0";
+
+    "/system/network/interfaces/vlan0" = VLAN_NETWORK_PARAMS;
+    "/system/network/interfaces/vlan0/device" = "eth0.3";
+    "/system/network/interfaces/vlan0/physdev" = "eth0";
 
 
 =cut

--- a/ncm-network/src/main/perl/network.pod
+++ b/ncm-network/src/main/perl/network.pod
@@ -156,11 +156,11 @@ To enable channel bonding with quattor using devices eth0 and eth1 to form bond0
 
     include 'components/network/config';
 
-    "/system/network/interfaces/eth0/bootproto"="none";
-    "/system/network/interfaces/eth0/master"="bond0";
+    "/system/network/interfaces/eth0/bootproto" = "none";
+    "/system/network/interfaces/eth0/master" = "bond0";
 
-    "/system/network/interfaces/eth1/bootproto"="none";
-    "/system/network/interfaces/eth1/master"="bond0";
+    "/system/network/interfaces/eth1/bootproto" = "none";
+    "/system/network/interfaces/eth1/master" = "bond0";
 
     "/system/network/interfaces/bond0" = NETWORK_PARAMS;
     "/system/network/interfaces/bond0/driver" = "bonding";
@@ -168,9 +168,9 @@ To enable channel bonding with quattor using devices eth0 and eth1 to form bond0
     "/system/network/interfaces/bond0/bonding_opts/miimon" = 100;
 
     include 'components/modprobe/config';
-    "/software/components/modprobe/modules" = push(nlist("name","bonding","alias","bond0"));
+    "/software/components/modprobe/modules" = append(nlist("name","bonding","alias","bond0"));
 
-    "/software/components/network/dependencies/pre" = push("modprobe");
+    "/software/components/network/dependencies/pre" = append("modprobe");
 
 =head1 VLAN support
 

--- a/ncm-network/src/main/perl/network.pod
+++ b/ncm-network/src/main/perl/network.pod
@@ -154,7 +154,7 @@ Set the behaviour for interface eth[i]. This overrides the default setting.
 
 To enable channel bonding with quattor using devices eth0 and eth1 to form bond0, proceed as follows:
 
-    include pro_software_component_network;
+    include 'components/network/config';
 
     "/system/network/interfaces/eth0/bootproto"="none";
     "/system/network/interfaces/eth0/master"="bond0";
@@ -164,13 +164,13 @@ To enable channel bonding with quattor using devices eth0 and eth1 to form bond0
 
     "/system/network/interfaces/bond0" = NETWORK_PARAMS;
     "/system/network/interfaces/bond0/driver" = "bonding";
+    "/system/network/interfaces/bond0/bonding_opts/mode" = 6;
+    "/system/network/interfaces/bond0/bonding_opts/miimon" = 100;
 
-    include pro_software_component_modprobe;
+    include 'components/modprobe/config';
     "/software/components/modprobe/modules" = push(nlist("name","bonding","alias","bond0"));
-    "/software/components/modprobe/modules" =
-    push(nlist("name","bonding","options","mode=6 miimon=100"));
 
-    "/software/components/network/dependencies/pre" = push("modprobe"); 
+    "/software/components/network/dependencies/pre" = push("modprobe");
 
 =head1 VLAN support
 
@@ -181,6 +181,5 @@ An example:
     "/system/network/interfaces/vlan0" = VLAN_NETWORK_PARAMS;
     "/system/network/interfaces/vlan0/device" = "eth0.3";
     "/system/network/interfaces/vlan0/physdev" = "eth0";
-
 
 =cut

--- a/ncm-network/src/main/perl/network.pod
+++ b/ncm-network/src/main/perl/network.pod
@@ -155,17 +155,17 @@ Set the behaviour for interface eth[i]. This overrides the default setting.
 To enable channel bonding with quattor using devices eth0 and eth1 to form bond0, proceed as follows:
 
     include 'components/network/config';
+    prefix "/system/network/interfaces";
+    "eth0/bootproto" = "none";
+    "eth0/master" = "bond0";
 
-    "/system/network/interfaces/eth0/bootproto" = "none";
-    "/system/network/interfaces/eth0/master" = "bond0";
+    "eth1/bootproto" = "none";
+    "eth1/master" = "bond0";
 
-    "/system/network/interfaces/eth1/bootproto" = "none";
-    "/system/network/interfaces/eth1/master" = "bond0";
-
-    "/system/network/interfaces/bond0" = NETWORK_PARAMS;
-    "/system/network/interfaces/bond0/driver" = "bonding";
-    "/system/network/interfaces/bond0/bonding_opts/mode" = 6;
-    "/system/network/interfaces/bond0/bonding_opts/miimon" = 100;
+    "bond0" = NETWORK_PARAMS;
+    "bond0/driver" = "bonding";
+    "bond0/bonding_opts/mode" = 6;
+    "bond0/bonding_opts/miimon" = 100;
 
     include 'components/modprobe/config';
     "/software/components/modprobe/modules" = append(nlist("name","bonding","alias","bond0"));


### PR DESCRIPTION
The last commit is most relevant, this fixes the example to use ```bonding_opts``` instead of modules which does not work anymore.
The rest is a cleanup of this pod:
 - fixed pod errors
 - style adjustments for escaping special chars etc.
 - code blocks for examples instead of text
 - ...