### PR TITLE
ncm-metaconfig: service ganesha service change stat_exporter Access type

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/ganesha/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ganesha/pan/schema.pan
@@ -226,7 +226,7 @@ type ganesha_snmp_adm = {
 } = nlist();
 
 type ganesha_stat_exporter = {
-    "Access" : string = "localhost"
+    "Access" : string[] = list("localhost")
     "Port" : long = 10401
 } = nlist();
 


### PR DESCRIPTION
The Access attribute is assumed a comma separated list in the TT files (and auto-promotion from scalar to list with the CCM::TT::Scalar instances seems to fail with TT on EL5)

Fixes #499
