### PR TITLE
ncm-mysql: Flush privileges after user and database operations

### DIFF
--- a/ncm-mysql/src/main/perl/mysql.pm
+++ b/ncm-mysql/src/main/perl/mysql.pm
@@ -247,6 +247,8 @@ sub Configure {
       }
     }
 
+    $self->flushPrivileges($server);
+
     # Mark the server as enabled
     $servers->{$server_name}->{enabled} = 1;
     
@@ -316,10 +318,26 @@ sub Configure {
       }
     }
 
+    $self->flushPrivileges($server);
+
   }
 
 
   return 0;
+}
+
+
+# Flush privileges on a given server.
+#
+# Arguments :
+#  server : hash describing MySQL server to use (see schema)
+sub flushPrivileges() {
+  my ($self, $server) = @_;
+  # Ensure privileges are applied
+  my $status = $self->mysqlExecCmd($server,"FLUSH PRIVILEGES");
+  if ( $status ) {
+    $self->warn("Error flushing privileges");
+  }
 }
 
 

--- a/ncm-mysql/src/main/perl/mysql.pm
+++ b/ncm-mysql/src/main/perl/mysql.pm
@@ -336,7 +336,7 @@ sub flushPrivileges() {
   # Ensure privileges are applied
   my $status = $self->mysqlExecCmd($server,"FLUSH PRIVILEGES");
   if ( $status ) {
-    $self->warn("Error flushing privileges");
+    $self->warn("Error flushing privileges on server $server->{host}");
   }
 }
 


### PR DESCRIPTION
Fixes #480.

Not tested on real systems.