### PR TITLE
ncm-cron: Fix race condition bug

### DIFF
--- a/ncm-cron/src/main/perl/cron.pm
+++ b/ncm-cron/src/main/perl/cron.pm
@@ -404,6 +404,11 @@ sub Configure {
         $p->run();
         $self->error("Could not refresh cron by running \"svcadm refresh cron\"")
             if $?;
+    } else {
+    # For Linux: as a workarond for a RedHat 5 cron race condition bug: touch /etc/cron.d
+    #            when we are done generating the files. cron(8) will reload as a result
+        sleep 1;
+        utime(undef, undef, $linux_crondir);
     }
 
     return 1;

--- a/ncm-cron/src/main/perl/cron.pm
+++ b/ncm-cron/src/main/perl/cron.pm
@@ -407,8 +407,13 @@ sub Configure {
     } else {
     # For Linux: as a workarond for a RedHat 5 cron race condition bug: touch /etc/cron.d
     #            when we are done generating the files. cron(8) will reload as a result
-        sleep 1;
-        utime(undef, undef, $linux_crondir);
+        if ($NoAction) {
+            $self->info("Would have touched $linux_crondir to workaround a cron bug");
+        } else {
+            $self->debug(1,"Touching $linux_crondir to workaround a cron bug");
+            sleep 1;
+            utime(undef, undef, $linux_crondir);
+        }
     }
 
     return 1;

--- a/ncm-cron/src/main/perl/cron.pod
+++ b/ncm-cron/src/main/perl/cron.pod
@@ -126,7 +126,7 @@ Default : None
 If the 'timing' nlist is used to specify the time, it can contain any of the
 keys: 'minute', 'hour', 'day', 'month' and 'weekday'. An unspecified key will
 have a value of '*'. A further key of 'smear' can be used to specify (in
-seconds) a maximum interval for smearing the start time, which can be as much
+minutes) a maximum interval for smearing the start time, which can be as much
 as a day. When a smeared job is created, a random increment between zero and
 the smear time is applied to the start time of the job.  If the start time
 results in the job running on the following day, then all other fields (day,


### PR DESCRIPTION
There is a race condition: when the component mass creates files (within a second) cron may read in just some of the cronjobs ignoring all the others until crond restarted or the host is rebooted. RedHat 5 has this bug.
RH6 uses inotify and not suspectible to this.

By touching /etc/cron.d we force crond to re-read all the files (cronjobs).