### PR TITLE
ncm-ceph: fix test_host_connection tries to access homeDir from wrong place

### DIFF
--- a/ncm-ceph/src/main/perl/Ceph/commands.pm
+++ b/ncm-ceph/src/main/perl/Ceph/commands.pm
@@ -177,7 +177,7 @@ sub ssh_known_keys {
 # check if host is reachable
 sub test_host_connection {
     my ($self, $host, $gvalues) = @_; 
-    $self->ssh_known_keys($host, $gvalues->{key_accept}, $gvalues->{homedir});
+    $self->ssh_known_keys($host, $gvalues->{key_accept}, $gvalues->{cephusr}->{homeDir});
     return $self->run_command_as_ceph_with_ssh(['uname'], $host); 
 }
 


### PR DESCRIPTION
`test_host_connection` is trying to access the `homeDir` variable under `$gvalues` when it's under `$gvalues->{cephusr}`.