### PR TITLE
ncm-sudo: Fix generation of parameter lists

### DIFF
--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -170,17 +170,17 @@ sub generate_general_options {
         foreach my $b (BOOLEAN_OPTS) {
             if (defined $opts{$b}) {
                 if ($opts{$b}->getValue eq 'true') {
-                    $ln .= "$b\t";
+                    $ln .= "$b,";
                 } else {
-                    $ln .= "!$b\t";
+                    $ln .= "!$b,";
                 }
             }
         }
         foreach my $o (INT_OPTS, STRING_OPTS) {
-            $ln .= "$o=" . $opts{$o}->getValue . "\t"
+            $ln .= "$o=" . $opts{$o}->getValue . ","
             if defined $opts{$o};
         }
-        $ln =~ s{\t$}{};
+        $ln =~ s{[\s,]$}{};
         push (@$dfl, $ln);
     }
     return $dfl;

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -168,17 +168,12 @@ sub generate_general_options {
         }
         my %opts = $def{PRIVILEGE_OPTS()}->getHash;
         foreach my $b (BOOLEAN_OPTS) {
-            if (defined $opts{$b}) {
-                if ($opts{$b}->getValue eq 'true') {
-                    $ln .= "$b,";
-                } else {
-                    $ln .= "!$b,";
-                }
-            }
+            $ln .= ($opts{$b}->getValue eq 'true' ? '' : '!' ). "$b,"
+                if (defined $opts{$b});
         }
         foreach my $o (INT_OPTS, STRING_OPTS) {
             $ln .= "$o=" . $opts{$o}->getValue . ","
-            if defined $opts{$o};
+                if defined $opts{$o};
         }
         $ln =~ s{[\s,]$}{};
         push (@$dfl, $ln);

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -24,82 +24,87 @@ our $EC = LC::Exception::Context->new->will_store_all;
 our $NoActionSupported = 1;
 
 # Path for the sudoers file.
-use constant FILE_PATH		=> '/etc/sudoers';
+use constant FILE_PATH => '/etc/sudoers';
 # PAN's path to this component.
-use constant PROFILE_BASE	=> "/software/components/sudo/";
+use constant PROFILE_BASE => "/software/components/sudo/";
 # PAN's paths to the component's fields.
-use constant { USER_ALIASES	=> PROFILE_BASE . "user_aliases",
-	       CMD_ALIASES	=> PROFILE_BASE . "cmd_aliases",
-	       RUNAS_ALIASES	=> PROFILE_BASE . "run_as_aliases",
-	       HOST_ALIASES	=> PROFILE_BASE . "host_aliases",
-	       GENERAL_OPTS	=> PROFILE_BASE . "general_options",
-	       PRIVILEGE_LINES	=> PROFILE_BASE . "privilege_lines",
-	       PRIVILEGE_USER	=> "user",
-	       PRIVILEGE_HOST	=> "host",
-	       PRIVILEGE_RUNAS	=> "run_as",
-	       PRIVILEGE_CMD	=> "cmd",
-	       PRIVILEGE_OPTS	=> "options",
-	       INCLUDES		=> PROFILE_BASE . "includes",
-	       INCLUDES_DIRS	=> PROFILE_BASE . "includes_dirs"
-       };
+use constant {
+    USER_ALIASES     => PROFILE_BASE . "user_aliases",
+    CMD_ALIASES      => PROFILE_BASE . "cmd_aliases",
+    RUNAS_ALIASES    => PROFILE_BASE . "run_as_aliases",
+    HOST_ALIASES     => PROFILE_BASE . "host_aliases",
+    GENERAL_OPTS     => PROFILE_BASE . "general_options",
+    PRIVILEGE_LINES  => PROFILE_BASE . "privilege_lines",
+    PRIVILEGE_USER   => "user",
+    PRIVILEGE_HOST   => "host",
+    PRIVILEGE_RUNAS  => "run_as",
+    PRIVILEGE_CMD    => "cmd",
+    PRIVILEGE_OPTS   => "options",
+    INCLUDES         => PROFILE_BASE . "includes",
+    INCLUDES_DIRS    => PROFILE_BASE . "includes_dirs"
+};
 
 use constant VISUDO_CHECK => qw(/usr/sbin/visudo -c -f /proc/self/fd/0);
 
 # All possible "Default" options separated by type.
-use constant BOOLEAN_OPTS	=> qw(long_otp_prompt
-				      ignore_dot
-				      mail_always
-				      mail_badpass
-				      mail_no_user
-				      mail_no_host
-				      mail_no_perms
-				      tty_tickets
-				      lecture
-				      authenticate
-				      root_sudo
-				      log_host
-				      log_year
-				      shell_noargs
-				      set_home
-				      always_set_home
-				      path_info
-				      preserve_groups
-				      fqdn
-				      insults
-				      requiretty
-				      env_editor
-				      rootpw
-				      runaspw
-				      targetpw
-				      set_logname
-				      stay_setuid
-				      env_reset
-				      use_loginclass
-				      );
-use constant INT_OPTS		=> qw(passwd_tries
-				    loglinelen
-				    timestamp_timeout
-				    passwd_timeout
-				    umask
-				    );
-use constant STRING_OPTS	=> qw(badpass_message
-                    env_keep
-                    env_delete
-                    timestampdir
-				    timestampowner
-				    passprompt
-				    runas_default
-				    syslog_goodpri
-				    syslog_badpri
-				    editor
-				    logfile
-				    syslog
-				    mailerpath
-				    mailerflags
-				    mailto
-				    exempt_group
-				    verifypw
-				    listpw);
+use constant BOOLEAN_OPTS => qw(
+    long_otp_prompt
+    ignore_dot
+    mail_always
+    mail_badpass
+    mail_no_user
+    mail_no_host
+    mail_no_perms
+    tty_tickets
+    lecture
+    authenticate
+    root_sudo
+    log_host
+    log_year
+    shell_noargs
+    set_home
+    always_set_home
+    path_info
+    preserve_groups
+    fqdn
+    insults
+    requiretty
+    env_editor
+    rootpw
+    runaspw
+    targetpw
+    set_logname
+    stay_setuid
+    env_reset
+    use_loginclass
+);
+use constant INT_OPTS => qw(
+    passwd_tries
+    loglinelen
+    timestamp_timeout
+    passwd_timeout
+    umask
+);
+use constant STRING_OPTS => qw(
+    badpass_message
+    env_keep
+    env_delete
+    timestampdir
+    timestampowner
+    passprompt
+    runas_default
+    syslog_goodpri
+    syslog_badpri
+    editor
+    logfile
+    syslog
+    mailerpath
+    mailerflags
+    mailto
+    exempt_group
+    verifypw
+    listpw
+);
 
 # generate_aliases method
 #
@@ -108,29 +113,29 @@ use constant STRING_OPTS	=> qw(badpass_message
 # be transformed into a set of lines, but it is useful to have it this
 # way for debugging.
 sub generate_aliases {
-	my ($self, $config) = @_;
-	my $aliases = { USER_ALIASES()	=> [],
-			HOST_ALIASES()	=> [],
-			RUNAS_ALIASES()	=> [],
-			CMD_ALIASES()	=> []
-		      };
+    my ($self, $config) = @_;
+    my $aliases = {
+        USER_ALIASES()  => [],
+        HOST_ALIASES()  => [],
+        RUNAS_ALIASES() => [],
+        CMD_ALIASES()   => []
+    };
 
-	foreach my $alias (USER_ALIASES, HOST_ALIASES, RUNAS_ALIASES,
-			   CMD_ALIASES) {
-		next unless $config->elementExists ($alias);
-		my $list = $config->getElement ($alias);
-		next unless defined $list;
-		while ($list->hasNextElement) {
-			my $lm = $list->getNextElement;
-			my $ln = $lm->getName;
-			$ln .= "\t= ";
-			$ln .= $lm->getNextElement->getValue . ","
-			while $lm->hasNextElement;
-			chop $ln;
-			push (@{$$aliases{$alias}}, $ln);
-		}
-	}
-	return $aliases;
+    foreach my $alias (USER_ALIASES, HOST_ALIASES, RUNAS_ALIASES, CMD_ALIASES) {
+        next unless $config->elementExists ($alias);
+        my $list = $config->getElement ($alias);
+        next unless defined $list;
+        while ($list->hasNextElement) {
+            my $lm = $list->getNextElement;
+            my $ln = $lm->getName;
+            $ln .= "\t= ";
+            $ln .= $lm->getNextElement->getValue . ","
+            while $lm->hasNextElement;
+            chop $ln;
+            push (@{$$aliases{$alias}}, $ln);
+        }
+    }
+    return $aliases;
 }
 
 # generate_general_options method
@@ -138,48 +143,47 @@ sub generate_aliases {
 # Returns a reference to an array of strings each containing one
 # "Default" line.
 sub generate_general_options {
+    my ($self, $config) = @_;
+    my $dfl = [];
 
-	my ($self, $config) = @_;
-	my $dfl = [];
+    return unless $config->elementExists (GENERAL_OPTS);
 
-	return unless $config->elementExists (GENERAL_OPTS);
+    my $lst = $config->getElement (GENERAL_OPTS);
 
-	my $lst = $config->getElement (GENERAL_OPTS);
-
-	while ($lst->hasNextElement) {
-		my $el = $lst->getNextElement;
-		my %def = $el->getHash;
-		my $ln;
-		# Only one of "user", "run_as" or "host" may be defined!!
-		if (defined $def{PRIVILEGE_USER()}) {
-			$ln = ":" . $def{PRIVILEGE_USER()}->getValue . "\t";
-		} elsif (defined $def{PRIVILEGE_RUNAS()}) {
-			$ln = ">" . $def{PRIVILEGE_RUNAS()}->getValue . "\t";
-		} elsif (defined $def{PRIVILEGE_HOST ()}) {
-			$ln = "@" . $def{PRIVILEGE_HOST ()}->getValue . "\t";
-		} elsif (defined $def{PRIVILEGE_CMD ()}) {
-			$ln = "!" . $def{PRIVILEGE_CMD ()}->getValue . "\t";
-		} else {
-			$ln = "\t";
-		}
-		my %opts = $def{PRIVILEGE_OPTS()}->getHash;
-		foreach my $b (BOOLEAN_OPTS) {
-			if (defined $opts{$b}) {
-				if ($opts{$b}->getValue eq 'true') {
-					$ln .= "$b\t";
-				} else {
-					$ln .= "!$b\t";
-				}
-			}
-		}
-		foreach my $o (INT_OPTS, STRING_OPTS) {
-			$ln .= "$o=" . $opts{$o}->getValue . "\t"
-			if defined $opts{$o};
-		}
-		$ln =~ s{\t$}{};
-		push (@$dfl, $ln);
-	}
-	return $dfl;
+    while ($lst->hasNextElement) {
+        my $el = $lst->getNextElement;
+        my %def = $el->getHash;
+        my $ln;
+        # Only one of "user", "run_as" or "host" may be defined!!
+        if (defined $def{PRIVILEGE_USER()}) {
+            $ln = ":" . $def{PRIVILEGE_USER()}->getValue . "\t";
+        } elsif (defined $def{PRIVILEGE_RUNAS()}) {
+            $ln = ">" . $def{PRIVILEGE_RUNAS()}->getValue . "\t";
+        } elsif (defined $def{PRIVILEGE_HOST ()}) {
+            $ln = "@" . $def{PRIVILEGE_HOST ()}->getValue . "\t";
+        } elsif (defined $def{PRIVILEGE_CMD ()}) {
+            $ln = "!" . $def{PRIVILEGE_CMD ()}->getValue . "\t";
+        } else {
+            $ln = "\t";
+        }
+        my %opts = $def{PRIVILEGE_OPTS()}->getHash;
+        foreach my $b (BOOLEAN_OPTS) {
+            if (defined $opts{$b}) {
+                if ($opts{$b}->getValue eq 'true') {
+                    $ln .= "$b\t";
+                } else {
+                    $ln .= "!$b\t";
+                }
+            }
+        }
+        foreach my $o (INT_OPTS, STRING_OPTS) {
+            $ln .= "$o=" . $opts{$o}->getValue . "\t"
+            if defined $opts{$o};
+        }
+        $ln =~ s{\t$}{};
+        push (@$dfl, $ln);
+    }
+    return $dfl;
 }
 
 # generate_privilege_lines method
@@ -187,45 +191,46 @@ sub generate_general_options {
 # Returns a reference to an array of strings, each containing one
 # complete privilege escalation line.
 sub generate_privilege_lines {
-	my ($self, $config) = @_;
-	my $lns = [];
+    my ($self, $config) = @_;
+    my $lns = [];
 
-	# Privilege lines are mandatory.
-	my $list = $config->getElement (PRIVILEGE_LINES);
-	while ($list->hasNextElement) {
-		my $el = $list->getNextElement;
-		my %info = $el->getHash;
-		my $ln = $info{PRIVILEGE_USER()}->getValue;
-		$ln .= "\t" . $info{PRIVILEGE_HOST()}->getValue;
-		$ln .= "= (". $info{PRIVILEGE_RUNAS()}->getValue . ")\t";
-		$ln .= $info{PRIVILEGE_OPTS()}->getValue . "\t"
-		if defined $info{PRIVILEGE_OPTS()};
-		$ln .= $info{PRIVILEGE_CMD()}->getValue;
-		push (@$lns, $ln);
-	}
-	return $lns;
+    # Privilege lines are mandatory.
+    my $list = $config->getElement (PRIVILEGE_LINES);
+    while ($list->hasNextElement) {
+        my $el = $list->getNextElement;
+        my %info = $el->getHash;
+        my $ln = $info{PRIVILEGE_USER()}->getValue;
+        $ln .= "\t" . $info{PRIVILEGE_HOST()}->getValue;
+        $ln .= "= (". $info{PRIVILEGE_RUNAS()}->getValue . ")\t";
+        $ln .= $info{PRIVILEGE_OPTS()}->getValue . "\t"
+        if defined $info{PRIVILEGE_OPTS()};
+        $ln .= $info{PRIVILEGE_CMD()}->getValue;
+        push (@$lns, $ln);
+    }
+    return $lns;
 }
 
 # Returns true if the contents of the file passed as an argument make
 # a valid /etc/sudoers.
-sub is_valid_sudoers
-{
+sub is_valid_sudoers {
     my ($self, $fh) = @_;
-
     my ($err, $out);
-
-    my $proc = CAF::Process->new ([VISUDO_CHECK], stdin => "$fh",
-				  stderr => \$err, stdout => \$out,
-				  keeps_state => 1,
-				  log => $self);
+    my $proc = CAF::Process->new (
+        [VISUDO_CHECK],
+        stdin => "$fh",
+        stderr => \$err,
+        stdout => \$out,
+        keeps_state => 1,
+        log => $self
+    );
 
     $proc->execute();
 
     if ($? || $out !~ m{parsed OK}) {
-	$self->error ("sudoers check said: $err");
-	return 0;
+        $self->error ("sudoers check said: $err");
+        return 0;
     } else {
-	$self->warn ($err) if $err;
+        $self->warn ($err) if $err;
     }
     return 1;
 }
@@ -248,62 +253,66 @@ sub is_valid_sudoers
 sub write_sudoers {
     my ($self, $aliases, $opts, $lns, $includes, $includes_dirs) = @_;
 
-    my $fh = CAF::FileWriter->new (FILE_PATH,
-				   mode => 0440,
-				   owner => 0,
-				   group => 0,
-				   backup => '.old',
-				   log => $self);
+    my $fh = CAF::FileWriter->new (
+        FILE_PATH,
+        mode => 0440,
+        owner => 0,
+        group => 0,
+        backup => '.old',
+        log => $self
+    );
 
-    print $fh ("# File created by ncm-sudo v. ${project.version}\n",
-	       "# Read man(5) sudoers for understanding the structure\n",
-	       "# of this file\n");
+    print $fh (
+        "# File created by ncm-sudo v. ${project.version}\n",
+        "# Read man(5) sudoers for understanding the structure\n",
+        "# of this file\n"
+    );
 
     print $fh ("\n# User alias specification\n");
 
     foreach my $alias (@{$aliases->{USER_ALIASES()}}) {
-	printf $fh "%-15s %10s\n", "User_Alias", $alias;
+        printf $fh "%-15s %10s\n", "User_Alias", $alias;
     }
 
     print $fh "\n# Runas alias specification\n";
     foreach my $alias (@{$aliases->{RUNAS_ALIASES()}}) {
-	printf $fh "%-15s %10s\n", "Runas_Alias", $alias;
+        printf $fh "%-15s %10s\n", "Runas_Alias", $alias;
     }
 
     print $fh "\n# Command alias specification\n";
     foreach my $alias (@{$aliases->{CMD_ALIASES()}}) {
-	printf $fh "%-15s %10s\n", "Cmnd_Alias", $alias;
+        printf $fh "%-15s %10s\n", "Cmnd_Alias", $alias;
     }
 
     print $fh "\n# Host alias specification\n";
     foreach my $alias (@{$aliases->{HOST_ALIASES()}}) {
-	printf $fh "%-15s %10s\n", "Host_Alias", $alias;
+        printf $fh "%-15s %10s\n", "Host_Alias", $alias;
     }
 
     print $fh ("\n# Files to be included\n");
     foreach my $include (@$includes) {
-	print $fh "#include $include\n";
+        print $fh "#include $include\n";
     }
 
     print $fh "\n# Directories to be included\n";
     foreach my $include (@$includes_dirs) {
-	print $fh "#includedir $include\n";
+        print $fh "#includedir $include\n";
     }
 
 
     print $fh ("\n# Defaults specification\n");
     foreach my $opt ((@$opts)) {
-	printf $fh "%s%s\n", "Defaults", $opt;
+        printf $fh "%s%s\n", "Defaults", $opt;
     }
 
     print $fh ("\n# User privilege specification\n");
     foreach my $line (@$lns) {
-	print $fh "$line\n";
+        print $fh "$line\n";
     }
 
     if (!$self->is_valid_sudoers($fh)) {
-	$self->error("Invalid sudoers file. Not saving");
-	$fh->cancel();
+        $self->error("Invalid sudoers file. Not saving");
+        $fh->cancel();
     }
 
     $fh->close();
@@ -318,7 +327,7 @@ sub generate_includes
     my ($self, $config, $path) = @_;
 
     if ($config->elementExists ($path)) {
-	return $config->getElement ($path)->getTree();
+        return $config->getElement ($path)->getTree();
     }
     return [];
 }
@@ -330,13 +339,13 @@ sub generate_includes
 # Assume mandatory fields are there. You'll have to crash anyways if
 # they're not present.
 sub Configure {
-	my ($self, $config) = @_;
+        my ($self, $config) = @_;
 
-	my $aliases = $self->generate_aliases ($config);
-	my $opts = $self->generate_general_options ($config);
-	my $incls = $self->generate_includes ($config, INCLUDES);
-	my $incls_dirs = $self->generate_includes ($config, INCLUDES_DIRS);
-	my $lns = $self->generate_privilege_lines ($config);
+        my $aliases = $self->generate_aliases ($config);
+        my $opts = $self->generate_general_options ($config);
+        my $incls = $self->generate_includes ($config, INCLUDES);
+        my $incls_dirs = $self->generate_includes ($config, INCLUDES_DIRS);
+        my $lns = $self->generate_privilege_lines ($config);
 
-	return !$self->write_sudoers ($aliases, $opts, $lns, $incls, $incls_dirs);
+        return !$self->write_sudoers ($aliases, $opts, $lns, $incls, $incls_dirs);
 }

--- a/ncm-sudo/src/test/perl/options.t
+++ b/ncm-sudo/src/test/perl/options.t
@@ -32,9 +32,9 @@ is($o->[1], '@h', "host defaults correctly processed");
 is($o->[2], ':u', "user defaults correctly processed");
 is($o->[3], '!c', 'command defaults correctly processed');
 is($o->[4], "", "No modifier leads to empty line heading");
-like($o->[5], qr{^\s*listpw\s*=\s*hello\s*$}, "String defaults correctly processed");
-like($o->[6], qr{^\s*loglinelen\s*=\s*5\s*$}, "Integer defaults correctly processed");
-like($o->[7], qr{^\s*!insults,requiretty,editor=vim\s*$}, "List with boolean and string defaults correctly processed");
+like($o->[5], qr{^\s+listpw\s*=\s*hello\s*$}, "String defaults correctly processed");
+like($o->[6], qr{^\s+loglinelen\s*=\s*5\s*$}, "Integer defaults correctly processed");
+like($o->[7], qr{^\s+!insults,requiretty,editor=vim\s*$}, "List with boolean and string defaults correctly processed");
 
 $cfg = get_config_for_profile('profile_empty');
 $o = $cmp->generate_general_options($cfg);

--- a/ncm-sudo/src/test/perl/options.t
+++ b/ncm-sudo/src/test/perl/options.t
@@ -26,7 +26,7 @@ $cfg = get_config_for_profile('profile_all_options');
 
 $o = $cmp->generate_general_options($cfg);
 
-is(scalar(@$o), 9, "All options were processed");
+is(scalar(@$o), 8, "All options were processed");
 is($o->[0], ">r", "run_as defaults correctly processed");
 is($o->[1], '@h', "host defaults correctly processed");
 is($o->[2], ':u', "user defaults correctly processed");
@@ -34,8 +34,7 @@ is($o->[3], '!c', 'command defaults correctly processed');
 is($o->[4], "", "No modifier leads to empty line heading");
 like($o->[5], qr{^\s*listpw\s*=\s*hello\s*$}, "String defaults correctly processed");
 like($o->[6], qr{^\s*loglinelen\s*=\s*5\s*$}, "Integer defaults correctly processed");
-like($o->[7], qr{^\s*!insults\s*$}, "Boolean defaults with false value correctly processed");
-like($o->[8], qr{^\s*requiretty\s*$}, "Boolean defaults with true value correctly processed");
+like($o->[7], qr{^\s*!insults,requiretty,editor=vim\s*$}, "List with boolean and string defaults correctly processed");
 
 $cfg = get_config_for_profile('profile_empty');
 $o = $cmp->generate_general_options($cfg);

--- a/ncm-sudo/src/test/perl/sudoers.t
+++ b/ncm-sudo/src/test/perl/sudoers.t
@@ -60,12 +60,12 @@ is(*$fh->{options}->{mode}, 0440,
    "sudoers is created with the correct permissions");
 
 isa_ok($fh, "CAF::FileWriter", "A file was created");
-like($fh, qr{^User_Alias\s*u$}m, "User aliases generated");
-like($fh, qr{^Runas_Alias\s*r$}m, "Runas aliases generated");
-like($fh, qr{^Cmnd_Alias\s*c$}m, "Command aliases generated");
-like($fh, qr{^Host_Alias\s*h$}m, "Host aliases generated");
+like($fh, qr{^User_Alias\s+u$}m, "User aliases generated");
+like($fh, qr{^Runas_Alias\s+r$}m, "Runas aliases generated");
+like($fh, qr{^Cmnd_Alias\s+c$}m, "Command aliases generated");
+like($fh, qr{^Host_Alias\s+h$}m, "Host aliases generated");
 like($fh, qr{^#include i$}m, "Include lines generated");
-like($fh, qr{^Defaults\s*o$}m, "Defaults lines generated");
+like($fh, qr{^Defaults\s+o$}m, "Defaults lines generated");
 like($fh, qr{^l$}m, "Privilege lines generated");
 like($fh, qr{^#includedir id$}m, "Includedir lines generated");
 

--- a/ncm-sudo/src/test/perl/sudoers.t
+++ b/ncm-sudo/src/test/perl/sudoers.t
@@ -46,7 +46,7 @@ $aliases = { $USER => ["u"],
 	     $CMD => ["c"],
 	     $HOST => ["h"]
 	   };
-$opts = ["\to"];
+$opts = ["\t!insults,requiretty"];
 $lns = ["l"];
 $includes = ["i"];
 $includes_dirs = ["id"];
@@ -65,7 +65,7 @@ like($fh, qr{^Runas_Alias\s+r$}m, "Runas aliases generated");
 like($fh, qr{^Cmnd_Alias\s+c$}m, "Command aliases generated");
 like($fh, qr{^Host_Alias\s+h$}m, "Host aliases generated");
 like($fh, qr{^#include i$}m, "Include lines generated");
-like($fh, qr{^Defaults\s+o$}m, "Defaults lines generated");
+like($fh, qr{^Defaults\s+!insults,requiretty$}m, "Defaults lines generated");
 like($fh, qr{^l$}m, "Privilege lines generated");
 like($fh, qr{^#includedir id$}m, "Includedir lines generated");
 

--- a/ncm-sudo/src/test/resources/profile_all_options.pan
+++ b/ncm-sudo/src/test/resources/profile_all_options.pan
@@ -14,4 +14,5 @@ prefix "/software/components/sudo";
 "general_options/5/options/listpw" = "hello";
 "general_options/6/options/loglinelen" = 5;
 "general_options/7/options/insults" = false;
-"general_options/8/options/requiretty" = true;
+"general_options/7/options/requiretty" = true;
+"general_options/7/options/editor" = "vim";


### PR DESCRIPTION
Specifying multiple options was possible, but untested by the unit tests, the delimiter was incorrectly specified as a tab character rather than a comma.

Fixes #460 as reported by @drossy.