### PR TITLE
ncm-network: Support all five systemd device naming schemes

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -214,7 +214,7 @@ sub Configure
     opendir(DIR, $dir_pref);
     # here's the reason why it only verifies eth, bond, bridge, usb and vlan
     # devices. add regexp at will
-    my $dev_regexp='-((eth|seth|em|bond|br|vlan|usb|ib|p\d+p|en(o|(p\d+)?s))\d+(\.\d+)?|enx[[:xdigit:]]{12})';
+    my $dev_regexp='-((eth|seth|em|bond|br|vlan|usb|ib|p\d+p|en(o|(p\d+)?s))\d+|enx[[:xdigit:]]{12})(\.\d+)?';
     # $1 is the device name
     foreach my $file (grep(/$dev_regexp/, readdir(DIR))) {
         my $msg;

--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -214,7 +214,7 @@ sub Configure
     opendir(DIR, $dir_pref);
     # here's the reason why it only verifies eth, bond, bridge, usb and vlan
     # devices. add regexp at will
-    my $dev_regexp='-((eth|seth|em|bond|br|vlan|usb|ib|p\d+p|eno)\d+(\.\d+)?)';
+    my $dev_regexp='-((eth|seth|em|bond|br|vlan|usb|ib|p\d+p|en(o|(p\d+)?s))\d+(\.\d+)?|enx[[:xdigit:]]{12})';
     # $1 is the device name
     foreach my $file (grep(/$dev_regexp/, readdir(DIR))) {
         my $msg;


### PR DESCRIPTION
As documented at:
  * http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
  * https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/ch-Consistent_Network_Device_Naming.html
  * http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-net_id.c#n20