### PR TITLE
ncm-ceph: various additions

### DIFF
--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -12,28 +12,27 @@ include { 'quattor/schema' };
     arg = ceph_component type
 }
 function valid_osd_names = {
+    if(!exists(ARGV[0]['clusters'])) { return(true); };
     names = list();
-    if(exists(ARGV[0]['clusters'])) {
         
-        clusters = ARGV[0]['clusters'];
-        foreach (name;cluster;clusters) {
-            append(names, name);
-        };
+    clusters = ARGV[0]['clusters'];
+    foreach (name;cluster;clusters) {
+        append(names, name);
+    };
 
-        foreach (name;cluster;clusters) {
-            foreach (host;hvals;clusters[name]['osdhosts']) {
-                foreach (osd;osdvals;clusters[name]['osdhosts'][host]['osds']) {
-                    foreach (idex;clname;names) {
-                        if (match(osd,clname + '-\d+$')){
-                            error("Osd path: " + osd + " is a ceph-reserved path!"); 
-                            return(false);
-                        };
+    foreach (name;cluster;clusters) {
+        foreach (host;hvals;clusters[name]['osdhosts']) {
+            foreach (osd;osdvals;clusters[name]['osdhosts'][host]['osds']) {
+                foreach (idex;clname;names) {
+                    if (match(osd,clname + '-\d+$')){
+                        error("Osd path: " + osd + " is a ceph-reserved path!"); 
+                        return(false);
                     };
                 };
             };
         };
-   };
-   return(true);
+    };
+    return(true);
 };
 
 @documentation{ 

--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -326,6 +326,7 @@ type ${project.artifactId}_component = {
     'deploy_version'   ? string with match(SELF, '[0-9]+\.[0-9]+\.[0-9]+')
     'key_accept'       ? string with match(SELF, '^(first|always)$') # explicit accept host keys
     'ssh_multiplex'    : boolean = true
+    'max_add_osd_failures_per_host' : long(0..) = 0
 } with valid_osd_names(SELF);
 
 bind '/software/components/${project.artifactId}' = ${project.artifactId}_component;

--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -323,7 +323,7 @@ type ceph_cluster = {
 
 @documentation{
 Decentralized config feature:
-For use with dedicated pan code that builds the cluster info from remote templates..
+For use with dedicated pan code that builds the cluster info from remote templates.
 }
 type ceph_localdaemons = {
     'osds'  : ceph_osd {}
@@ -333,7 +333,7 @@ type ceph_localdaemons = {
 type ${project.artifactId}_component = {
     include structure_component
     'clusters'         ? ceph_cluster {}
-    'localdaemons'     ? ceph_localdaemons #validation, but not used in component code
+    'localdaemons'     ? ceph_localdaemons # validation, but not used in component code
     'ceph_version'     ? string with match(SELF, '[0-9]+\.[0-9]+(\.[0-9]+)?')
     'deploy_version'   ? string with match(SELF, '[0-9]+\.[0-9]+\.[0-9]+')
     'key_accept'       ? string with match(SELF, '^(first|always)$') # explicit accept host keys

--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -13,6 +13,11 @@ include { 'quattor/schema' };
 }
 function valid_osd_names = {
     names = list();
+    if(!exists(ARGV[0]['clusters'])) {
+        #check if deployhost?
+        return(true);
+    };
+        
     clusters = ARGV[0]['clusters'];
     foreach (name;cluster;clusters) {
         append(names, name);
@@ -318,10 +323,19 @@ type ceph_cluster = {
     'crushmap'                  ? ceph_crushmap
 };
 
+@documentation{
+Experimental feature:
+For use with dedicated pan code that builds the cluster info from remote templates..
+}
+type ceph_localdaemons = {
+    'osds'  : ceph_osd {}
+};
+
 @documentation{ ceph clusters }
 type ${project.artifactId}_component = {
     include structure_component
-    'clusters'         : ceph_cluster {}
+    'clusters'         ? ceph_cluster {}
+    'localdaemons'     ? ceph_localdaemons #validation, but not used in component code
     'ceph_version'     ? string with match(SELF, '[0-9]+\.[0-9]+(\.[0-9]+)?')
     'deploy_version'   ? string with match(SELF, '[0-9]+\.[0-9]+\.[0-9]+')
     'key_accept'       ? string with match(SELF, '^(first|always)$') # explicit accept host keys

--- a/ncm-ceph/src/main/pan/components/ceph/schema.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/schema.pan
@@ -13,28 +13,26 @@ include { 'quattor/schema' };
 }
 function valid_osd_names = {
     names = list();
-    if(!exists(ARGV[0]['clusters'])) {
-        #check if deployhost?
-        return(true);
-    };
+    if(exists(ARGV[0]['clusters'])) {
         
-    clusters = ARGV[0]['clusters'];
-    foreach (name;cluster;clusters) {
-        append(names, name);
-    };
+        clusters = ARGV[0]['clusters'];
+        foreach (name;cluster;clusters) {
+            append(names, name);
+        };
 
-    foreach (name;cluster;clusters) {
-        foreach (host;hvals;clusters[name]['osdhosts']) {
-            foreach (osd;osdvals;clusters[name]['osdhosts'][host]['osds']) {
-                foreach (idex;clname;names) {
-                    if (match(osd,clname + '-\d+$')){
-                        error("Osd path: " + osd + " is a ceph-reserved path!"); 
-                        return(false);
+        foreach (name;cluster;clusters) {
+            foreach (host;hvals;clusters[name]['osdhosts']) {
+                foreach (osd;osdvals;clusters[name]['osdhosts'][host]['osds']) {
+                    foreach (idex;clname;names) {
+                        if (match(osd,clname + '-\d+$')){
+                            error("Osd path: " + osd + " is a ceph-reserved path!"); 
+                            return(false);
+                        };
                     };
                 };
             };
         };
-    };
+   };
    return(true);
 };
 
@@ -324,7 +322,7 @@ type ceph_cluster = {
 };
 
 @documentation{
-Experimental feature:
+Decentralized config feature:
 For use with dedicated pan code that builds the cluster info from remote templates..
 }
 type ceph_localdaemons = {

--- a/ncm-ceph/src/main/perl/Ceph/commands.pm
+++ b/ncm-ceph/src/main/perl/Ceph/commands.pm
@@ -164,7 +164,7 @@ sub ssh_known_keys {
             my $fh = CAF::FileEditor->open("$homedir/.ssh/known_hosts",
                                            log => $self);
             $fh->head_print($key);
-            $fh->close()
+            $fh->close();
         }
     } elsif ($key_accept eq 'always'){
         # SSH into machine with -o StrictHostKeyChecking=no

--- a/ncm-ceph/src/main/perl/Ceph/commands.pm
+++ b/ncm-ceph/src/main/perl/Ceph/commands.pm
@@ -92,8 +92,8 @@ sub run_command {
 
 # run a command prefixed with ceph and return the output in json format
 sub run_ceph_command {
-    my ($self, $command) = @_;
-    return $self->run_command([qw(/usr/bin/ceph -f json --cluster), $self->{cluster}, @$command]);
+    my ($self, $command, $dry) = @_;
+    return $self->run_command([qw(/usr/bin/ceph -f json --cluster), $self->{cluster}, @$command], $dry // 0);
 }
 
 sub run_daemon_command {

--- a/ncm-ceph/src/main/perl/Ceph/compare.pm
+++ b/ncm-ceph/src/main/perl/Ceph/compare.pm
@@ -138,7 +138,15 @@ sub add_osd {
     $self->debug(3, "Configuring new osd $osdkey on $hostname");
     if (!$self->prep_osd($osd)) {
         $self->error("osd $osdkey on $hostname could not be prepared. Osd directory not empty?"); 
-        return 0;
+        if ($structures->{ok_osd_failures}){
+            $structures->{ok_osd_failures}--;
+            $osd->{crush_ignore} = 1;
+            $self->warn("Ignored one osd prep and deploy failure for $osdkey on $hostname.", 
+                "$structures->{ok_osd_failures} more failures accepted");
+            return 1;
+        } else {
+            return 0;
+        }
     }
     $structures->{deployd}->{$hostname}->{osds}->{$osdkey} = $osd;
     return 1;
@@ -299,6 +307,7 @@ sub compare_host {
         $self->error("Host $hostname is not reachable, and can't be configured at this moment");
         return 0; 
     } else {
+        $structures->{ok_osd_failures} = $structures->{gvalues}->{max_add_osd_failures_per_host};
         $self->compare_global($hostname, $quat_host->{config}, $ceph_host->{config}, $structures) or return 0;
         my @uniqs = qw(mon mds);
         foreach my $dtype (@uniqs) {
@@ -336,6 +345,7 @@ sub compare_host {
             }
         }
         $structures->{deployd}->{$hostname}->{fqdn} = $quat_host->{fqdn};
+        delete $structures->{ok_osd_failures};
     }
     return 1;
 }

--- a/ncm-ceph/src/main/perl/Ceph/compare.pm
+++ b/ncm-ceph/src/main/perl/Ceph/compare.pm
@@ -141,7 +141,7 @@ sub add_osd {
         if ($structures->{ok_osd_failures}){
             $structures->{ok_osd_failures}--;
             $osd->{crush_ignore} = 1;
-            $self->warn("Ignored one osd prep and deploy failure for $osdkey on $hostname.", 
+            $self->warn("Ignored one osd prep and deploy failure for $osdkey on $hostname. ", 
                 "$structures->{ok_osd_failures} more failures accepted");
             return 1;
         } else {
@@ -365,8 +365,8 @@ sub delete_host {
     
 # Compare per host - add, delete, modify 
 sub compare_conf {
-    my ($self, $quat_conf, $ceph_conf, $mapping, $gvalues) = @_;
-
+    my ($self, $quat_conf, $ceph_conf_orig, $mapping, $gvalues) = @_;
+    my $ceph_conf =  dclone($ceph_conf_orig) if defined($ceph_conf_orig);
     my $structures = {
         configs  => {},
         deployd  => {},

--- a/ncm-ceph/src/main/perl/Ceph/config.pm
+++ b/ncm-ceph/src/main/perl/Ceph/config.pm
@@ -119,11 +119,11 @@ sub config_hash {
                     $host->{config} = $cfg;    
                 } elsif ($name =~ m/^osd\.(\S+)/) {
                     my $loc = $mapping->{get_loc}->{$1};
-                    if (!$loc) {
-                        $self->error("Could not find location of $name on host $hostname");
-                        return ;
+                    if ($loc) {
+                        $host->{osds}->{$loc}->{config} = $cfg;
+                    } else {
+                        $self->warn("Could not find location of $name on host $hostname, removing from configfile");
                     }
-                    $host->{osds}->{$loc}->{config} = $cfg;
                 } elsif ($name =~ m{^mon(\.\S+)?}) { # Only one monitor per host..
                     $host->{mon}->{config} = $cfg;
                 } elsif ($name =~ m{^mds(\.\S+)?}) { # Only one mds per host..

--- a/ncm-ceph/src/main/perl/Ceph/config.pm
+++ b/ncm-ceph/src/main/perl/Ceph/config.pm
@@ -91,7 +91,7 @@ sub inject_realtime {
             my $keyvalue = "--$param=$changes->{$param}";
             #$self->info("injecting $keyvalue realtime on $host"); #FIXME this does not work anymore, see mailinglist
             my $inj = $self->run_ceph_command([@cmd, $keyvalue], 1);
-            $self->warn("$keyvalue need to be injected for all applicable daemons on $host:", $inj);
+            $self->warn("$keyvalue need to be injected for all applicable daemons on $host: ", $inj);
         } else {
             $self->warn("Non-injectable value $param changed");
         }

--- a/ncm-ceph/src/main/perl/Ceph/config.pm
+++ b/ncm-ceph/src/main/perl/Ceph/config.pm
@@ -89,7 +89,6 @@ sub inject_realtime {
         if (!($param ~~ @NONINJECT)) { # Requires Perl > 5.10 !
             @cmd = ('tell',"*.$host",'injectargs','--');
             my $keyvalue = "--$param=$changes->{$param}";
-            #$self->info("injecting $keyvalue realtime on $host"); # this does not work anymore, see mailinglist
             my $inj = $self->run_ceph_command([@cmd, $keyvalue], 1);
             $self->warn("global setting $keyvalue changed on host $host. Affected daemons should be restarted, ",
                 "or the setting needs to be injected: ", $inj);

--- a/ncm-ceph/src/main/perl/Ceph/config.pm
+++ b/ncm-ceph/src/main/perl/Ceph/config.pm
@@ -89,8 +89,9 @@ sub inject_realtime {
         if (!($param ~~ @NONINJECT)) { # Requires Perl > 5.10 !
             @cmd = ('tell',"*.$host",'injectargs','--');
             my $keyvalue = "--$param=$changes->{$param}";
-            $self->info("injecting $keyvalue realtime on $host");
-            $self->run_ceph_command([@cmd, $keyvalue]) or return 0;
+            #$self->info("injecting $keyvalue realtime on $host"); #FIXME this does not work anymore, see mailinglist
+            my $inj = $self->run_ceph_command([@cmd, $keyvalue], 1);
+            $self->warn("$keyvalue need to be injected for all applicable daemons on $host:", $inj);
         } else {
             $self->warn("Non-injectable value $param changed");
         }

--- a/ncm-ceph/src/main/perl/Ceph/config.pm
+++ b/ncm-ceph/src/main/perl/Ceph/config.pm
@@ -89,11 +89,12 @@ sub inject_realtime {
         if (!($param ~~ @NONINJECT)) { # Requires Perl > 5.10 !
             @cmd = ('tell',"*.$host",'injectargs','--');
             my $keyvalue = "--$param=$changes->{$param}";
-            #$self->info("injecting $keyvalue realtime on $host"); #FIXME this does not work anymore, see mailinglist
+            #$self->info("injecting $keyvalue realtime on $host"); # this does not work anymore, see mailinglist
             my $inj = $self->run_ceph_command([@cmd, $keyvalue], 1);
-            $self->warn("$keyvalue need to be injected for all applicable daemons on $host: ", $inj);
+            $self->warn("global setting $keyvalue changed on host $host. Affected daemons should be restarted, ",
+                "or the setting needs to be injected: ", $inj);
         } else {
-            $self->warn("Non-injectable value $param changed");
+            $self->warn("Non-injectable setting $param changed, affected daemons should be restarted");
         }
     }
     return 1;

--- a/ncm-ceph/src/main/perl/Ceph/crushmap.pm
+++ b/ncm-ceph/src/main/perl/Ceph/crushmap.pm
@@ -119,6 +119,10 @@ sub crush_merge {
                     my $osds = $osdhosts->{$name}->{osds};
                     $bucket->{buckets} = [];
                     foreach my $osd (sort(keys %{$osds})){ 
+                        if ($osds->{$osd}->{crush_ignore}){
+                            $self->warn("Osd $osd on $name was set to ignore");
+                            next;
+                        }
                         my $osdname = $self->get_name_from_mapping($gvalues->{mapping},
                             $name, $osds->{$osd}->{osd_path});
                         if (!$osdname) {

--- a/ncm-ceph/src/main/perl/Ceph/crushmap.pm
+++ b/ncm-ceph/src/main/perl/Ceph/crushmap.pm
@@ -168,12 +168,14 @@ sub labelize_bucket {
         $lhash{buckets} = [];
         foreach my $bucket (@{$tbucket->{buckets}}) {
             if (!$bucket->{labels} || ($label ~~ $bucket->{labels})) {
-                push(@{$lhash{buckets}}, $self->labelize_bucket($bucket, $label));
+                my $tmpb = $self->labelize_bucket($bucket, $label);
+                push(@{$lhash{buckets}}, $tmpb) if $tmpb;
             }        
         }
         if (!@{$lhash{buckets}}) {
             # check/eliminate empty buckets
-            $self->warn("Bucket $lhash{name} has no child buckets after labeling");
+            $self->warn("Bucket $lhash{name} has no child buckets after labeling, deleting bucket");
+            return;
         }
     }
     delete $lhash{labels}; # Not needed anymore

--- a/ncm-ceph/src/main/perl/Ceph/crushmap.pm
+++ b/ncm-ceph/src/main/perl/Ceph/crushmap.pm
@@ -120,7 +120,7 @@ sub crush_merge {
                     $bucket->{buckets} = [];
                     foreach my $osd (sort(keys %{$osds})){ 
                         if ($osds->{$osd}->{crush_ignore}){
-                            $self->warn("Osd $osd on $name was set to ignore");
+                            $self->warn("OSD $osd on $name was set to ignore");
                             next;
                         }
                         my $osdname = $self->get_name_from_mapping($gvalues->{mapping},

--- a/ncm-ceph/src/main/perl/Ceph/daemon.pm
+++ b/ncm-ceph/src/main/perl/Ceph/daemon.pm
@@ -208,7 +208,7 @@ sub check_empty {
             return 0;
         }
     } else {
-        my $checkmntcmd = ['/usr/bin/findmnt', $loc ];
+        my $checkmntcmd = ['/bin/findmnt', $loc ];
         if (!$self->run_command_as_ceph_with_ssh($checkmntcmd, $host)) {
             $self->error("OSD path is not a mounted file system on $host:$loc");
             return 0;

--- a/ncm-ceph/src/main/perl/Ceph/daemon.pm
+++ b/ncm-ceph/src/main/perl/Ceph/daemon.pm
@@ -208,6 +208,11 @@ sub check_empty {
             return 0;
         }
     } else {
+        my $checkmntcmd = ['usr/bin/findmnt', $loc ];
+        if (!$self->run_command_as_ceph_with_ssh($checkmntcmd, $host)) {
+            $self->error("OSD path is not a mounted file system on $host:$loc");
+            return 0;
+        } 
         my $mkdircmd = ['sudo', '/bin/mkdir', '-p', $loc];
         $self->run_command_as_ceph_with_ssh($mkdircmd, $host); 
         my $lscmd = [@LS_COMMAND, '-1', $loc];

--- a/ncm-ceph/src/main/perl/Ceph/daemon.pm
+++ b/ncm-ceph/src/main/perl/Ceph/daemon.pm
@@ -208,7 +208,7 @@ sub check_empty {
             return 0;
         }
     } else {
-        my $checkmntcmd = ['usr/bin/findmnt', $loc ];
+        my $checkmntcmd = ['/usr/bin/findmnt', $loc ];
         if (!$self->run_command_as_ceph_with_ssh($checkmntcmd, $host)) {
             $self->error("OSD path is not a mounted file system on $host:$loc");
             return 0;

--- a/ncm-ceph/src/main/perl/ceph.pm
+++ b/ncm-ceph/src/main/perl/ceph.pm
@@ -253,7 +253,7 @@ sub Configure {
             is_deploy => $is_deploy,
             cephusr => $cephusr,
             key_accept => $t->{key_accept}, 
-            max_add_osd_failures_per_host => $t->{max_add_osd_failures_per_host}
+            max_add_osd_failures_per_host => $t->{max_add_osd_failures_per_host},
         }; 
         if ($is_deploy) {
             $self->do_configure($cluster, $gvalues) or return 0;

--- a/ncm-ceph/src/main/perl/ceph.pm
+++ b/ncm-ceph/src/main/perl/ceph.pm
@@ -252,7 +252,8 @@ sub Configure {
             hostname => $hostname,
             is_deploy => $is_deploy,
             cephusr => $cephusr,
-            key_accept => $t->{key_accept} 
+            key_accept => $t->{key_accept}, 
+            max_add_osd_failures_per_host => $t->{max_add_osd_failures_per_host}
         }; 
         if ($is_deploy) {
             $self->do_configure($cluster, $gvalues) or return 0;

--- a/ncm-ceph/src/test/perl/30-compare1.t
+++ b/ncm-ceph/src/test/perl/30-compare1.t
@@ -27,10 +27,18 @@ $CAF::Object::NoAction = 1;
 my $cfg = get_config_for_profile('basic_cluster');
 my $cmp = NCM::Component::ceph->new('ceph');
 my $mockc = Test::MockModule->new('NCM::Component::Ceph::commands');
+my $mock = Test::MockModule->new('NCM::Component::Ceph::daemon');
 my $t = $cfg->getElement($cmp->prefix())->getTree();
 my $cluster = $t->{clusters}->{ceph};
 $cmp->use_cluster();
 $mockc->mock('test_host_connection', 0 );
 my $structures = $cmp->compare_conf(\%data::QUATIN, \%data::CEPHIN, \%data::MAPPING, {});
 cmp_deeply($structures, \%data::COMPARE1, 'Action hash ok');
+
+$mockc->mock('test_host_connection', 1 );
+$mock->mock('prep_mds', 0 );
+
+$structures = $cmp->compare_conf(\%data::QUATIN, \%data::CEPHIN, \%data::MAPPING, { max_add_osd_failures_per_host => 1 }); 
+cmp_deeply($structures, \%data::COMPARE2, 'Quattor config hash');
+
 done_testing();

--- a/ncm-ceph/src/test/perl/32-compare2.t
+++ b/ncm-ceph/src/test/perl/32-compare2.t
@@ -7,7 +7,7 @@
 
 =head1 DESCRIPTION
 
-Test the compare function and the build of the action hashes
+Test the add osd function with max_add_osd_failures_per_host = 1
 
 
 =cut
@@ -21,6 +21,7 @@ use Test::Quattor qw(basic_cluster);
 use NCM::Component::ceph;
 use CAF::Object;
 use data;
+use Storable qw(dclone);
 use Readonly;
 
 $CAF::Object::NoAction = 1;
@@ -31,9 +32,21 @@ my $mock = Test::MockModule->new('NCM::Component::Ceph::daemon');
 my $t = $cfg->getElement($cmp->prefix())->getTree();
 my $cluster = $t->{clusters}->{ceph};
 $cmp->use_cluster();
-$mockc->mock('test_host_connection', 1 );
-$mock->mock('prep_mds', 0 );
+$mockc->mock('test_host_connection', 0 );
 
-my $structures = $cmp->compare_conf(\%data::QUATIN, \%data::CEPHIN, \%data::MAPPING, {});
-cmp_deeply($structures, \%data::COMPARE2, 'Quattor config hash');
+my $quatin_l = dclone(\%data::QUATIN);
+my $structures = $cmp->compare_conf($quatin_l, \%data::CEPHIN, \%data::MAPPING, { max_add_osd_failures_per_host => 0 });
+ok($structures, "No (OSD) failures");
+ok($structures->{deployd}->{ceph002}->{osds}->{"ceph002:/var/lib/ceph/osd/sdc"}, "OSD is to be deployed");
+
+$mock->mock('prep_osd', 0 );
+$quatin_l = dclone(\%data::QUATIN);
+$structures = $cmp->compare_conf($quatin_l, \%data::CEPHIN, \%data::MAPPING, { max_add_osd_failures_per_host => 0 });
+ok(!$structures, "OSD failures not tolerated");
+
+$quatin_l = dclone(\%data::QUATIN);
+$structures = $cmp->compare_conf($quatin_l, \%data::CEPHIN, \%data::MAPPING, { max_add_osd_failures_per_host => 1 });
+ok($structures, "1 OSD failure per host tolerated");
+ok(!$structures->{deployd}->{ceph002}->{osds}->{"ceph002:/var/lib/ceph/osd/sdc"}, "OSD is not going to be deployed");
+is($quatin_l->{ceph002}->{osds}->{"ceph002:/var/lib/ceph/osd/sdc"}->{crush_ignore}, 1, "OSD is not included in crushmap");
 done_testing();

--- a/ncm-ceph/src/test/perl/53-crushmap-label.t
+++ b/ncm-ceph/src/test/perl/53-crushmap-label.t
@@ -33,13 +33,17 @@ if ($generate) {
     my $cfg = get_config_for_profile('labeled_crushmap');
     my $t = $cfg->getElement($cmp->prefix())->getTree();
     my $cluster = $t->{clusters}->{ceph};
+    my $mapping = {};
 
     my $crush = $cluster->{crushmap};
     while (my ($hostname, $host) = each(%{$cluster->{osdhosts}})) {
         $cmp->structure_osds($hostname, $host); # Is normally done in the daemon part
-}
+        while (my ($osdkey, $osd) = each(%{$host->{osds}})) {
+            $cmp->add_to_mapping($mapping, 'osd.0', $hostname, $osd->{osd_path});
+        }
+    }   
 
-    $cmp->crush_merge($crush->{buckets}, $cluster->{osdhosts}, []);
+    $cmp->crush_merge($crush->{buckets}, $cluster->{osdhosts}, [], { mapping => $mapping });
 
     diag explain $crush->{buckets};
 }

--- a/ncm-ceph/src/test/perl/crushdata.pm
+++ b/ncm-ceph/src/test/perl/crushdata.pm
@@ -285,7 +285,7 @@ Readonly::Array our @RELBBUCKETS => (
              },
              {
                'labels' => [
-                 'tst-1'
+                 'tst-0'
                ],
                'name' => 'osd.0',
                'type' => 'osd',
@@ -301,7 +301,7 @@ Readonly::Array our @RELBBUCKETS => (
              },
              {
                'labels' => [
-                 'tst-1'
+                 'tst-0'
                ],
                'name' => 'osd.0',
                'type' => 'osd',
@@ -317,7 +317,7 @@ Readonly::Array our @RELBBUCKETS => (
              },
              {
                'labels' => [
-                 'tst-1'
+                 'tst-0'
                ],
                'name' => 'osd.0',
                'type' => 'osd',
@@ -333,7 +333,7 @@ Readonly::Array our @RELBBUCKETS => (
              },
              {
                'labels' => [
-                 'tst-1'
+                 'tst-0'
                ],
                'name' => 'osd.0',
                'type' => 'osd',
@@ -349,7 +349,7 @@ Readonly::Array our @RELBBUCKETS => (
              },
              {
                'labels' => [
-                 'tst-1'
+                 'tst-0'
                ],
                'name' => 'osd.0',
                'type' => 'osd',
@@ -365,7 +365,7 @@ Readonly::Array our @RELBBUCKETS => (
              },
              {
                'labels' => [
-                 'tst-1'
+                 'tst-0'
                ],
                'name' => 'osd.0',
                'type' => 'osd',
@@ -501,6 +501,36 @@ Readonly::Array our @LBBUCKETS => (
              'name' => 'osd.0',
              'type' => 'osd',
              'weight' => '1'
+           },
+           {
+             'name' => 'osd.0',
+             'type' => 'osd',
+             'weight' => '1'
+           },
+           {
+             'name' => 'osd.0',
+             'type' => 'osd',
+             'weight' => '1'
+           },
+           {
+             'name' => 'osd.0',
+             'type' => 'osd',
+             'weight' => '1'
+           },
+           {
+             'name' => 'osd.0',
+             'type' => 'osd',
+             'weight' => '1'
+           },
+           {
+             'name' => 'osd.0',
+             'type' => 'osd',
+             'weight' => '1'
+           },
+           {
+             'name' => 'osd.0',
+             'type' => 'osd',
+             'weight' => '1'
            }
          ],
          'name' => 'ceph003-tst-0',
@@ -584,42 +614,6 @@ Readonly::Array our @LBBUCKETS => (
            }
          ],
          'name' => 'ceph002-tst-1',
-         'type' => 'host'
-       },
-       {
-         'buckets' => [
-           {
-             'name' => 'osd.0',
-             'type' => 'osd',
-             'weight' => '1'
-           },
-           {
-             'name' => 'osd.0',
-             'type' => 'osd',
-             'weight' => '1'
-           },
-           {
-             'name' => 'osd.0',
-             'type' => 'osd',
-             'weight' => '1'
-           },
-           {
-             'name' => 'osd.0',
-             'type' => 'osd',
-             'weight' => '1'
-           },
-           {
-             'name' => 'osd.0',
-             'type' => 'osd',
-             'weight' => '1'
-           },
-           {
-             'name' => 'osd.0',
-             'type' => 'osd',
-             'weight' => '1'
-           }
-         ],
-         'name' => 'ceph003-tst-1',
          'type' => 'host'
        }
      ],

--- a/ncm-ceph/src/test/perl/data.pm
+++ b/ncm-ceph/src/test/perl/data.pm
@@ -368,7 +368,7 @@ Readonly::Hash our %QUATMAP => (
      }
    }
 );
-Readonly::Hash our %QUATIN => (
+our %QUATIN = (
    'ceph001' => {
      'config' => {
        'fsid' => 'a94f9906-ff68-487d-8193-23ad04c1b5c4',
@@ -861,7 +861,7 @@ Readonly::Hash our %COMPARE2 => (
        }
      }
    },
-   'gvalues' => {},
+   'gvalues' => {max_add_osd_failures_per_host => 1},
    'skip' => {},
    'mapping' => {
      'get_id' => {

--- a/ncm-ceph/src/test/resources/basic_cluster.pan
+++ b/ncm-ceph/src/test/resources/basic_cluster.pan
@@ -63,6 +63,7 @@ prefix '/software/components/ceph/clusters';
 );         
 
 '/software/components/ceph/ssh_multiplex' = true;
+'/software/components/ceph/max_add_osd_failures_per_host' = 1;
 '/system/network/hostname' = 'ceph003';
 '/system/network/domainname' = 'cubone.os';
 

--- a/ncm-ceph/src/test/resources/labeled_crushmap.pan
+++ b/ncm-ceph/src/test/resources/labeled_crushmap.pan
@@ -109,6 +109,9 @@ prefix '/software/components/ceph/clusters/ceph';
         d = nlist();
         foreach(odx;disk;CEPH_OSD_DISKS) {
             jdx= odx % length(CEPH_JOURNAL_DISKS); ## RR over journal disks
+            if (host == 'ceph003') {
+                jdx=0; # Empty bucket tst-1 on ceph003
+            };
             d[disk] = nlist(
                 'journal_path', format('/var/lib/ceph/log/%s/osd-%s/journal', CEPH_JOURNAL_DISKS[jdx], disk),
                 'crush_weight', CEPH_DEFAULT_OSD_WEIGHT,


### PR DESCRIPTION
- add `max_add_osd_failures_per_host` option to be flexible with osd failures
- change schema to be able to use per host osd templates that are included on the deployhost.
- change injection to a warning: injecting on a host base does not work (anymore)
- remove empty crushmap buckets when labeling
