### PR TITLE
ncm-metaconfig: named: add newline after each include

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/named/named.tt
+++ b/ncm-metaconfig/src/main/metaconfig/named/named.tt
@@ -16,4 +16,4 @@ logging {
 
 [%- FOREACH i IN includes -%]
 include "[% i %]";
-[%- END %]
+[% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/named/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/named/tests/profiles/config.pan
@@ -9,6 +9,7 @@ prefix "/software/components/metaconfig/services/{/etc/named.conf}/contents";
     "file", "data/named.run");
 "logging/category" = nlist();
 "includes" = append("/etc/named.rfc1912.zones");
+"includes" = append("/etc/another.conf");
 
 "acls/clients" = list('127.0.0.1', '10.10.3.250', '10.10.10.250'); 
 "acls/vsc" = list("10.10.0.0/16", "10.20.0.0/16", "10.30.0.0/16");

--- a/ncm-metaconfig/src/main/metaconfig/named/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/named/tests/regexps/config/base
@@ -64,4 +64,5 @@ multiline
 ^zone "10.10.in-addr.arpa" IN \{\s{4}$
 ^\s{4}file "hpcugent/bar/10.10.rev";$
 ^include "/etc/named.rfc1912.zones";$
+^include "/etc/another.conf";$
 


### PR DESCRIPTION
Although multiple includes separated by `;` is valid, inserting a newline after each include makes it much more readable