### PR TITLE
ncm-metaconfig: deprecate daemon property

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/bacula/pan/fd.pan
+++ b/ncm-metaconfig/src/main/metaconfig/bacula/pan/fd.pan
@@ -5,7 +5,7 @@ include 'metaconfig/bacula/schema';
 bind "/software/components/metaconfig/services/{/etc/bacula/bacula-fd.conf}/contents" = bacula_config;
 
 prefix "/software/components/metaconfig/services/{/etc/bacula/bacula-fd.conf}";
-"daemon/0" = "bacula-fd";
+"daemons/bacula-fd" = "restart";
 "module" = "bacula/main";
 "mode" = 0640;
 

--- a/ncm-metaconfig/src/main/metaconfig/bacula/pan/sd.pan
+++ b/ncm-metaconfig/src/main/metaconfig/bacula/pan/sd.pan
@@ -5,7 +5,7 @@ include 'metaconfig/bacula/schema';
 bind "/software/components/metaconfig/services/{/etc/bacula/bacula-sd.conf}/contents" = bacula_config;
 
 prefix "/software/components/metaconfig/services/{/etc/bacula/bacula-sd.conf}";
-"daemon/0" = "bacula-sd";
+"daemons/bacula-sd" = "restart";
 "module" = "bacula/main";
 "mode" = 0640;
 

--- a/ncm-metaconfig/src/main/metaconfig/collectl/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/collectl/pan/config.pan
@@ -5,7 +5,7 @@ include 'metaconfig/collectl/schema';
 bind "/software/components/metaconfig/services/{/etc/collectl.conf}/contents" = collectl_config;
 
 prefix "/software/components/metaconfig/services/{/etc/collectl.conf}";
-"daemon" = list("collectl");
+"daemons/collectl" = "restart";
 "module" = "collectl/main";
 
 prefix "/software/components/metaconfig/services/{/etc/collectl.conf}/contents/main";

--- a/ncm-metaconfig/src/main/metaconfig/ctdb/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ctdb/pan/config.pan
@@ -5,5 +5,5 @@ include 'metaconfig/ctdb/schema';
 bind "/software/components/metaconfig/services/{/etc/sysconfig/ctdb}/contents/service" = ctdb_service;
 
 prefix "/software/components/metaconfig/services/{/etc/sysconfig/ctdb}";
-"daemon/0" = "ctdb";
+"daemons/ctdb" = "restart";
 "module" = "ctdb/sysconfig";

--- a/ncm-metaconfig/src/main/metaconfig/ctdb/pan/nodes.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ctdb/pan/nodes.pan
@@ -5,5 +5,5 @@ include 'metaconfig/ctdb/schema';
 bind "/software/components/metaconfig/services/{/etc/ctdb/nodes}/contents/nodelist" = ctdb_nodes;
 
 prefix "/software/components/metaconfig/services/{/etc/ctdb/nodes}";
-"daemon/0" = "ctdb";
+"daemons/ctdb" = "restart";
 "module" = "ctdb/list";

--- a/ncm-metaconfig/src/main/metaconfig/ctdb/pan/public_addresses.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ctdb/pan/public_addresses.pan
@@ -5,5 +5,5 @@ include 'metaconfig/ctdb/schema';
 bind "/software/components/metaconfig/services/{/etc/ctdb/public_addresses}/contents/addresses" = ctdb_public_addresses;
 
 prefix "/software/components/metaconfig/services/{/etc/ctdb/public_addresses}";
-"daemon/0" = "ctdb";
+"daemons/ctdb" = "restart";
 "module" = "ctdb/publicaddress";

--- a/ncm-metaconfig/src/main/metaconfig/devicemapper/pan/multipath.pan
+++ b/ncm-metaconfig/src/main/metaconfig/devicemapper/pan/multipath.pan
@@ -5,6 +5,6 @@ include 'metaconfig/devicemapper/schema';
 bind "/software/components/metaconfig/services/{/etc/multipath.conf}/contents" = multipath_config;
 
 prefix "/software/components/metaconfig/services/{/etc/multipath.conf}";
-"daemon/0" = "multipathd";
+"daemons/multipathd" = "restart";
 "module" = "devicemapper/multipath";
 

--- a/ncm-metaconfig/src/main/metaconfig/django/pan/graphite-web.pan
+++ b/ncm-metaconfig/src/main/metaconfig/django/pan/graphite-web.pan
@@ -5,5 +5,5 @@ include 'metaconfig/django/schema';
 bind "/software/components/metaconfig/services/{/opt/graphite/webapp/graphite/local_settings.py}/contents" = django_main;
 
 prefix "/software/components/metaconfig/services/{/opt/graphite/webapp/graphite/local_settings.py}";
-"daemon/0" = "httpd";
+"daemons/httpd" = "restart";
 "module" = "django/main";

--- a/ncm-metaconfig/src/main/metaconfig/ganesha/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ganesha/pan/config.pan
@@ -9,7 +9,7 @@ include 'metaconfig/ganesha/schema';
 bind "/software/components/metaconfig/services/{/etc/ganesha/ganesha.nfsd.conf}/contents" = ganesha_config;
 
 prefix "/software/components/metaconfig/services/{/etc/ganesha/ganesha.nfsd.conf}";
-"daemon" = {if (CTDB_MANAGES_GANESHA) { null } else { list(GANESHA_SERVICE) }};
+"daemons" = {if (CTDB_MANAGES_GANESHA) { null } else { dict(GANESHA_SERVICE, "restart") }};
 "module" = "ganesha/main";
 
 prefix "/software/components/metaconfig/services/{/etc/ganesha/ganesha.nfsd.conf}/contents/main";

--- a/ncm-metaconfig/src/main/metaconfig/graphite/pan/relay.pan
+++ b/ncm-metaconfig/src/main/metaconfig/graphite/pan/relay.pan
@@ -5,7 +5,7 @@ include 'metaconfig/graphite/schema';
 bind "/software/components/metaconfig/services/{/etc/carbon/relay-rules.conf}/contents" = carbon_relay_relay_rules;
 
 prefix "/software/components/metaconfig/services/{/etc/carbon/relay-rules.conf}";
-"daemon/0" = "carbon-relay";
+"daemons/carbon-relay" = "restart";
 "module" = "graphite/relay-rules";
 "mode" = 0644;
 

--- a/ncm-metaconfig/src/main/metaconfig/httpd/pan/httpd_conf.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/pan/httpd_conf.pan
@@ -6,5 +6,5 @@ bind "/software/components/metaconfig/services/{/etc/httpd/conf/httpd.conf}/cont
 
 prefix "/software/components/metaconfig/services/{/etc/httpd/conf/httpd.conf}";
 "module" = "httpd/httpd_conf";
-"daemon/0" = "httpd";
+"daemons/httpd" = "restart";
 

--- a/ncm-metaconfig/src/main/metaconfig/httpd/tests/profiles/graphite-web.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/tests/profiles/graphite-web.pan
@@ -6,7 +6,7 @@ bind "/software/components/metaconfig/services/{/etc/httpd/conf.d/graphite-web.c
 
 prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/graphite-web.conf}";
 "module" = "httpd/generic_server";
-"daemon/0" = "httpd";
+"daemons/httpd" = "restart";
 
 variable HTTPD_OS_FLAVOUR ?= 'el6';
 variable FULL_HOSTNAME = 'myhost.domain';

--- a/ncm-metaconfig/src/main/metaconfig/httpd/tests/profiles/php_conf.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/tests/profiles/php_conf.pan
@@ -6,6 +6,6 @@ bind "/software/components/metaconfig/services/{/etc/httpd/conf.d/php.conf}/cont
 
 prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/php.conf}";
 "module" = "httpd/generic_server";
-"daemon/0" = "httpd";
+"daemons/httpd" = "restart";
 
 "/software/components/metaconfig/services/{/etc/httpd/conf.d/php.conf}/contents" = create('struct/php_conf');

--- a/ncm-metaconfig/src/main/metaconfig/httpd/tests/profiles/wsgi_conf.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/tests/profiles/wsgi_conf.pan
@@ -6,7 +6,7 @@ bind "/software/components/metaconfig/services/{/etc/httpd/conf.d/wsgi.conf}/con
 
 prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/wsgi.conf}";
 "module" = "httpd/generic_server";
-"daemon/0" = "httpd";
+"daemons/httpd" = "restart";
 
 variable FULL_HOSTNAME = 'myhost.domain';
 variable HOSTNAME = 'myhost';

--- a/ncm-metaconfig/src/main/metaconfig/kerberos/pan/kdc_conf.pan
+++ b/ncm-metaconfig/src/main/metaconfig/kerberos/pan/kdc_conf.pan
@@ -8,7 +8,7 @@ prefix "/software/components/metaconfig/services/{/var/kerberos/krb5kdc/kdc.conf
 
 "mode" = 0600;
 "module" = "kerberos/kdc/config";
-"daemon/0" = "krb5kdc";
+"daemons/krb5kdc" = "restart";
 
 "contents/defaults" = nlist();
 

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/config.pan
@@ -7,7 +7,7 @@ bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.co
 variable METACONFIG_LOGSTASH_VERSION ?= '1.2';
 
 prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}";
-"daemon/0" = "logstash";
+"daemons/logstash" = "restart";
 "owner" = "root";
 "group" = "root";
 "mode" = 0644;

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder.pan
@@ -5,7 +5,7 @@ include 'metaconfig/logstash/schema';
 bind "/software/components/metaconfig/services/{/etc/logstash-forwarder}/contents" = type_logstash_forwarder;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder}";
-"daemon/0" = "logstash-forwarder";
+"daemons/logstash-forwarder" = "restart";
 "owner" = "root";
 "group" = "root";
 "mode" = 0640;

--- a/ncm-metaconfig/src/main/metaconfig/named/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/named/pan/config.pan
@@ -9,5 +9,5 @@ prefix  "/software/components/metaconfig/services/{/etc/named.conf}";
 "owner" = "root";
 "group" = "named";
 "module" = "named/named";
-"daemon/0" = "named";
+"daemons/named" = "restart";
 

--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/config.pan
@@ -8,7 +8,7 @@ prefix "/software/components/metaconfig/services/{/etc/nginx/nginx.conf}";
 "mode" = 0644;
 "owner" = "root";
 "group" = "root";
-"daemon/0" = "nginx";
+"daemons/nginx" = "restart";
 "module" = "nginx/nginx";
 
 prefix "/software/components/metaconfig/services/{/etc/nginx/nginx.conf}/contents";

--- a/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/buoy/daemon/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/buoy/daemon/config.pan
@@ -6,7 +6,7 @@ bind "/software/components/metaconfig/services/{/opt/perfsonar_ps/perfsonarbuoy_
 
 prefix "/software/components/metaconfig/services/{/opt/perfsonar_ps/perfsonarbuoy_ma/etc/daemon.conf}";
 
-"daemon/0" = "perfsonarbuoy_ma";
+"daemons/perfsonarbuoy_ma" = "restart";
 "owner" = "root";
 "group" = "root";
 "module" = "perfsonar/ma";

--- a/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/buoy/mesh.pan
+++ b/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/buoy/mesh.pan
@@ -6,9 +6,9 @@ bind "/software/components/metaconfig/services/{/opt/perfsonar_ps/perfsonarbuoy_
 
 prefix "/software/components/metaconfig/services/{/opt/perfsonar_ps/perfsonarbuoy_ma/etc/owmesh.conf}";
 "module" = "perfsonar/owmesh";
-"daemon" = list(
-    "perfsonarbuoy_bw_master", 
-    "perfsonarbuoy_bw_collector",
-    "perfsonarbuoy_owp_master", 
-    "perfsonarbuoy_owp_collector"
-    );
+"daemons" = dict(
+    "perfsonarbuoy_bw_master", "restart",
+    "perfsonarbuoy_bw_collector", "restart",
+    "perfsonarbuoy_owp_master", "restart",
+    "perfsonarbuoy_owp_collector", "restart",
+);

--- a/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/bwctl/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/bwctl/config.pan
@@ -16,7 +16,7 @@ prefix "/software/components/metaconfig/services/{/etc/bwctld/bwctld.conf}";
 "owner" = "root";
 "group" = "root";
 "module" = "general";
-"daemon/0" = "bwctld";
+"daemons/bwctld" = "restart";
 
 prefix "/software/components/metaconfig/services/{/var/lib/bwctl/.bwctlrc}";
 "module" = "general";
@@ -30,11 +30,11 @@ prefix "/software/components/metaconfig/services/{/var/lib/bwctl/.bwctlrc}";
     l = value("/software/components/metaconfig/services/{/var/lib/bwctl/.bwctlrc}");
     l["owner"] = "perfsonar";
     l["group"] = "perfsonar";
-    l["daemon"] = list("perfsonarbuoy_bw_master");
+    l["daemons"] = dict("perfsonarbuoy_bw_master", "restart");
     l;
 };
 
 prefix "/software/components/metaconfig/services/{/etc/bwctld/bwctld.limits}";
 "module" = "perfsonar/bwctl-limits";
-"daemon/0" = "bwctld";
+"daemons/bwctld" = "restart";
 

--- a/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/lookup/daemon/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/lookup/daemon/config.pan
@@ -9,5 +9,5 @@ prefix "/software/components/metaconfig/services/{/opt/perfsonar_ps/lookup_servi
 "module" = "perfsonar/lookup_service";
 "owner" = "root";
 "group" = "root";
-"daemon/0" = "lookup_service";
+"daemons/lookup_service" = "restart";
 "backup" = ".old";

--- a/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/lookup/registration/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/perfsonar/pan/lookup/registration/config.pan
@@ -9,4 +9,4 @@ prefix "/software/components/metaconfig/services/{/opt/perfsonar_ps/ls_registrat
 "module" = "general";
 "owner" = "root";
 "group" = "root";
-"daemon/0" = "ls_registration_daemon";
+"daemons/ls_registration_daemon" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/perfsonar/tests/profiles/bwctl.pan
+++ b/ncm-metaconfig/src/main/metaconfig/perfsonar/tests/profiles/bwctl.pan
@@ -20,7 +20,7 @@ prefix "/software/components/metaconfig/services/{/var/lib/bwctl/.bwctlrc}/conte
     l = value("/software/components/metaconfig/services/{/var/lib/bwctl/.bwctlrc}");
     l["owner"] = "perfsonar";
     l["group"] = "perfsonar";
-    l["daemon"] = list("perfsonarbuoy_bw_master");
+    l["daemons"] = dict("perfsonarbuoy_bw_master", "restart");
     l;
 };
 

--- a/ncm-metaconfig/src/main/metaconfig/rpcidmapd/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/rpcidmapd/pan/config.pan
@@ -5,6 +5,6 @@ include 'metaconfig/rpcidmapd/schema';
 bind "/software/components/metaconfig/services/{/etc/idmapd.conf}/contents" = rpcidmapd_config;
 
 prefix "/software/components/metaconfig/services/{/etc/idmapd.conf}";
-"daemon/0" = "rpcidmapd";
+"daemons/rpcidmapd" = "restart";
 "module" = "rpcidmapd/main";
 

--- a/ncm-metaconfig/src/main/metaconfig/snmp/pan/snmpd.pan
+++ b/ncm-metaconfig/src/main/metaconfig/snmp/pan/snmpd.pan
@@ -9,4 +9,4 @@ prefix "/software/components/metaconfig/services/{/etc/snmp/snmpd.conf}";
 "group" = "root";
 "module" = "snmp/snmpd";
 "mode" = 0644;
-"daemon" = list('snmpd');
+"daemons/snmpd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/snmp/pan/snmptrapd.pan
+++ b/ncm-metaconfig/src/main/metaconfig/snmp/pan/snmptrapd.pan
@@ -9,4 +9,4 @@ prefix "/software/components/metaconfig/services/{/etc/snmp/snmptrapd.conf}";
 "group" = "root";
 "module" = "snmp/snmptrapd";
 "mode" = 0644;
-"daemon" = list('snmptrapd');
+"daemons/snmptrapd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/pan/metaconfig.pan
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/pan/metaconfig.pan
@@ -4,4 +4,4 @@ structure template metaconfig/xinetd/metaconfig;
 "group" = "root";
 "module" = "xinetd/main";
 "mode" = 0644;
-"daemon" = list('xinetd');
+"daemons/xinetd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/config.pan
@@ -5,6 +5,6 @@ include 'metaconfig/zookeeper/schema';
 bind "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}/contents" = zookeeper_server_config;
 
 prefix "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}";
-"daemon/0" = "zookeeper-server";
+"daemons/zookeeper-server" = "restart";
 "module" = "zookeeper/server";
 "mode" = 0644;

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/base
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/base
@@ -1,4 +1,4 @@
-Base test for zookeepr main server config
+Base test for zookeeper main server config
 ---
 multiline
 metaconfigservice=/etc/zookeeper/conf/zoo.cfg

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/values
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/values
@@ -1,4 +1,4 @@
-Values test for zookeepr main server config
+Values test for zookeeper main server config
 ---
 multiline
 metaconfigservice=/etc/zookeeper/conf/zoo.cfg

--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -15,7 +15,7 @@ type ${project.artifactId}_config =  {
      'mode' : long = 0644
      'owner' : string = 'root'
      'group' : string = 'root'
-     'daemon' ? string[]
+     'daemon' ? string[] with deprecated(0, "daemon property has been deprecated, daemons should be used instead")
      'daemons' ? caf_service_action{}
      'module' : string
      'backup' ? string

--- a/ncm-metaconfig/src/main/perl/metaconfig.pod
+++ b/ncm-metaconfig/src/main/perl/metaconfig.pod
@@ -55,15 +55,6 @@ for the daemon will be taken at most once.
 If multiple actions are to be taken for the same daemon, all actions
 will be taken (no attempt to optimize is made).
 
-=item * daemon ? string[]
-
-[Deprecated in favour of daemons]
-
-List of daemons to restart if the file changes.
-
-Even if multiple C<services> are associated to the same daemon, the
-daemon will be restarted at most once.
-
 =item * preamble ? string
 
 Text to place at start of file.
@@ -199,8 +190,8 @@ We'll define the permissions, who renders it and which daemons are associated to
     "owner" = "root";
     "group" = "root";
     "module" = "tiny";
-    "daemon/0" = "foo";
-    "daemon/1" = "bar";
+    "daemons/foo" = "restart";
+    "daemons/bar" = "reload";
 
 And we'll ensure the module that renders it is installed (Yum-based
 syntax here):

--- a/ncm-metaconfig/src/test/perl/error.t
+++ b/ncm-metaconfig/src/test/perl/error.t
@@ -31,7 +31,7 @@ my $cfg = {
 				a => [0..3]
 				}
 			},
-	   daemon => ['httpd'],
+	   daemons => {'httpd' => 'restart'},
 	   module => "ljhljhljhlujuih908yp08y",
 	  };
 

--- a/ncm-metaconfig/src/test/perl/json.t
+++ b/ncm-metaconfig/src/test/perl/json.t
@@ -34,7 +34,7 @@ my $cfg = {
 				a => [0..3]
 				}
 			},
-	   daemon => ['httpd'],
+	   daemons => {'httpd' => 'restart'},
 	   module => "json",
 	  };
 

--- a/ncm-metaconfig/src/test/resources/simple.pan
+++ b/ncm-metaconfig/src/test/resources/simple.pan
@@ -6,5 +6,5 @@ prefix "/software/components/metaconfig/services/{/foo/bar}";
 "owner" = 'root';
 "group" = 'root';
 "module" = "json";
-"daemon/0" = "foo";
+"daemons/foo" = "restart";
 "contents" = nlist("foo", "bar");


### PR DESCRIPTION
The `daemon` structure has been replaced with `daemons`, this deprecates it by generating a deprecation warning if it is used.

This is essentially a nicer version of #456 for this release to provide a better route to removal.

Fixes #457.