### PR TITLE
ncm-metaconfig: remove daemon property

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -15,7 +15,6 @@ type ${project.artifactId}_config =  {
      'mode' : long = 0644
      'owner' : string = 'root'
      'group' : string = 'root'
-     'daemon' ? string[] with { deprecated(0, "daemon property has been deprecated, daemons should be used instead"); true; }
      'daemons' ? caf_service_action{}
      'module' : string
      'backup' ? string


### PR DESCRIPTION
The daemon property was a good start, but is now deprecated and replaced with the daemons structure.
This removes the deprecated property, the code associated with it and anything that was testing it.

Fixes #431