### PR TITLE
ncm-ceph: Only check ceph-deploy version on deployhost

### DIFF
--- a/ncm-ceph/src/main/perl/ceph.pm
+++ b/ncm-ceph/src/main/perl/ceph.pm
@@ -160,7 +160,7 @@ sub check_versions {
     my $cversion = $self->run_ceph_command([qw(--version)]);
     my @vl = split(' ',$cversion);
     my $cephv = $vl[2];
-    my ($stdout, $deplv) = $self->run_ceph_deploy_command([qw(--version)]);
+    my ($stdout, $deplv) = $self->run_ceph_deploy_command([qw(--version)]) if $qdeploy;
     if ($deplv) {
         chomp($deplv);
     }


### PR DESCRIPTION
Small fix. Otherwise will give error on non-deploy host where ceph-deploy is not installed (eg. when using localdaemons structure to configure ceph)