### PR TITLE
ncm-modprobe: fix for install, remove and options, added blacklist

### DIFF
--- a/ncm-modprobe/src/main/pan/components/modprobe/schema.pan
+++ b/ncm-modprobe/src/main/pan/components/modprobe/schema.pan
@@ -11,7 +11,8 @@ type module_type = {
     "alias"     ? string # alias for the loadable module"
     "options"   ? string # options for the loadable module"
     "install"   ? string # command to run when loading module"
-    "remove"    ? string # command to run when removing module "
+    "remove"    ? string # command to run when removing module"
+    "blacklist" ? string # ignored, only the name of the module is used"
 };
 
 type component_modprobe_type = {

--- a/ncm-modprobe/src/main/perl/modprobe.pm
+++ b/ncm-modprobe/src/main/perl/modprobe.pm
@@ -23,16 +23,24 @@ use LC::File qw(directory_contents);
 
 no strict 'refs';
 
-foreach my $method (qw(alias options install remove)) {
+foreach my $method (qw(alias options install remove blacklist)) {
     *{__PACKAGE__ . "::process_$method"} = sub {
         my ($self, $t, $fh) = @_;
         foreach my $i (@{$t->{modules}}) {
             if (exists($i->{$method})) {
-                $self->verbose("Adding $method $i->{$method} for $i->{name}");
-                print $fh "$method $i->{$method} $i->{name}\n";
+                if ($method eq "alias") {
+                    $self->verbose("Adding: $method $i->{$method} $i->{name}");
+                    print $fh "$method $i->{$method} $i->{name}\n";
+                } elsif ($method eq "blacklist") {
+                    $self->verbose("Adding: $method $i->{name}");
+                    print $fh "$method $i->{name}\n";
+                } else {
+                    $self->verbose("Adding: $method $i->{name} $i->{$method}");
+                    print $fh "$method $i->{name} $i->{$method}\n";
+                }
             }
         }
-    };
+    }
 }
 
 use strict 'refs';
@@ -70,6 +78,7 @@ sub Configure
     $self->process_options($t, $fh);
     $self->process_install($t, $fh);
     $self->process_remove($t, $fh);
+    $self->process_blacklist($t, $fh);
 
     $self->mkinitrd($fh) if $fh->close();
     return 1;

--- a/ncm-modprobe/src/main/perl/modprobe.pod
+++ b/ncm-modprobe/src/main/perl/modprobe.pod
@@ -14,14 +14,14 @@ NCM::modprobe - NCM modprobe configuration component
 =item Configure()
 
 The method configures the modprobe configuration file /etc/modules.conf
-for 2.4 kernels and configuration file /etc/modprobe.d/ncm-modprobe.conf
+for 2.4 kernels and configuration file /etc/modprobe.d/quattor.conf
 for 2.6 kernels. The method also creates a new initial ramdisk images for
 preloading modules for all the kernel releases installed in the node.
 
 =item Unconfigure()
 
 The method unconfigures the modprobe configuration file /etc/modules.conf
-for 2.4 kernels and configuration file /etc/modprobe.d/ncm-modprobe.conf
+for 2.4 kernels and configuration file /etc/modprobe.d/quattor.conf
 for 2.6 kernels. The method also creates a new initial ramdisk images for
 preloading modules for all the kernel releases installed in the node.
 
@@ -41,8 +41,8 @@ activates/deactivates the component.
 The modules item is a list of module_type. The module type is base on
 the fields "name" name of the loadable module, "alias" alias for the
 loadable module, "options" options for the loadable module, "install"
-command to run when loading module and "remove" command to run when
-removing module.
+command to run when loading module, "remove" command to run when
+removing module and "blacklist" to disable a module.
 
 =back
 

--- a/ncm-modprobe/src/test/perl/generator.t
+++ b/ncm-modprobe/src/test/perl/generator.t
@@ -21,4 +21,4 @@ use NCM::Component::modprobe;
 
 my $cmp = NCM::Component::modprobe->new("modprobe");
 
-can_ok($cmp, qw(process_alias process_install process_options process_remove));
+can_ok($cmp, qw(process_alias process_install process_options process_remove process_blacklist));

--- a/ncm-modprobe/src/test/perl/process_aliases.t
+++ b/ncm-modprobe/src/test/perl/process_aliases.t
@@ -9,9 +9,6 @@
 
 Test the C<process_alias> method.
 
-This method is identical to C<process_install>, C<process_options> and
-C<process_remove>.  It's enough to test this one.
-
 =cut
 
 use strict;

--- a/ncm-modprobe/src/test/perl/process_blacklist.t
+++ b/ncm-modprobe/src/test/perl/process_blacklist.t
@@ -1,0 +1,47 @@
+# -*- mode: cperl -*-
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+=pod
+
+=head1 DESCRIPTION
+
+Test the C<process_blacklist> method.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Test::Quattor;
+use CAF::FileWriter;
+use NCM::Component::modprobe;
+use CAF::Object;
+use Readonly;
+
+$CAF::Object::NoAction = 1;
+
+my $cmp = NCM::Component::modprobe->new("modprobe");
+
+my $fh = CAF::FileWriter->new("/etc/modprobe.d");
+
+Readonly::Hash my %TREE => (modules => [
+        {
+            blacklist => "",
+            name => "module_name1",
+        },
+        {
+            blacklist => "module_string",
+            name => "module_name2",
+        },
+    ],
+);
+
+$cmp->process_blacklist(\%TREE, $fh);
+
+like($fh, qr{^blacklist\s+module_name1$}m,
+     "First blacklist line rendered correctly");
+like($fh, qr{^blacklist\s+module_name2$}m,
+     "Second blacklist line rendered correctly");
+unlike($fh, qr{module_string$}m, "Module string correctly ignored");

--- a/ncm-modprobe/src/test/perl/process_install.t
+++ b/ncm-modprobe/src/test/perl/process_install.t
@@ -1,0 +1,47 @@
+# -*- mode: cperl -*-
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+=pod
+
+=head1 DESCRIPTION
+
+Test the C<process_install> method.
+
+This method is identical to C<process_options> and
+C<process_remove>.  It's enough to test this one.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Test::Quattor;
+use CAF::FileWriter;
+use NCM::Component::modprobe;
+use CAF::Object;
+use Readonly;
+
+$CAF::Object::NoAction = 1;
+
+my $cmp = NCM::Component::modprobe->new("modprobe");
+
+my $fh = CAF::FileWriter->new("/etc/modprobe.d");
+
+Readonly::Hash my %TREE => (modules => [
+        {
+            install => "module_command",
+            name => "module_name1",
+        },
+        {
+            name => "module_name2",
+        },
+    ],
+);
+
+$cmp->process_install(\%TREE, $fh);
+
+like($fh, qr{^install\s+module_name1\s+module_command$}m,
+     "First install line rendered correctly");
+unlike($fh, qr{module_name2$}m, "Module without command not printed");


### PR DESCRIPTION
This should fix bugs #412 and #413 and add "blacklist" functionality.