### PR TITLE
ncm-download timeouts

### DIFF
--- a/ncm-download/src/main/pan/components/download/schema.pan
+++ b/ncm-download/src/main/pan/components/download/schema.pan
@@ -40,6 +40,7 @@ type component_download_file = {
     "capath"  ? string
     "cert" ? string
     "key" ? string
+    "timeout" ? long # seconds, overrides setting in component
 };
 
 type component_download_type = extensible {
@@ -48,6 +49,8 @@ type component_download_type = extensible {
     "proto"  ? string with match(SELF, "https?")
     "files"  ? component_download_file{}
     "proxyhosts" ? string[]
+    "head_timeout" ? long # seconds, timeout for HEAD requests which checks for changes
+    "timeout" ? long # seconds, total timeout for fetch of file, can be overridden per file
 };
 
 bind "/software/components/download" = component_download_type;

--- a/ncm-download/src/main/perl/download.pm
+++ b/ncm-download/src/main/perl/download.pm
@@ -121,6 +121,9 @@ sub Configure {
             $min_age = $inf->{files}->{$f}->{min_age};
         }
 
+	my $timeout = $inf->{files}->{$f}->{timeout};
+	$timeout = $inf->{timeout} unless defined($timeout);
+
         my $success = 0;
         if (@proxyhosts && $inf->{files}->{$f}->{proxy}) {
             my $attempts = scalar @proxyhosts;
@@ -133,7 +136,8 @@ sub Configure {
                 $success += $self->download(
                     file => $file,
                     href => $source,
-                    timeout => $inf->{timeout},
+                    timeout => $timeout,
+                    head_timeout => $inf->{head_timeout},
                     proxy => $proxy,
                     gssneg => $gss,
                     cacert => $inf->{files}->{$f}->{cacert},
@@ -216,7 +220,9 @@ sub get_head
     local $ENV{'HTTPS_CA_FILE'} = $opts{cacert} if (exists($opts{cacert}));
     local $ENV{'HTTPS_CA_DIR'} = $opts{capath} if (exists($opts{capath}));
 
-    return LWP::UserAgent->new->head($source);
+    my $lwp = LWP::UserAgent->new;
+    $lwp->timeout($opts{head_timeout}) if (defined($opts{head_timeout}));
+    return $lwp->head($source);
 }
 
 sub download {


### PR DESCRIPTION
We've been having problems with the ncm-download component taking a long time to timeout because there is no timeout set.

I found some code in sudo.pm which adds a timeout switch to the curl command (though it is not in the schema). However, there is no timeout on the LWP client which does the HEAD request before this.

So I've added a head_timeout parameter at the component level, with a default of 3 seconds set. The curl timeout has been added to schema.pan, and it is possible to override it per file.