### PR TITLE
ncm-autofs: Add direct mount support

### DIFF
--- a/ncm-autofs/src/main/perl/autofs.pm
+++ b/ncm-autofs/src/main/perl/autofs.pm
@@ -257,12 +257,13 @@ sub Configure($$@) {
 
       foreach my $map (keys(%mount_points)) {
         my $map_attrs = $master_entry_attrs{$map};
+        my $map_type_prefix = $map_attrs->{type} eq 'direct' ? '' : $map_attrs->{type}.':';
         foreach my $mountp ( @{$mount_points{$map}} ) {
           $self->debug(2,"Checking entry for mount point $mountp (map $map)...");
           $cnt += $self->updateMap($master_contents_ref,
                                    '^#?\s*('.$error_prefix.'\s*)?'.$mountp.'\s+.*',
-                                   '^'.$map_attrs->{prefix}.$mountp.'\s+'.$map_attrs->{type}.':'.$map.'\s+'.$map_attrs->{options}.'\s*$',
-                                   $map_attrs->{prefix}."$mountp\t".$map_attrs->{type}.":$map\t".$map_attrs->{options},
+                                   '^'.$map_attrs->{prefix}.$mountp.'\s+'.$map_type_prefix.$map.'\s+'.$map_attrs->{options}.'\s*$',
+                                   $map_attrs->{prefix}."$mountp\t".$map_type_prefix."$map\t".$map_attrs->{options},
                                   );
         }
       }
@@ -274,8 +275,9 @@ sub Configure($$@) {
       foreach my $map (keys(%mount_points)) {
         my $map_attrs = $master_entry_attrs{$map};
         foreach my $mountp ( @{$mount_points{$map}} ) {
+          my $map_type_prefix = $map_attrs->{type} eq 'direct' ? '' : $map_attrs->{type}.':';
           $master_contents .= $map_attrs->{prefix}.
-                                       "$mountp\t".$map_attrs->{type}.":$map\t".$map_attrs->{options}."\n";
+                                       "$mountp\t".$map_type_prefix."$map\t".$map_attrs->{options}."\n";
         }
       }
       $cnt += LC::Check::file("/etc/auto.master",

--- a/ncm-autofs/src/main/perl/autofs.pm
+++ b/ncm-autofs/src/main/perl/autofs.pm
@@ -263,7 +263,7 @@ sub Configure($$@) {
           $cnt += $self->updateMap($master_contents_ref,
                                    '^#?\s*('.$error_prefix.'\s*)?'.$mountp.'\s+.*',
                                    '^'.$map_attrs->{prefix}.$mountp.'\s+'.$map_type_prefix.$map.'\s+'.$map_attrs->{options}.'\s*$',
-                                   $map_attrs->{prefix}."$mountp\t".$map_type_prefix."$map\t".$map_attrs->{options},
+                                   $map_attrs->{prefix}."$mountp\t$map_type_prefix$map\t".$map_attrs->{options},
                                   );
         }
       }
@@ -277,7 +277,7 @@ sub Configure($$@) {
         foreach my $mountp ( @{$mount_points{$map}} ) {
           my $map_type_prefix = $map_attrs->{type} eq 'direct' ? '' : $map_attrs->{type}.':';
           $master_contents .= $map_attrs->{prefix}.
-                                       "$mountp\t".$map_type_prefix."$map\t".$map_attrs->{options}."\n";
+                                       "$mountp\t$map_type_prefix$map\t".$map_attrs->{options}."\n";
         }
       }
       $cnt += LC::Check::file("/etc/auto.master",


### PR DESCRIPTION
Slight modification to add the direct mount support.

Fixes #335 

This fix works with the following pan example:
```
include {'features/nfs/client/autofs'};
include {'components/autofs/config'};

variable USER_ENTRIES = {
    tbl = nlist(escape("/MY_MOUNTPOINT"),nlist("location","MY_SERVER:/MY_EXPORT","options",""));
};

"/software/components/autofs/maps/MY_MOUNTPOINT" = nlist(
    "enabled",true,
    "mapname","/etc/auto.direct",
    "mountpoint","/-",
    "options","-rw",
    "type","direct",
    "entries", USER_ENTRIES
);
```

Credit @StephaneGerardVUB