### PR TITLE
ncm-ccm: add tabcompletion option

### DIFF
--- a/ncm-ccm/src/main/pan/components/ccm/config.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/config.pan
@@ -4,12 +4,15 @@
 # ${build-info}
 
 unique template components/${project.artifactId}/config;
+
 include 'components/${project.artifactId}/schema';
+
+bind '/software/components/ccm' = component_ccm;
 
 '/software/packages' = pkg_repl('ncm-${project.artifactId}','${no-snapshot-version}-${RELEASE}','noarch');
 
 prefix '/software/components/${project.artifactId}';
-'dependencies/pre' ?= list ('spma');
+'dependencies/pre' ?= list('spma');
 'active' ?= true;
 'dispatch' ?= true;
 'version' ?= '${no-snapshot-version}';

--- a/ncm-ccm/src/main/pan/components/ccm/schema.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/schema.pan
@@ -31,6 +31,7 @@ type component_ccm = {
     'base_url'         ? type_absoluteURI
     'dbformat'         ? string with match(SELF, "^(DB_File|CDB_File|GDBM_File)$")
     'json_typed'       ? boolean
+    'tabcompletion'    ? boolean
 };
 
 bind '/software/components/ccm' = component_ccm;

--- a/ncm-ccm/src/main/pan/components/ccm/schema.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/schema.pan
@@ -5,8 +5,8 @@
 
 declaration template components/ccm/schema;
 
-include {'quattor/schema'};
-include {'pan/types'};
+include 'quattor/types/component';
+include 'pan/types';
 
 type component_ccm = {
     include structure_component
@@ -33,5 +33,3 @@ type component_ccm = {
     'json_typed'       ? boolean
     'tabcompletion'    ? boolean
 };
-
-bind '/software/components/ccm' = component_ccm;

--- a/ncm-ccm/src/test/resources/base.pan
+++ b/ncm-ccm/src/test/resources/base.pan
@@ -1,7 +1,11 @@
 object template base;
 
-prefix "/software/components/ccm";
+function pkg_repl = { null; };
+include 'components/ccm/config';
+"/software/components/ccm/dependencies/pre" = null;
 
+prefix "/software/components/ccm";
+"profile" = "https://my.server/myprofile";
 "configFile" = "/etc/ccm.conf";
 "ca_file" = "/etc/sindes/ca/ca.crt";
 "version" = "1.2.3";


### PR DESCRIPTION
Allows ncm-ccm to enable tabcompletion generation, which is disabled by default in CCM