### PR TITLE
ncm-authconfig: Correct ldap object class for automount entries

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -302,7 +302,7 @@ type sssd_netgroup = {
 type sssd_autofs = {
     "map_object_class" : string = "automountMap"
     "map_name" : string = "ou"
-    "entry_object_class" : string = "automountMap"
+    "entry_object_class" : string = "automount"
     "entry_key" : string = "cn"
     "entry_value" : string = "automountInformation"
     "search_base" ? string


### PR DESCRIPTION
The sssd-ldap man page appears to be incorrect, the autofs schema e.g. http://people.redhat.com/nalin/schema/autofs.schema actually uses automount for the map entries not automountMap