### PR TITLE
ncm-spma: remove call to resolve_pkg_rep

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/repository_cleanup.pan
+++ b/ncm-spma/src/main/pan/components/spma/repository_cleanup.pan
@@ -9,18 +9,6 @@
 
 template  components/spma/repository_cleanup;
 
-# Resolve package versions for packages required by AII, if any.
-variable AII_OSINTALL_RPM_PKGS = value('/system/aii/osinstall/ks/base_packages');
-variable AII_OSINTALL_RPM_PKGS = {
-  if ( is_defined(AII_OSINSTALL_EXTRAPKGS) ) {
-    foreach (i;pkg;AII_OSINSTALL_EXTRAPKGS) {
-      SELF[length(SELF)] = pkg;
-    };
-  };
-  SELF;
-};
-"/software/packages" = resolve_pkg_rep(value("/software/repositories"),AII_OSINTALL_RPM_PKGS);
-
 # Remove contents attached to repository (useless after version resolution, not part of the schema)
 "/software/repositories" = purge_rep_list(value("/software/packages"));
 


### PR DESCRIPTION
- useless with YUM-based AII

Fixes a potential issue idendified during 15.4.0-rc4 (https://github.com/quattor/release/issues/96).