### PR TITLE
ncm-metaconfig: service logstash: change forwarder configfile location 

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/forwarder.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/forwarder.pan
@@ -2,7 +2,7 @@ object template forwarder;
 
 include 'metaconfig/logstash/forwarder';
 
-prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder}/contents";
+prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents";
 
 "network/servers/0" = nlist("host", "myhost", "port", 12345);
 "network/servers/1" = nlist("host", "myhost2", "port", 12346);

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/forwarder/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/forwarder/base
@@ -1,7 +1,7 @@
 Base test for forwarder
 ---
 multiline
-/etc/logstash-forwarder
+/etc/logstash-forwarder.conf
 ---
 ^\{$
 ^\s{4}"network": \{$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder.pan
@@ -2,9 +2,9 @@ unique template metaconfig/logstash/forwarder;
 
 include 'metaconfig/logstash/schema';
 
-bind "/software/components/metaconfig/services/{/etc/logstash-forwarder}/contents" = type_logstash_forwarder;
+bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_forwarder;
 
-prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder}";
+prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}";
 "daemons/logstash-forwarder" = "restart";
 "owner" = "root";
 "group" = "root";


### PR DESCRIPTION
With the first 0.4.0 rpm released by elastic, the default configfile used by the rpm is now in `/etc/logstash-forwarder.conf`