### PR TITLE
ncm-ceph: Add `straw2` as possible bucket algorithm

### DIFF
--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -245,7 +245,7 @@ type ceph_radosgwh = {
     arg = bucket algoritm
 }
 function is_ceph_crushmap_bucket_alg = {
-    if (!match(ARGV[0], '^(uniform|list|tree|straw)$')){
+    if (!match(ARGV[0], '^(uniform|list|tree|straw|straw2)$')){
         error(ARGV[0] +  'is not a valid bucket algorithm');
         return(false);
     };

--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -245,7 +245,7 @@ type ceph_radosgwh = {
     arg = bucket algoritm
 }
 function is_ceph_crushmap_bucket_alg = {
-    if (!match(ARGV[0], '^(uniform|list|tree|straw|straw2)$')){
+    if (!match(ARGV[0], '^(uniform|list|tree|straw2?)$')){
         error(ARGV[0] +  'is not a valid bucket algorithm');
         return(false);
     };


### PR DESCRIPTION
The original implementation of the `straw` algorithm is flawed as Sage Weil describes [here](http://comments.gmane.org/gmane.comp.file-systems.ceph.devel/22317)
With the release of Hammer, `straw2` is now available which fixes what was wrong with the old algorithm.
There is no reason for any new Ceph cluster running Hammer to use straw.
Ideally, straw2 would be automatically chosen as the default algorithm for a cluster running Hammer or later.