### PR TITLE
ncm-ccm: change profile_failover from hostURI to hostURI[].

### DIFF
--- a/ncm-ccm/src/main/pan/components/ccm/schema.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/schema.pan
@@ -12,7 +12,7 @@ type component_ccm = {
     include structure_component
     'configFile'       : string = '/etc/ccm.conf'
     'profile'          : type_hostURI
-    'profile_failover' ? type_hostURI
+    'profile_failover' ? type_hostURI[]
     'context'          ? type_hostURI
     'debug'            : long(0..1) = 0
     'force'            : long(0..1) = 0

--- a/ncm-ccm/src/main/perl/ccm.pm
+++ b/ncm-ccm/src/main/perl/ccm.pm
@@ -52,7 +52,8 @@ sub Configure
     delete($t->{version});
 
     while (my ($k, $v) = each(%$t)) {
-        print $fh "$k $v\n";
+        my $value = ref($v) eq 'ARRAY' ? join(',', @$v) : $v;
+        print $fh "$k $value\n" if length($value);
     }
 
     if (_is_noquattor()) {


### PR DESCRIPTION
CCM will be supporting multiple failover URLs (comma seperated in the
config file) so this change will allow that to be configured by this
component. Code is backwards compatible with old schema.