### PR TITLE
ncm-sudo fixes

### DIFF
--- a/ncm-sudo/src/main/pan/components/sudo/schema.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/schema.pan
@@ -34,7 +34,7 @@ type structure_privilege_line = {
     "user"          : string        # "User invoking sudo"
     "run_as"        : string        # "User the program will run under"
     "host"          : string        # "host the command can be run from"
-    "options"       ? string        with match (SELF, "^(NOPASSWD:|PASSWD:|NOEXEC:|EXEC:|SETENV:|NOSETENV:|LOG_INPUT:|NOLOG_INPUT:|LOG_OUTPUT:|NOLOG_OUTPUT:)+$")
+    "options"       ? string        with match (SELF, "^((NOPASSWD|PASSWD|NOEXEC|EXEC|SETENV|NOSETENV|LOG_INPUT|NOLOG_INPUT|LOG_OUTPUT|NOLOG_OUTPUT):?)+$")
     # "Specific options for this command"
     "cmd"           : string        # "The command being run"
 };

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -355,3 +355,5 @@ sub Configure {
 
         return !$self->write_sudoers ($aliases, $opts, $lns, $incls, $incls_dirs);
 }
+
+1;

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -199,8 +199,11 @@ sub generate_privilege_lines {
         my $ln = $info{PRIVILEGE_USER()}->getValue;
         $ln .= "\t" . $info{PRIVILEGE_HOST()}->getValue;
         $ln .= "= (". $info{PRIVILEGE_RUNAS()}->getValue . ")\t";
-        $ln .= $info{PRIVILEGE_OPTS()}->getValue . "\t"
-        if defined $info{PRIVILEGE_OPTS()};
+	if (defined($info{PRIVILEGE_OPTS()})) {
+		$ln .= $info{PRIVILEGE_OPTS()}->getValue;
+		$ln .= ':' if $ln !~ /:$/;
+		$ln .= "\t";
+	}
         $ln .= $info{PRIVILEGE_CMD()}->getValue;
         push (@$lns, $ln);
     }


### PR DESCRIPTION
Hi,

One change is for ncm-sudo on Solaris, it fails because /proc/self/fd/0 is not a valid handle for stdin. Use a - instead on Solaris (this doesn't seem to work on a Linux tested).

Also, while trying to upgrade to the latest upstream, we are having a problem with the schema change in e79f799. The privilege options parameter was changed to require a colon at the end, which we do not have in our templates. It is difficult because it requires that we change the schema, templates and components all at once. So I propose this change which, I hope, will allow them to be changed independently. It does this by making the colon optional in the schema, and adding it in the code if it's not present.

Finally, a true (1) return was missing at the end of the package.