### PR TITLE
ncm-metaconfig: service logstash add support for filter kv

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/filter/bytes2human.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/filter/bytes2human.tt
@@ -1,0 +1,1 @@
+[%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="stringhash" names=['convert'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/filter/kv.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/filter/kv.tt
@@ -1,0 +1,2 @@
+[%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="string"
+        names=['prefix', 'source', 'target', 'trim', 'trimkey', 'value_split'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/filter/plugin.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/filter/plugin.tt
@@ -1,3 +1,4 @@
 [%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="boolean" names=['negate', 'drop'] -%]
-[%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="stringarray" names=['add_tag', 'remove_tag', 'remove_field'] -%]
-[%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="stringhash" names=['add_field'] -%]
+[%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="stringarray" names=['add_tag', 'remove_tag', 'remove_field', 
+    'exclude_keys', 'include_keys'] -%]
+[%- INCLUDE "metaconfig/logstash/1.2/type.tt" type="stringhash" names=['add_field', 'default_keys'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/server.pan
@@ -90,6 +90,12 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
         nlist("mutate", nlist(
             "remove_field", list("syslog_hostname", "syslog_message", "syslog_timestamp"),
             )),
+        nlist("bytes2human", nlist(
+            "convert", nlist(
+                "field1", "bytes",
+                "field2", "bytes",
+                ),
+            )),
     ),
 ));
 

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/server.pan
@@ -56,6 +56,20 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
                 "received_from", "%{@source_host}",
                 ),
             )),
+        nlist("kv", nlist(
+            "default_keys", nlist(
+                "key1", "value1", 
+                "key2", "value2",
+                ),
+            "exclude_keys", list("key1e", "key2e"),
+            "include_keys", list("key1i", "key2i"),
+            "prefix", "myprefix",
+            "source", "mysource",
+            "target", "mytarget",
+            "trim", "mytrim",
+            "trimkey", "mytrimkey",
+            "value_split", "myvaluesplit",
+            )),
         nlist("date", nlist(
             "match", nlist(
                 "name", "syslog_timestamp", 

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/server/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/server/base
@@ -41,6 +41,20 @@ filter \{$
 ^\s{16}"message" => "%\{RSYSLOGCUSTOM\}"$
 ^\s{12}}$
 ^\s{8}\}$
+^\s{8}kv \{$
+^\s{12}exclude_keys => \[ "key1e", "key2e" \]$
+^\s{12}include_keys => \[ "key1i", "key2i" \]$
+^\s{12}default_keys => \{$
+^\s{16}"key1" => "value1"$
+^\s{16}"key2" => "value2"$
+^\s{12}\}$
+^\s{12}prefix => "myprefix"$
+^\s{12}source => "mysource"$
+^\s{12}target => "mytarget"$
+^\s{12}trim => "mytrim"$
+^\s{12}trimkey => "mytrimkey"$
+^\s{12}value_split => "myvaluesplit"$
+^\s{8}\}$
 ^\s{8}date \{$
 ^\s{12}match => \[ "syslog_timestamp", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ", "yyyy-MM-dd'T'HH:mm:ssZZ" \]$
 ^\s{8}\}$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/server/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/server/base
@@ -68,6 +68,12 @@ filter \{$
 ^\s{8}mutate \{$
 ^\s{12}remove_field => \[ "syslog_hostname", "syslog_message", "syslog_timestamp" \]$
 ^\s{8}\}$
+^\s{8}bytes2human \{$
+^\s{12}convert => \{$
+^\s{16}"field1" => "bytes"$
+^\s{16}"field2" => "bytes"$
+^\s{12}\}$
+^\s{8}\}$
 ^\s{4}\}$
 output \{$
 ^\s{4}elasticsearch \{$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -157,11 +157,25 @@ type logstash_filter_mutate = {
     "exclude_tags" ? string[] # DEPRECATED, should be replaced by conditional block
 };
 
+type logstash_filter_kv = {
+    include logstash_filter_plugin_common
+    "default_keys" ? string{}
+    "exclude_keys" ? string[]
+    "include_keys" ? string[]
+    "prefix" ? string
+    "source" ? string
+    "target" ? string
+    "trim" ? string
+    "trimkey" ? string
+    "value_split" ? string
+};
+
 type logstash_filter_plugin = {
     "grok" ? logstash_filter_grok
     "date" ? logstash_filter_date
     "grep" ? logstash_filter_grep
     "mutate" ? logstash_filter_mutate
+    "kv" ? logstash_filter_kv
 } with length(SELF) == 1;
 
 @{ Common output }

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -137,6 +137,11 @@ type logstash_filter_grok = {
     "patterns_dir" ? string[]
 };
 
+type logstash_filter_bytes2human = {
+    include logstash_filter_plugin_common
+    "convert" : string{}
+};
+
 type logstash_filter_date = {
     include logstash_filter_plugin_common
     "match" : logstash_filter_name_patternlist
@@ -176,6 +181,7 @@ type logstash_filter_plugin = {
     "grep" ? logstash_filter_grep
     "mutate" ? logstash_filter_mutate
     "kv" ? logstash_filter_kv
+    "bytes2human" ? logstash_filter_bytes2human
 } with length(SELF) == 1;
 
 @{ Common output }


### PR DESCRIPTION
Add support for the `bytes2human` and `kv` filters.