### PR TITLE
ncm-authconfig: correct module regexp for pamadditions entry attribute

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -17,7 +17,7 @@ type yesnostring = string with match(SELF, "yes|no");
 
 type authconfig_pamadditions_line_type = {
   "order"       : string with match(SELF, '^(first|last)$')
-  "entry"       : string with match(SELF, '^\s*\w+\s+\S+\.so(\s|$)')
+  "entry"       : string with match(SELF, '^\s*(required|requisite|sufficient|optional|include|substack)\s+\S+\.so(\s|$)')
 };
 
 type authconfig_pamadditions_type = {

--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -17,7 +17,7 @@ type yesnostring = string with match(SELF, "yes|no");
 
 type authconfig_pamadditions_line_type = {
   "order"       : string with match(SELF, '^(first|last)$')
-  "entry"       : string with match(SELF, '\S+\.so$')
+  "entry"       : string with match(SELF, '^\s*\w+\s+\S+\.so(\s|$)')
 };
 
 type authconfig_pamadditions_type = {

--- a/ncm-authconfig/src/main/perl/authconfig.pm
+++ b/ncm-authconfig/src/main/perl/authconfig.pm
@@ -50,7 +50,7 @@ sub update_pam_file
         my @whence = $i->{order} eq 'first' ?
         	@begin_whence : ENDING_OF_FILE;
 
-        if ($i->{entry} =~ m{(\S+\.so)}) {
+        if ($i->{entry} =~ m{(?:^|\s+)(\S+\.so)(?:\s|$)}) {
             my $module = $1;
             $fh->add_or_replace_lines(qr{^#?\s*$tree->{section}\s+\S+\s+$module},
                                       qr{^$tree->{section}\s+$i->{entry}$},

--- a/ncm-authconfig/src/test/perl/update_pam.t
+++ b/ncm-authconfig/src/test/perl/update_pam.t
@@ -16,11 +16,13 @@ Test the update_pam_file method
 use strict;
 use warnings;
 use Test::More;
-use Test::Quattor;
+use Test::Quattor qw(pamadditions);
 use NCM::Component::authconfig;
 use Readonly;
 use Cwd;
+use CAF::Object;
 
+$CAF::Object::NoAction = 1;
 
 Readonly my $PAM_FILE => getcwd()."/target/tmp/file.pam";
 Readonly my $NEW_ENTRY => 'required pam_access.so accessfile=/tmp/acc.conf';
@@ -152,6 +154,21 @@ is($cmp->{ERROR}, 1, "1 error");
 
 unlike("$fh", qr{NO MODULE}, "entry skipped");
 
+=pod
+
+=test2 Sample from template
+
+Test the sample from the config instance
+
+=cut
+
+# succesfully compiled template verifies the schema
+my $cfg = get_config_for_profile("pamadditions");
+$cmp->build_pam_systemauth($cfg->getElement('/software/components/authconfig/pamadditions')->getTree());
+$fh = get_file("/etc/pam.d/sshd");
+is("$fh",
+   "account required      pam_access.so accessfile=/etc/security/access_sshd.conf\n",
+   "added line to (empty) pam sshd config");
+
 
 done_testing();
-

--- a/ncm-authconfig/src/test/resources/pamadditions.pan
+++ b/ncm-authconfig/src/test/resources/pamadditions.pan
@@ -1,0 +1,13 @@
+object template pamadditions;
+
+function pkg_repl = {return(null);};
+include 'components/authconfig/config';
+'/software/components/authconfig/dependencies/pre' = null; # remove it to avoid mocking spma
+
+prefix "/software/components/authconfig/pamadditions/system";
+"conffile" = "/etc/pam.d/sshd";
+"section" = "account";
+"lines" = append(nlist(
+    "order", "first",
+    "entry", "required      pam_access.so accessfile=/etc/security/access_sshd.conf",
+));


### PR DESCRIPTION
Fixes #529