### PR TITLE
ncm-mysql: allow an empty password for a DB user

### DIFF
--- a/ncm-mysql/src/main/pan/components/mysql/schema.pan
+++ b/ncm-mysql/src/main/pan/components/mysql/schema.pan
@@ -34,10 +34,19 @@ function component_mysql_check_db_script = {
   };
 };
 
+# The function validating password imposes a non-empty string.
+function component_mysql_password_valid = {
+  if (  match(SELF, '^[^\\]+$') ) {
+    true;
+  } else {
+    false;
+  };
+};
+
 type component_mysql_user_right = string with match(SELF, '^(ALL( PRIVILEGES)?|ALTER( ROUTINE)?|CREATE( (ROUTINE|TEMPORARY TABLES|USER|VIEW))?|DELETE|DROP|EVENT|EXECUTE|FILE|GRANT OPTION|INDEX|INSERT|LOCK TABLES|PROCESS|REFERENCES|RELOAD|REPLICATION (CLIENT|SLAVE)|SELECT|SHOW (DATABASES|VIEW)|SHUTDOWN|SUPER|TRIGGER|UPDATE|USAGE)$');
 
 type component_mysql_db_user = {
-  'password'  : string with match(SELF, '^[^\\]+$')
+  'password'  : string with (length(SELF) == 0) || component_mysql_password_valid(SELF)
   'rights'    : component_mysql_user_right[] = list('SELECT')
   'shortPwd'  : boolean = false
 };
@@ -61,7 +70,7 @@ type component_mysql_db_options = {
 type component_mysql_server_options = {
   'host'      ? string
   'adminuser' : string
-  'adminpwd'  : string with length(SELF) > 0
+  'adminpwd'  : string with component_mysql_password_valid(SELF)
   'options'   ? string{}
   'users'     ? component_mysql_db_user{}
 };


### PR DESCRIPTION
Required for backward compatibily. If desirable to change this, it would be good to open a separate issue and discuss it as part of 15.6 release.

Also applies the same validation rules for admin password (empty password excluded)

Fixes #506