### PR TITLE
ncm-network: allow for bonding with lacp while keeping validation

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -36,12 +36,13 @@ type structure_bonding_options = {
     "primary" ? string with exists("/system/network/interfaces/" + SELF)
     "lacp_rate" ? long(0..1)
 } with {
-    if ( SELF['mode'] != 4 ) {
+    if ( SELF['mode'] == 1 || SELF['mode'] == 5 || SELF['mode'] == 6 ) {
         if ( ! exists(SELF["primary"]) ) {
             error("Bonding configured but no primary is defined.");
         };
-        if ( ! exists(SELF["updelay"]) ) {
-            error("Bonding configured but no updelay is defined.");
+    } else {
+        if ( exists(SELF["primary"]) ) {
+            error("Primary is defined but this is not allowed with this bonding mode.");
         };
     };
     true;

--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -29,7 +29,7 @@ type structure_interface_alias = {
 # Describes the bonding options for configuring channel bonding on SL5
 # and similar.
 type structure_bonding_options = {
-    "mode" : long
+    "mode" : long(0..6)
     "miimon" : long
     "updelay" ? long
     "downdelay" ? long

--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -36,11 +36,7 @@ type structure_bonding_options = {
     "primary" ? string with exists("/system/network/interfaces/" + SELF)
     "lacp_rate" ? long(0..1)
 } with {
-    if ( SELF['mode'] == 4 ) {
-        if ( ! exists(SELF["lacp_rate"]) ) {
-            error("Bonding using LACP configured but no rate set.");
-        };
-    } else {
+    if ( SELF['mode'] != 4 ) {
         if ( ! exists(SELF["primary"]) ) {
             error("Bonding configured but no primary is defined.");
         };

--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -31,9 +31,24 @@ type structure_interface_alias = {
 type structure_bonding_options = {
     "mode" : long
     "miimon" : long
-    "updelay" : long
+    "updelay" ? long
     "downdelay" ? long
-    "primary" : string with exists("/system/network/interfaces/" + SELF)
+    "primary" ? string with exists("/system/network/interfaces/" + SELF)
+    "lacp_rate" ? long(0..1)
+} with {
+    if ( SELF['mode'] == 4 ) {
+        if ( ! exists(SELF["lacp_rate"]) ) {
+            error("Bonding using LACP configured but no rate set.");
+        };
+    } else {
+        if ( ! exists(SELF["primary"]) ) {
+            error("Bonding configured but no primary is defined.");
+        };
+        if ( ! exists(SELF["updelay"]) ) {
+            error("Bonding configured but no updelay is defined.");
+        };
+    };
+    true;
 };
 
 # describes the bridging options


### PR DESCRIPTION
When bonding with LACP is configured (mode=4), updelay and primary are not required but lacp_rate is.