### PR TITLE
ncm-network: Add fqdn to interface_alias type

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -18,7 +18,7 @@ type structure_interface_alias = {
     "ip"      ? type_ip
     "netmask" : type_ip
     "broadcast" ? type_ip
-    "fqdn"    ? string
+    "fqdn"    ? type_fqdn
 };
 
 @documentation{

--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -18,6 +18,7 @@ type structure_interface_alias = {
     "ip"      ? type_ip
     "netmask" : type_ip
     "broadcast" ? type_ip
+    "fqdn"    ? string
 };
 
 @documentation{


### PR DESCRIPTION
This is inserted by aquilon for any aliases with hostnames.