### PR TITLE
ncm-nagios & ncm-icinga: Seperate type definitions

### DIFF
--- a/ncm-icinga/src/main/pan/components/icinga/schema.pan
+++ b/ncm-icinga/src/main/pan/components/icinga/schema.pan
@@ -5,7 +5,8 @@
 
 declaration template components/icinga/schema;
 
-include 'quattor/schema';
+include 'quattor/types/component';
+include 'pan/types';
 
 # Please note that the "use" directive is not supported in order to make
 # validation code easier. If you want hosts to inherit settings then use

--- a/ncm-icinga/src/main/pan/components/icinga/schema.pan
+++ b/ncm-icinga/src/main/pan/components/icinga/schema.pan
@@ -5,7 +5,7 @@
 
 declaration template components/icinga/schema;
 
-include {'quattor/schema'};
+include 'quattor/schema';
 
 # Please note that the "use" directive is not supported in order to make
 # validation code easier. If you want hosts to inherit settings then use
@@ -65,7 +65,7 @@ type structure_icinga_host_generic = {
     "notifications_enabled" ? boolean
     "stalking_options" ? string with match (SELF, "^(o|d|u)$")
     "register" : boolean = true
-} = nlist();
+} = dict();
 
 
 # Host definition.
@@ -111,19 +111,19 @@ type structure_icinga_host = {
     "_cpus" ? string
     "_enclosureip" ? string
     "_enclosureslot" ? long
-} = nlist();
+} = dict();
 
 # Hostgroup definition
 type structure_icinga_hostgroup = {
     "alias" : string
     "members" ? icinga_hoststring[]
-} = nlist();
+} = dict();
 
 # Host dependency definition
 type structure_icinga_hostdependency = {
     "dependent_host_name" : icinga_hoststring # Should be string[]?
     "notification_failure_criteria" : icinga_host_notification_string[]
-} = nlist();
+} = dict();
 
 # Service definition
 type structure_icinga_service = {
@@ -171,7 +171,7 @@ type structure_icinga_servicegroup = {
     "notes" ? string
     "notes_url" ? type_absoluteURI
     "action_url" ? type_absoluteURI
-} = nlist();
+} = dict();
 
 # Servicedependency definition:
 type structure_icinga_servicedependency = {
@@ -199,13 +199,13 @@ type structure_icinga_contact = {
     "service_notification_commands" : icinga_commandstrings []
     "email" : string
     "pager" ? string
-} = nlist();
+} = dict();
 
 # Contact group definition
 type structure_icinga_contactgroup = {
     "alias" : string
     "members" : icinga_contactstring[]
-} = nlist();
+} = dict();
 
 # Time range definition
 type icinga_timerange = string with
@@ -221,7 +221,7 @@ type structure_icinga_timeperiod = {
     "friday" ? icinga_timerange
     "saturday" ? icinga_timerange
     "sunday" ? icinga_timerange
-} = nlist();
+} = dict();
 
 # Extended information for services
 type structure_icinga_serviceextinfo = {
@@ -291,7 +291,7 @@ type structure_icinga_cgi_cfg = {
     "send_ack_notifications" ? boolean
     "set_expire_ack_by_default" ? boolean
     "standalone_installation" ? boolean
-} = nlist();
+} = dict();
 
 # General options
 type structure_icinga_icinga_cfg = {
@@ -438,7 +438,7 @@ type structure_icinga_icinga_cfg = {
     "syslog_local_facility" ? long
     "use_daemon_log" ? boolean
     "use_syslog_local_facility" ? boolean
-} = nlist();
+} = dict();
 
 type structure_icinga_service_list=structure_icinga_service[];
 
@@ -479,7 +479,7 @@ type structure_icinga_ido2db_cfg = {
     "max_logentries_age" ? long
     "max_notifications_age" ? long
     "socket_perm" ? string
-} = nlist();
+} = dict();
 
 # Everything that can be handled by this component
 type structure_component_icinga = {

--- a/ncm-icinga/src/main/pan/components/icinga/schema.pan
+++ b/ncm-icinga/src/main/pan/components/icinga/schema.pan
@@ -11,46 +11,46 @@ include {'quattor/schema'};
 # validation code easier. If you want hosts to inherit settings then use
 # Pan statements like create ("...") or value ("...")
 
-type hoststring =  string with exists ("/software/components/icinga/hosts/" + SELF) ||
+type icinga_hoststring =  string with exists ("/software/components/icinga/hosts/" + SELF) ||
     SELF=="*" || SELF == 'dummy';
 
-type hostgroupstring = string with exists ("/software/components/icinga/hostgroups/" + escape(SELF)) || SELF=="*";
+type icinga_hostgroupstring = string with exists ("/software/components/icinga/hostgroups/" + escape(SELF)) || SELF=="*";
 
-type commandstrings = string [] with exists ("/software/components/icinga/commands/" + SELF[0]);
+type icinga_commandstrings = string [] with exists ("/software/components/icinga/commands/" + SELF[0]);
 
-type timeperiodstring = string with exists ("/software/components/icinga/timeperiods/" + SELF) ||
+type icinga_timeperiodstring = string with exists ("/software/components/icinga/timeperiods/" + SELF) ||
     SELF=="*";
 
-type contactgroupstring = string with exists ("/software/components/icinga/contactgroups/" + SELF) ||
+type icinga_contactgroupstring = string with exists ("/software/components/icinga/contactgroups/" + SELF) ||
     SELF=="*";
 
-type contactstring = string with exists ("/software/components/icinga/contacts/" + SELF) ||
+type icinga_contactstring = string with exists ("/software/components/icinga/contacts/" + SELF) ||
     SELF=="*";
 
-type servicegroupstring = string with exists ("/software/components/icinga/servicegroups/" + SELF) ||
+type icinga_servicegroupstring = string with exists ("/software/components/icinga/servicegroups/" + SELF) ||
     SELF=="*";
 
-type servicestring = string with exists ("/software/components/icinga/services/" + SELF) ||
+type icinga_servicestring = string with exists ("/software/components/icinga/services/" + SELF) ||
     SELF=="*";
 
-type service_notification_string = string with match (SELF, "^(w|u|c|r|f)$");
-type host_notification_string = string with match (SELF, "^(d|u|r|f)$");
-type stalking_string = string with match (SELF, "^(o|w|u|c)$");
-type execution_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
-type notification_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
+type icinga_service_notification_string = string with match (SELF, "^(w|u|c|r|f)$");
+type icinga_host_notification_string = string with match (SELF, "^(d|u|r|f)$");
+type icinga_stalking_string = string with match (SELF, "^(o|w|u|c)$");
+type icinga_execution_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
+type icinga_notification_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
 
 type structure_icinga_host_generic = {
     "name" ? string # Used instead of alias when it s a template declaration
-    "check_command" : commandstrings
+    "check_command" : icinga_commandstrings
     "max_check_attempts" : long
     "check_interval" ? long
     "active_checks_enabled" ? boolean
     "passive_checks_enabled" ? boolean
-    "check_period" : timeperiodstring
+    "check_period" : icinga_timeperiodstring
     "obsess_over_host" ? boolean
     "check_freshness" ? boolean
     "freshness_threshold" ? long
-    "event_handler" ? commandstrings
+    "event_handler" ? icinga_commandstrings
     "event_handler_enabled" ? boolean
     "low_flap_threshold" ? long
     "high_flap_threshold" ? long
@@ -58,10 +58,10 @@ type structure_icinga_host_generic = {
     "process_perf_data" ? boolean
     "retain_status_information" ? boolean
     "retain_nonstatus_information" ? boolean
-    "contact_groups" : contactgroupstring[]
+    "contact_groups" : icinga_contactgroupstring[]
     "notification_interval" : long
-    "notification_period" : timeperiodstring
-    "notification_options" : host_notification_string []
+    "notification_period" : icinga_timeperiodstring
+    "notification_options" : icinga_host_notification_string []
     "notifications_enabled" ? boolean
     "stalking_options" ? string with match (SELF, "^(o|d|u)$")
     "register" : boolean = true
@@ -73,18 +73,18 @@ type structure_icinga_host = {
     "alias" : string
     "use" ? string # Used to insert a template host declaration
     "address" ? type_ip # If not present, gethostbyname will be used.
-    "parents" ? hoststring[]
-    "hostgroups" ? hostgroupstring[]
-    "check_command" : commandstrings
+    "parents" ? icinga_hoststring[]
+    "hostgroups" ? icinga_hostgroupstring[]
+    "check_command" : icinga_commandstrings
     "max_check_attempts" : long
     "check_interval" ? long
     "active_checks_enabled" ? boolean
     "passive_checks_enabled" ? boolean
-    "check_period" : timeperiodstring
+    "check_period" : icinga_timeperiodstring
     "obsess_over_host" ? boolean
     "check_freshness" ? boolean
     "freshness_threshold" ? long
-    "event_handler" ? commandstrings
+    "event_handler" ? icinga_commandstrings
     "event_handler_enabled" ? boolean
     "low_flap_threshold" ? long
     "high_flap_threshold" ? long
@@ -93,10 +93,10 @@ type structure_icinga_host = {
     "failure_prediction_enabled" ? boolean = true
     "retain_status_information" ? boolean
     "retain_nonstatus_information" ? boolean
-    "contact_groups" : contactgroupstring[]
+    "contact_groups" : icinga_contactgroupstring[]
     "notification_interval" : long
-    "notification_period" : timeperiodstring
-    "notification_options" : host_notification_string []
+    "notification_period" : icinga_timeperiodstring
+    "notification_options" : icinga_host_notification_string []
     "notifications_enabled" ? boolean
     "stalking_options" ? string with match (SELF, "^(o|d|u)$")
     "register" : boolean = true
@@ -116,35 +116,35 @@ type structure_icinga_host = {
 # Hostgroup definition
 type structure_icinga_hostgroup = {
     "alias" : string
-    "members" ? hoststring[]
+    "members" ? icinga_hoststring[]
 } = nlist();
 
 # Host dependency definition
 type structure_icinga_hostdependency = {
-    "dependent_host_name" : hoststring # Should be string[]?
-    "notification_failure_criteria" : host_notification_string[]
+    "dependent_host_name" : icinga_hoststring # Should be string[]?
+    "notification_failure_criteria" : icinga_host_notification_string[]
 } = nlist();
 
 # Service definition
 type structure_icinga_service = {
     "name"  ? string # Used when it s a template declaration
     "use" ? string # Used to include template
-    "host_name" ? hoststring[]
-    "hostgroup_name" ? hostgroupstring[]
-    "servicegroups" ? servicegroupstring []
+    "host_name" ? icinga_hoststring[]
+    "hostgroup_name" ? icinga_hostgroupstring[]
+    "servicegroups" ? icinga_servicegroupstring []
     "is_volatile" ? boolean
-    "check_command" ? commandstrings
+    "check_command" ? icinga_commandstrings
     "max_check_attempts" : long
     "check_interval" : long
     "retry_interval" : long
     "active_checks_enabled" ? boolean
     "passive_checks_enabled" ? boolean
-    "check_period" ? timeperiodstring
+    "check_period" ? icinga_timeperiodstring
     "parallelize_check" ? boolean
     "obsess_over_service" ? boolean
     "check_freshness" ? boolean
     "freshness_threshold" ? long
-    "event_handler" ? commandstrings
+    "event_handler" ? icinga_commandstrings
     "event_handler_enabled" ? boolean
     "low_flap_threshold" ? long
     "high_flap_threshold" ? long
@@ -153,11 +153,11 @@ type structure_icinga_service = {
     "retain_status_information" ? boolean
     "retain_nonstatus_information" ? boolean
     "notification_interval" : long
-    "notification_period" : timeperiodstring
-    "notification_options" : service_notification_string []
+    "notification_period" : icinga_timeperiodstring
+    "notification_options" : icinga_service_notification_string []
     "notifications_enabled" ? boolean
-    "contact_groups" : contactgroupstring[]
-    "stalking_options" ? stalking_string[]
+    "contact_groups" : icinga_contactgroupstring[]
+    "stalking_options" ? icinga_stalking_string[]
     "register" : boolean = true
     "failure_prediction_enabled" ? boolean
     "action_url" ? string
@@ -166,8 +166,8 @@ type structure_icinga_service = {
 # Servicegroup definition:
 type structure_icinga_servicegroup = {
     "alias" : string
-    "members" ? servicestring []
-    "servicegroup_members" ? servicegroupstring[]
+    "members" ? icinga_servicestring []
+    "servicegroup_members" ? icinga_servicegroupstring[]
     "notes" ? string
     "notes_url" ? type_absoluteURI
     "action_url" ? type_absoluteURI
@@ -175,28 +175,28 @@ type structure_icinga_servicegroup = {
 
 # Servicedependency definition:
 type structure_icinga_servicedependency = {
-    "dependent_host_name"   : hoststring[]
-    "dependent_hostgroup_name" ? hostgroupstring[]
-    "dependent_service_description" : servicestring
-    "host_name" ? hoststring
-    "hostgroup_name" ? hostgroupstring
+    "dependent_host_name"   : icinga_hoststring[]
+    "dependent_hostgroup_name" ? icinga_hostgroupstring[]
+    "dependent_service_description" : icinga_servicestring
+    "host_name" ? icinga_hoststring
+    "hostgroup_name" ? icinga_hostgroupstring
     "service_description" : string
     "inherits_parent" ? boolean
-    "execution_failure_criteria" ? execution_failure_string []
-    "notification_failure_criteria" ? notification_failure_string []
-    "dependency_period" ? timeperiodstring
+    "execution_failure_criteria" ? icinga_execution_failure_string []
+    "notification_failure_criteria" ? icinga_notification_failure_string []
+    "dependency_period" ? icinga_timeperiodstring
 } with has_host_or_hostgroup (SELF);;
 
 # Contact definition
 type structure_icinga_contact = {
     "alias" : string
-    "contactgroups" ? contactgroupstring []
-    "host_notification_period" : timeperiodstring
-    "service_notification_period" : timeperiodstring
-    "host_notification_options" : host_notification_string []
-    "service_notification_options" : service_notification_string []
-    "host_notification_commands" : commandstrings []
-    "service_notification_commands" : commandstrings []
+    "contactgroups" ? icinga_contactgroupstring []
+    "host_notification_period" : icinga_timeperiodstring
+    "service_notification_period" : icinga_timeperiodstring
+    "host_notification_options" : icinga_host_notification_string []
+    "service_notification_options" : icinga_service_notification_string []
+    "host_notification_commands" : icinga_commandstrings []
+    "service_notification_commands" : icinga_commandstrings []
     "email" : string
     "pager" ? string
 } = nlist();
@@ -204,30 +204,30 @@ type structure_icinga_contact = {
 # Contact group definition
 type structure_icinga_contactgroup = {
     "alias" : string
-    "members" : contactstring[]
+    "members" : icinga_contactstring[]
 } = nlist();
 
 # Time range definition
-type timerange = string with
+type icinga_timerange = string with
     match (SELF, "^(([0-9]+:[0-9]+)-([0-9]+:[0-9]+),)*([0-9]+:[0-9]+)-([0-9]+:[0-9]+)$");
 
 # Time period definition
 type structure_icinga_timeperiod = {
     "alias" ? string
-    "monday" ? timerange
-    "tuesday"   ? timerange
-    "wednesday" ? timerange
-    "thursday"  ? timerange
-    "friday"    ? timerange
-    "saturday"  ? timerange
-    "sunday"    ? timerange
+    "monday" ? icinga_timerange
+    "tuesday"   ? icinga_timerange
+    "wednesday" ? icinga_timerange
+    "thursday"  ? icinga_timerange
+    "friday"    ? icinga_timerange
+    "saturday"  ? icinga_timerange
+    "sunday"    ? icinga_timerange
 } = nlist();
 
 # Extended information for services
 type structure_icinga_serviceextinfo = {
-    "host_name" ? hoststring[]
+    "host_name" ? icinga_hoststring[]
     "service_description" : string
-    "hostgroup_name" ? hostgroupstring[]
+    "hostgroup_name" ? icinga_hostgroupstring[]
     "notes" ? string
     "notes_url" ? type_absoluteURI
     "action_url" ? type_absoluteURI
@@ -355,8 +355,8 @@ type structure_icinga_icinga_cfg = {
     "enable_notifications" : boolean = true
     "enable_event_handlers" : boolean = true
     "process_performance_data" : boolean = true
-    "service_perfdata_command" : commandstrings = list("process-service-perfdata")
-    "host_perfdata_command" : commandstrings = list("process-host-perfdata")
+    "service_perfdata_command" : icinga_commandstrings = list("process-service-perfdata")
+    "host_perfdata_command" : icinga_commandstrings = list("process-host-perfdata")
     "host_perfdata_file" : string = "/var/icinga/host-perf.dat"
     "service_perfdata_file" : string = "/var/icinga/service-perf.dat"
     "host_perfdata_file_template" : string = "[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$"
@@ -365,8 +365,8 @@ type structure_icinga_icinga_cfg = {
     "service_perfdata_file_mode" : string = "a"
     "host_perfdata_file_processing_interval" : long = 0
     "service_perfdata_file_processing_interval" : long = 0
-    "host_perfdata_file_processing_command" ? commandstrings
-    "service_perfdata_file_processing_command" ? commandstrings
+    "host_perfdata_file_processing_command" ? icinga_commandstrings
+    "service_perfdata_file_processing_command" ? icinga_commandstrings
     "allow_empty_hostgroup_assignment" ? boolean
     "obsess_over_services" : boolean = false
     "check_for_orphaned_services" : boolean = true

--- a/ncm-icinga/src/main/pan/components/icinga/schema.pan
+++ b/ncm-icinga/src/main/pan/components/icinga/schema.pan
@@ -127,7 +127,7 @@ type structure_icinga_hostdependency = {
 
 # Service definition
 type structure_icinga_service = {
-    "name"  ? string # Used when it s a template declaration
+    "name" ? string # Used when it s a template declaration
     "use" ? string # Used to include template
     "host_name" ? icinga_hoststring[]
     "hostgroup_name" ? icinga_hostgroupstring[]
@@ -175,7 +175,7 @@ type structure_icinga_servicegroup = {
 
 # Servicedependency definition:
 type structure_icinga_servicedependency = {
-    "dependent_host_name"   : icinga_hoststring[]
+    "dependent_host_name" : icinga_hoststring[]
     "dependent_hostgroup_name" ? icinga_hostgroupstring[]
     "dependent_service_description" : icinga_servicestring
     "host_name" ? icinga_hoststring
@@ -215,12 +215,12 @@ type icinga_timerange = string with
 type structure_icinga_timeperiod = {
     "alias" ? string
     "monday" ? icinga_timerange
-    "tuesday"   ? icinga_timerange
+    "tuesday" ? icinga_timerange
     "wednesday" ? icinga_timerange
-    "thursday"  ? icinga_timerange
-    "friday"    ? icinga_timerange
-    "saturday"  ? icinga_timerange
-    "sunday"    ? icinga_timerange
+    "thursday" ? icinga_timerange
+    "friday" ? icinga_timerange
+    "saturday" ? icinga_timerange
+    "sunday" ? icinga_timerange
 } = nlist();
 
 # Extended information for services
@@ -237,21 +237,21 @@ type structure_icinga_serviceextinfo = {
 
 # CGI configuration
 type structure_icinga_cgi_cfg = {
-    "main_config_file"      : string = "/etc/icinga/icinga.cfg"
-    "physical_html_path"    : string = "/usr/share/icinga"
-    "url_html_path"         : string = "/icinga"
-    "url_stylesheets_path"  : string = "/icinga/stylesheets"
-    "http_charset"          : string = "utf-8"
-    "show_context_help"     : boolean = false
-    "highlight_table_rows"  : boolean = false
-    "use_pending_states"    : boolean = true
-    "use_logging"           : boolean = false
-    "cgi_log_file"          : string = "/var/log/icinga/gui/icinga-cgi.log"
+    "main_config_file" : string = "/etc/icinga/icinga.cfg"
+    "physical_html_path" : string = "/usr/share/icinga"
+    "url_html_path" : string = "/icinga"
+    "url_stylesheets_path" : string = "/icinga/stylesheets"
+    "http_charset" : string = "utf-8"
+    "show_context_help" : boolean = false
+    "highlight_table_rows" : boolean = false
+    "use_pending_states" : boolean = true
+    "use_logging" : boolean = false
+    "cgi_log_file" : string = "/var/log/icinga/gui/icinga-cgi.log"
     "cgi_log_rotation_method" : string = "d"
     "cgi_log_archive_path" : string = "/var/log/icinga/gui"
     "enforce_comments_on_actions" : boolean = false
     "first_day_of_week" : boolean = false
-    "use_authentication"    : boolean = true
+    "use_authentication" : boolean = true
     "use_ssl_authentication": boolean = false
     "authorized_for_system_information" : string = "icingaadmin"
     "authorized_for_configuration_information" : string = "icingaadmin"
@@ -262,24 +262,24 @@ type structure_icinga_cgi_cfg = {
     "authorized_for_all_host_commands" : string = "icingaadmin"
     "show_all_services_host_is_authorized_for": boolean = true
     "show_partial_hostgroups" : boolean = false
-    "statusmap_background_image"    ? string
-    "default_statusmap_layout"  : long = 5
-    "default_statuswrl_layout"  : long = 4
-    "statuswrl_include"         ? string
-    "ping_syntax"               : string = "/bin/ping -n -U -c 5 $HOSTADDRESS$"
-    "refresh_rate"              : long = 90
-    "escape_html_tags"          : boolean = true
-    "persistent_ack_comments"   : boolean = false
-    "action_url_target"         : string = "main"
-    "notes_url_target"          : string = "main"
-    "lock_author_names"         : boolean = true
+    "statusmap_background_image" ? string
+    "default_statusmap_layout" : long = 5
+    "default_statuswrl_layout" : long = 4
+    "statuswrl_include" ? string
+    "ping_syntax" : string = "/bin/ping -n -U -c 5 $HOSTADDRESS$"
+    "refresh_rate" : long = 90
+    "escape_html_tags" : boolean = true
+    "persistent_ack_comments" : boolean = false
+    "action_url_target" : string = "main"
+    "notes_url_target" : string = "main"
+    "lock_author_names" : boolean = true
     "default_downtime_duration" : long = 7200
     "status_show_long_plugin_output": boolean = false
     "tac_show_only_hard_state": boolean = false
     "suppress_maintenance_downtime" : boolean = false
-    "show_tac_header"           : boolean = true
-    "show_tac_header_pending"   : boolean = true
-    "tab_friendly_titles"       : boolean = true
+    "show_tac_header" : boolean = true
+    "show_tac_header_pending" : boolean = true
+    "tab_friendly_titles" : boolean = true
     "default_expiring_acknowledgement_duration" ? long
     "default_expiring_disabled_notifications_duration" ? long
     "display_status_totals" ? boolean

--- a/ncm-nagios/src/main/pan/components/nagios/schema.pan
+++ b/ncm-nagios/src/main/pan/components/nagios/schema.pan
@@ -10,47 +10,47 @@ include {'quattor/schema'};
 # validation code easier. If you want hosts to inherit settings then use
 # Pan statements like create ("...") or value ("...")
 
-type hoststring =  string with exists ("/software/components/nagios/hosts/" + SELF) ||
+type nagios_hoststring =  string with exists ("/software/components/nagios/hosts/" + SELF) ||
 	SELF=="*";
 
-type hostgroupstring = string with exists ("/software/components/nagios/hostgroups/" + SELF) || SELF=="*";
+type nagios_hostgroupstring = string with exists ("/software/components/nagios/hostgroups/" + SELF) || SELF=="*";
 
-type commandstrings = string [] with exists ("/software/components/nagios/commands/" + SELF[0]);
+type nagios_commandstrings = string [] with exists ("/software/components/nagios/commands/" + SELF[0]);
 
-type timeperiodstring = string with exists ("/software/components/nagios/timeperiods/" + SELF) ||
+type nagios_timeperiodstring = string with exists ("/software/components/nagios/timeperiods/" + SELF) ||
 	SELF=="*";
 
-type contactgroupstring = string with exists ("/software/components/nagios/contactgroups/" + SELF) ||
+type nagios_contactgroupstring = string with exists ("/software/components/nagios/contactgroups/" + SELF) ||
 	SELF=="*";
 
-type contactstring = string with exists ("/software/components/nagios/contacts/" + SELF) ||
+type nagios_contactstring = string with exists ("/software/components/nagios/contacts/" + SELF) ||
 	SELF=="*";	
 
-type servicegroupstring = string with exists ("/software/components/nagios/servicegroups/" + SELF) ||
+type nagios_servicegroupstring = string with exists ("/software/components/nagios/servicegroups/" + SELF) ||
 	SELF=="*";
 
-type servicestring = string with exists ("/software/components/nagios/services/" + SELF) ||
+type nagios_servicestring = string with exists ("/software/components/nagios/services/" + SELF) ||
 	SELF=="*";
 
-type service_notification_string = string with match (SELF, "^(w|u|c|r|f)$");
-type host_notification_string = string with match (SELF, "^(d|u|r|f)$");
-type stalking_string = string with match (SELF, "^(o|w|u|c)$");
-type execution_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
-type notification_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
+type nagios_service_notification_string = string with match (SELF, "^(w|u|c|r|f)$");
+type nagios_host_notification_string = string with match (SELF, "^(d|u|r|f)$");
+type nagios_stalking_string = string with match (SELF, "^(o|w|u|c)$");
+type nagios_execution_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
+type nagios_notification_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
 
 type structure_nagios_host_generic = {
         "name" ? string # Used instead of alias when it s a template declaration
-        "check_command" : commandstrings
+        "check_command" : nagios_commandstrings
         "max_check_attempts" : long
         "check_interval" ? long
         "retry_interval" ? long
         "active_checks_enabled" ? boolean
         "passive_checks_enabled" ? boolean
-        "check_period" : timeperiodstring
+        "check_period" : nagios_timeperiodstring
         "obsess_over_host" ? boolean
         "check_freshness" ? boolean
         "freshness_threshold" ? long
-        "event_handler" ? commandstrings
+        "event_handler" ? nagios_commandstrings
         "event_handler_enabled" ? boolean
         "low_flap_threshold" ? long
         "high_flap_threshold" ? long
@@ -58,10 +58,10 @@ type structure_nagios_host_generic = {
         "process_perf_data" ? boolean
         "retain_status_information" ? boolean
         "retain_nonstatus_information" ? boolean
-        "contact_groups" : contactgroupstring[]
+        "contact_groups" : nagios_contactgroupstring[]
         "notification_interval" : long
-        "notification_period" : timeperiodstring
-        "notification_options" : host_notification_string []
+        "notification_period" : nagios_timeperiodstring
+        "notification_options" : nagios_host_notification_string []
         "notifications_enabled" ? boolean
         "stalking_options" ? string with match (SELF, "^(o|d|u)$")
         "register" : boolean = true
@@ -72,18 +72,18 @@ type structure_nagios_host = {
 	"alias" : string 
 	"use" ? string # Used to insert a template host declaration
 	"address" ? type_ip # If not present, gethostbyname will be used.
-	"parents" ? hoststring[]
-	"hostgroups" ? hostgroupstring[]
-	"check_command" : commandstrings
+	"parents" ? nagios_hoststring[]
+	"hostgroups" ? nagios_hostgroupstring[]
+	"check_command" : nagios_commandstrings
 	"max_check_attempts" : long
 	"check_interval" ? long
 	"active_checks_enabled" ? boolean
 	"passive_checks_enabled" ? boolean
-	"check_period" : timeperiodstring
+	"check_period" : nagios_timeperiodstring
 	"obsess_over_host" ? boolean
 	"check_freshness" ? boolean
 	"freshness_threshold" ? long
-	"event_handler" ? commandstrings
+	"event_handler" ? nagios_commandstrings
 	"event_handler_enabled" ? boolean
 	"low_flap_threshold" ? long
 	"high_flap_threshold" ? long
@@ -91,10 +91,10 @@ type structure_nagios_host = {
 	"process_perf_data" ? boolean
 	"retain_status_information" ? boolean
 	"retain_nonstatus_information" ? boolean
-	"contact_groups" : contactgroupstring[]
+	"contact_groups" : nagios_contactgroupstring[]
 	"notification_interval" : long
-	"notification_period" : timeperiodstring
-	"notification_options" : host_notification_string []
+	"notification_period" : nagios_timeperiodstring
+	"notification_options" : nagios_host_notification_string []
 	"notifications_enabled" ? boolean
 	"stalking_options" ? string with match (SELF, "^(o|d|u)$")
 	"register" : boolean = true
@@ -104,35 +104,35 @@ type structure_nagios_host = {
 # Hostgroup definition
 type structure_nagios_hostgroup = {
 	"alias"	: string
-	"members" ? hoststring[]
+	"members" ? nagios_hoststring[]
 };
 
 # Host dependency definition
 type structure_nagios_hostdependency = {
-	"dependent_host_name" : hoststring # Should be string[]?
-	"notification_failure_criteria" : host_notification_string[]
+	"dependent_host_name" : nagios_hoststring # Should be string[]?
+	"notification_failure_criteria" : nagios_host_notification_string[]
 };
 
 # Service definition
 type structure_nagios_service = {
 	"name"	? string # Used when it s a template declaration
-	"use" ? string # Used to include template 
-	"host_name" ? hoststring[]
-	"hostgroup_name" ? hostgroupstring[]
-	"servicegroups" ? servicegroupstring []
+	"use" ? string # Used to include template
+	"host_name" ? nagios_hoststring[]
+	"hostgroup_name" ? nagios_hostgroupstring[]
+	"servicegroups" ? nagios_servicegroupstring []
 	"is_volatile" ? boolean
-	"check_command" ? commandstrings
+	"check_command" ? nagios_commandstrings
 	"max_check_attempts" : long
 	"normal_check_interval" : long
 	"retry_check_interval" : long
 	"active_checks_enabled" ? boolean
 	"passive_checks_enabled" ? boolean
-	"check_period" ? timeperiodstring
+	"check_period" ? nagios_timeperiodstring
 	"parallelize_check" ? boolean                           # deprecated in Nagios 3
 	"obsess_over_service" ? boolean
 	"check_freshness" ? boolean
 	"freshness_threshold" ? long
-	"event_handler" ? commandstrings
+	"event_handler" ? nagios_commandstrings
 	"event_handler_enabled" ? boolean
 	"low_flap_threshold" ? long
 	"high_flap_threshold" ? long
@@ -141,11 +141,11 @@ type structure_nagios_service = {
 	"retain_status_information" ? boolean
 	"retain_nonstatus_information" ? boolean
 	"notification_interval" : long
-	"notification_period" : timeperiodstring
-	"notification_options" : service_notification_string []
+	"notification_period" : nagios_timeperiodstring
+	"notification_options" : nagios_service_notification_string []
 	"notifications_enabled" ? boolean
-	"contact_groups" : contactgroupstring[]
-	"stalking_options" ? stalking_string[]
+	"contact_groups" : nagios_contactgroupstring[]
+	"stalking_options" ? nagios_stalking_string[]
 	"register" : boolean = true
 	"failure_prediction_enabled" ? boolean
 	"action_url" ? string
@@ -154,8 +154,8 @@ type structure_nagios_service = {
 # Servicegroup definition:
 type structure_nagios_servicegroup = {
 	"alias"	: string
-	"members" ? servicestring []
-	"servicegroup_members" ? servicegroupstring[]
+	"members" ? nagios_servicestring []
+	"servicegroup_members" ? nagios_servicegroupstring[]
 	"notes" ? string
 	"notes_url" ? type_absoluteURI
 	"action_url" ? type_absoluteURI
@@ -163,28 +163,28 @@ type structure_nagios_servicegroup = {
 
 # Servicedependency definition:
 type structure_nagios_servicedependency = {
-	"dependent_host_name"	: hoststring[]
-	"dependent_hostgroup_name" ? hostgroupstring[]
-	"dependent_service_description" : servicestring
-	"host_name" ? hoststring
-	"hostgroup_name" ? hostgroupstring
+	"dependent_host_name"	: nagios_hoststring[]
+	"dependent_hostgroup_name" ? nagios_hostgroupstring[]
+	"dependent_service_description" : nagios_servicestring
+	"host_name" ? nagios_hoststring
+	"hostgroup_name" ? nagios_hostgroupstring
 	"service_description" : string
 	"inherits_parent" ? boolean
-	"execution_failure_criteria" ? execution_failure_string [] 
-	"notification_failure_criteria" ? notification_failure_string []
-	"dependency_period" ? timeperiodstring
+	"execution_failure_criteria" ? nagios_execution_failure_string []
+	"notification_failure_criteria" ? nagios_notification_failure_string []
+	"dependency_period" ? nagios_timeperiodstring
 } with has_host_or_hostgroup (SELF);;
 
 # Contact definition
 type structure_nagios_contact = {
 	"alias"	: string
-	"contactgroups" : contactgroupstring []
-	"host_notification_period" : timeperiodstring
-	"service_notification_period" : timeperiodstring
-	"host_notification_options" : host_notification_string []
-	"service_notification_options" : service_notification_string []
-	"host_notification_commands" : commandstrings []
-	"service_notification_commands" : commandstrings []
+	"contactgroups" : nagios_contactgroupstring []
+	"host_notification_period" : nagios_timeperiodstring
+	"service_notification_period" : nagios_timeperiodstring
+	"host_notification_options" : nagios_host_notification_string []
+	"service_notification_options" : nagios_service_notification_string []
+	"host_notification_commands" : nagios_commandstrings []
+	"service_notification_commands" : nagios_commandstrings []
 	"email" : string
 	"pager" : string
 };
@@ -192,31 +192,31 @@ type structure_nagios_contact = {
 # Contact group definition
 type structure_nagios_contactgroup = {
 	"alias" : string
-	"members" : contactstring[]
+	"members" : nagios_contactstring[]
 };
 
 # Time range definition
-type timerange = string with
+type nagios_timerange = string with
     match (SELF, "^(([0-9]+:[0-9]+)-([0-9]+:[0-9]+),)*([0-9]+:[0-9]+)-([0-9]+:[0-9]+)$");
 
 # Time period definition
 type structure_nagios_timeperiod = {
 	"alias" ? string
-	"monday" ? timerange
-	"tuesday"	? timerange
-	"wednesday"	? timerange
-	"thursday"	? timerange
-	"friday"	? timerange
-	"saturday"	? timerange
-	"sunday"	? timerange
+	"monday" ? nagios_timerange
+	"tuesday"	? nagios_timerange
+	"wednesday"	? nagios_timerange
+	"thursday"	? nagios_timerange
+	"friday"	? nagios_timerange
+	"saturday"	? nagios_timerange
+	"sunday"	? nagios_timerange
 };
 
 # Extended information for services
 # Deprecated in Nagios 3
 type structure_nagios_serviceextinfo = {
-	"host_name" ? hoststring[]
+	"host_name" ? nagios_hoststring[]
 	"service_description" : string
-	"hostgroup_name" ? hostgroupstring[]	
+	"hostgroup_name" ? nagios_hostgroupstring[]
 	"notes" ? string
 	"notes_url" ? type_absoluteURI
 	"action_url" ? type_absoluteURI
@@ -315,8 +315,8 @@ type structure_nagios_nagios_cfg = {
 	"enable_notifications" : boolean = true
 	"enable_event_handlers" : boolean = true
 	"process_performance_data" : boolean = true
-	"service_perfdata_command" : commandstrings = list("process-service-perfdata")
-	"host_perfdata_command" : commandstrings = list("process-host-perfdata")
+	"service_perfdata_command" : nagios_commandstrings = list("process-service-perfdata")
+	"host_perfdata_command" : nagios_commandstrings = list("process-host-perfdata")
 	"host_perfdata_file" : string = "/var/log/nagios/host-perf.dat"
 	"service_perfdata_file" : string = "/var/log/nagios/service-perf.dat"
 	"host_perfdata_file_template" : string = "[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$"
@@ -325,8 +325,8 @@ type structure_nagios_nagios_cfg = {
 	"service_perfdata_file_mode" : string = "a"
 	"host_perfdata_file_processing_interval" : long = 0
 	"service_perfdata_file_processing_interval" : long = 0
-	"host_perfdata_file_processing_command" ? commandstrings
-	"service_perfdata_file_processing_command" ? commandstrings
+	"host_perfdata_file_processing_command" ? nagios_commandstrings
+	"service_perfdata_file_processing_command" ? nagios_commandstrings
 	"obsess_over_services" : boolean = false
 	"check_for_orphaned_services" : boolean = true
 	"check_service_freshness" : boolean = true

--- a/ncm-nagios/src/main/pan/components/nagios/schema.pan
+++ b/ncm-nagios/src/main/pan/components/nagios/schema.pan
@@ -4,7 +4,8 @@
 
 declaration template components/nagios/schema;
 
-include 'quattor/schema';
+include 'quattor/types/component';
+include 'pan/types';
 
 # Please note that the "use" directive is not supported in order to make
 # validation code easier. If you want hosts to inherit settings then use

--- a/ncm-nagios/src/main/pan/components/nagios/schema.pan
+++ b/ncm-nagios/src/main/pan/components/nagios/schema.pan
@@ -11,26 +11,26 @@ include {'quattor/schema'};
 # Pan statements like create ("...") or value ("...")
 
 type nagios_hoststring =  string with exists ("/software/components/nagios/hosts/" + SELF) ||
-	SELF=="*";
+    SELF=="*";
 
 type nagios_hostgroupstring = string with exists ("/software/components/nagios/hostgroups/" + SELF) || SELF=="*";
 
 type nagios_commandstrings = string [] with exists ("/software/components/nagios/commands/" + SELF[0]);
 
 type nagios_timeperiodstring = string with exists ("/software/components/nagios/timeperiods/" + SELF) ||
-	SELF=="*";
+    SELF=="*";
 
 type nagios_contactgroupstring = string with exists ("/software/components/nagios/contactgroups/" + SELF) ||
-	SELF=="*";
+    SELF=="*";
 
 type nagios_contactstring = string with exists ("/software/components/nagios/contacts/" + SELF) ||
-	SELF=="*";	
+    SELF=="*";
 
 type nagios_servicegroupstring = string with exists ("/software/components/nagios/servicegroups/" + SELF) ||
-	SELF=="*";
+    SELF=="*";
 
 type nagios_servicestring = string with exists ("/software/components/nagios/services/" + SELF) ||
-	SELF=="*";
+    SELF=="*";
 
 type nagios_service_notification_string = string with match (SELF, "^(w|u|c|r|f)$");
 type nagios_host_notification_string = string with match (SELF, "^(d|u|r|f)$");
@@ -39,160 +39,160 @@ type nagios_execution_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$
 type nagios_notification_failure_string = string with match (SELF, "^(o|w|u|c|p|n)$");
 
 type structure_nagios_host_generic = {
-        "name" ? string # Used instead of alias when it s a template declaration
-        "check_command" : nagios_commandstrings
-        "max_check_attempts" : long
-        "check_interval" ? long
-        "retry_interval" ? long
-        "active_checks_enabled" ? boolean
-        "passive_checks_enabled" ? boolean
-        "check_period" : nagios_timeperiodstring
-        "obsess_over_host" ? boolean
-        "check_freshness" ? boolean
-        "freshness_threshold" ? long
-        "event_handler" ? nagios_commandstrings
-        "event_handler_enabled" ? boolean
-        "low_flap_threshold" ? long
-        "high_flap_threshold" ? long
-        "flap_detection_enabled" : boolean = true
-        "process_perf_data" ? boolean
-        "retain_status_information" ? boolean
-        "retain_nonstatus_information" ? boolean
-        "contact_groups" : nagios_contactgroupstring[]
-        "notification_interval" : long
-        "notification_period" : nagios_timeperiodstring
-        "notification_options" : nagios_host_notification_string []
-        "notifications_enabled" ? boolean
-        "stalking_options" ? string with match (SELF, "^(o|d|u)$")
-        "register" : boolean = true
+    "name" ? string # Used instead of alias when it s a template declaration
+    "check_command" : nagios_commandstrings
+    "max_check_attempts" : long
+    "check_interval" ? long
+    "retry_interval" ? long
+    "active_checks_enabled" ? boolean
+    "passive_checks_enabled" ? boolean
+    "check_period" : nagios_timeperiodstring
+    "obsess_over_host" ? boolean
+    "check_freshness" ? boolean
+    "freshness_threshold" ? long
+    "event_handler" ? nagios_commandstrings
+    "event_handler_enabled" ? boolean
+    "low_flap_threshold" ? long
+    "high_flap_threshold" ? long
+    "flap_detection_enabled" : boolean = true
+    "process_perf_data" ? boolean
+    "retain_status_information" ? boolean
+    "retain_nonstatus_information" ? boolean
+    "contact_groups" : nagios_contactgroupstring[]
+    "notification_interval" : long
+    "notification_period" : nagios_timeperiodstring
+    "notification_options" : nagios_host_notification_string []
+    "notifications_enabled" ? boolean
+    "stalking_options" ? string with match (SELF, "^(o|d|u)$")
+    "register" : boolean = true
 };
 
 # Host definition.
 type structure_nagios_host = {
-	"alias" : string 
-	"use" ? string # Used to insert a template host declaration
-	"address" ? type_ip # If not present, gethostbyname will be used.
-	"parents" ? nagios_hoststring[]
-	"hostgroups" ? nagios_hostgroupstring[]
-	"check_command" : nagios_commandstrings
-	"max_check_attempts" : long
-	"check_interval" ? long
-	"active_checks_enabled" ? boolean
-	"passive_checks_enabled" ? boolean
-	"check_period" : nagios_timeperiodstring
-	"obsess_over_host" ? boolean
-	"check_freshness" ? boolean
-	"freshness_threshold" ? long
-	"event_handler" ? nagios_commandstrings
-	"event_handler_enabled" ? boolean
-	"low_flap_threshold" ? long
-	"high_flap_threshold" ? long
-	"flap_detection_enabled" : boolean = true
-	"process_perf_data" ? boolean
-	"retain_status_information" ? boolean
-	"retain_nonstatus_information" ? boolean
-	"contact_groups" : nagios_contactgroupstring[]
-	"notification_interval" : long
-	"notification_period" : nagios_timeperiodstring
-	"notification_options" : nagios_host_notification_string []
-	"notifications_enabled" ? boolean
-	"stalking_options" ? string with match (SELF, "^(o|d|u)$")
-	"register" : boolean = true
-	"action_url" ? string
+    "alias" : string
+    "use" ? string # Used to insert a template host declaration
+    "address" ? type_ip # If not present, gethostbyname will be used.
+    "parents" ? nagios_hoststring[]
+    "hostgroups" ? nagios_hostgroupstring[]
+    "check_command" : nagios_commandstrings
+    "max_check_attempts" : long
+    "check_interval" ? long
+    "active_checks_enabled" ? boolean
+    "passive_checks_enabled" ? boolean
+    "check_period" : nagios_timeperiodstring
+    "obsess_over_host" ? boolean
+    "check_freshness" ? boolean
+    "freshness_threshold" ? long
+    "event_handler" ? nagios_commandstrings
+    "event_handler_enabled" ? boolean
+    "low_flap_threshold" ? long
+    "high_flap_threshold" ? long
+    "flap_detection_enabled" : boolean = true
+    "process_perf_data" ? boolean
+    "retain_status_information" ? boolean
+    "retain_nonstatus_information" ? boolean
+    "contact_groups" : nagios_contactgroupstring[]
+    "notification_interval" : long
+    "notification_period" : nagios_timeperiodstring
+    "notification_options" : nagios_host_notification_string []
+    "notifications_enabled" ? boolean
+    "stalking_options" ? string with match (SELF, "^(o|d|u)$")
+    "register" : boolean = true
+    "action_url" ? string
 };
 
 # Hostgroup definition
 type structure_nagios_hostgroup = {
-	"alias"	: string
-	"members" ? nagios_hoststring[]
+    "alias" : string
+    "members" ? nagios_hoststring[]
 };
 
 # Host dependency definition
 type structure_nagios_hostdependency = {
-	"dependent_host_name" : nagios_hoststring # Should be string[]?
-	"notification_failure_criteria" : nagios_host_notification_string[]
+    "dependent_host_name" : nagios_hoststring # Should be string[]?
+    "notification_failure_criteria" : nagios_host_notification_string[]
 };
 
 # Service definition
 type structure_nagios_service = {
-	"name"	? string # Used when it s a template declaration
-	"use" ? string # Used to include template
-	"host_name" ? nagios_hoststring[]
-	"hostgroup_name" ? nagios_hostgroupstring[]
-	"servicegroups" ? nagios_servicegroupstring []
-	"is_volatile" ? boolean
-	"check_command" ? nagios_commandstrings
-	"max_check_attempts" : long
-	"normal_check_interval" : long
-	"retry_check_interval" : long
-	"active_checks_enabled" ? boolean
-	"passive_checks_enabled" ? boolean
-	"check_period" ? nagios_timeperiodstring
-	"parallelize_check" ? boolean                           # deprecated in Nagios 3
-	"obsess_over_service" ? boolean
-	"check_freshness" ? boolean
-	"freshness_threshold" ? long
-	"event_handler" ? nagios_commandstrings
-	"event_handler_enabled" ? boolean
-	"low_flap_threshold" ? long
-	"high_flap_threshold" ? long
-	"flap_detection_enabled" : boolean = true
-	"process_perf_data" ? boolean
-	"retain_status_information" ? boolean
-	"retain_nonstatus_information" ? boolean
-	"notification_interval" : long
-	"notification_period" : nagios_timeperiodstring
-	"notification_options" : nagios_service_notification_string []
-	"notifications_enabled" ? boolean
-	"contact_groups" : nagios_contactgroupstring[]
-	"stalking_options" ? nagios_stalking_string[]
-	"register" : boolean = true
-	"failure_prediction_enabled" ? boolean
-	"action_url" ? string
+    "name" ? string # Used when it s a template declaration
+    "use" ? string # Used to include template
+    "host_name" ? nagios_hoststring[]
+    "hostgroup_name" ? nagios_hostgroupstring[]
+    "servicegroups" ? nagios_servicegroupstring []
+    "is_volatile" ? boolean
+    "check_command" ? nagios_commandstrings
+    "max_check_attempts" : long
+    "normal_check_interval" : long
+    "retry_check_interval" : long
+    "active_checks_enabled" ? boolean
+    "passive_checks_enabled" ? boolean
+    "check_period" ? nagios_timeperiodstring
+    "parallelize_check" ? boolean # deprecated in Nagios 3
+    "obsess_over_service" ? boolean
+    "check_freshness" ? boolean
+    "freshness_threshold" ? long
+    "event_handler" ? nagios_commandstrings
+    "event_handler_enabled" ? boolean
+    "low_flap_threshold" ? long
+    "high_flap_threshold" ? long
+    "flap_detection_enabled" : boolean = true
+    "process_perf_data" ? boolean
+    "retain_status_information" ? boolean
+    "retain_nonstatus_information" ? boolean
+    "notification_interval" : long
+    "notification_period" : nagios_timeperiodstring
+    "notification_options" : nagios_service_notification_string []
+    "notifications_enabled" ? boolean
+    "contact_groups" : nagios_contactgroupstring[]
+    "stalking_options" ? nagios_stalking_string[]
+    "register" : boolean = true
+    "failure_prediction_enabled" ? boolean
+    "action_url" ? string
 } with has_host_or_hostgroup (SELF);;
 
 # Servicegroup definition:
 type structure_nagios_servicegroup = {
-	"alias"	: string
-	"members" ? nagios_servicestring []
-	"servicegroup_members" ? nagios_servicegroupstring[]
-	"notes" ? string
-	"notes_url" ? type_absoluteURI
-	"action_url" ? type_absoluteURI
+    "alias" : string
+    "members" ? nagios_servicestring []
+    "servicegroup_members" ? nagios_servicegroupstring[]
+    "notes" ? string
+    "notes_url" ? type_absoluteURI
+    "action_url" ? type_absoluteURI
 };
 
 # Servicedependency definition:
 type structure_nagios_servicedependency = {
-	"dependent_host_name"	: nagios_hoststring[]
-	"dependent_hostgroup_name" ? nagios_hostgroupstring[]
-	"dependent_service_description" : nagios_servicestring
-	"host_name" ? nagios_hoststring
-	"hostgroup_name" ? nagios_hostgroupstring
-	"service_description" : string
-	"inherits_parent" ? boolean
-	"execution_failure_criteria" ? nagios_execution_failure_string []
-	"notification_failure_criteria" ? nagios_notification_failure_string []
-	"dependency_period" ? nagios_timeperiodstring
+    "dependent_host_name" : nagios_hoststring[]
+    "dependent_hostgroup_name" ? nagios_hostgroupstring[]
+    "dependent_service_description" : nagios_servicestring
+    "host_name" ? nagios_hoststring
+    "hostgroup_name" ? nagios_hostgroupstring
+    "service_description" : string
+    "inherits_parent" ? boolean
+    "execution_failure_criteria" ? nagios_execution_failure_string []
+    "notification_failure_criteria" ? nagios_notification_failure_string []
+    "dependency_period" ? nagios_timeperiodstring
 } with has_host_or_hostgroup (SELF);;
 
 # Contact definition
 type structure_nagios_contact = {
-	"alias"	: string
-	"contactgroups" : nagios_contactgroupstring []
-	"host_notification_period" : nagios_timeperiodstring
-	"service_notification_period" : nagios_timeperiodstring
-	"host_notification_options" : nagios_host_notification_string []
-	"service_notification_options" : nagios_service_notification_string []
-	"host_notification_commands" : nagios_commandstrings []
-	"service_notification_commands" : nagios_commandstrings []
-	"email" : string
-	"pager" : string
+    "alias" : string
+    "contactgroups" : nagios_contactgroupstring []
+    "host_notification_period" : nagios_timeperiodstring
+    "service_notification_period" : nagios_timeperiodstring
+    "host_notification_options" : nagios_host_notification_string []
+    "service_notification_options" : nagios_service_notification_string []
+    "host_notification_commands" : nagios_commandstrings []
+    "service_notification_commands" : nagios_commandstrings []
+    "email" : string
+    "pager" : string
 };
 
 # Contact group definition
 type structure_nagios_contactgroup = {
-	"alias" : string
-	"members" : nagios_contactstring[]
+    "alias" : string
+    "members" : nagios_contactstring[]
 };
 
 # Time range definition
@@ -201,211 +201,211 @@ type nagios_timerange = string with
 
 # Time period definition
 type structure_nagios_timeperiod = {
-	"alias" ? string
-	"monday" ? nagios_timerange
-	"tuesday"	? nagios_timerange
-	"wednesday"	? nagios_timerange
-	"thursday"	? nagios_timerange
-	"friday"	? nagios_timerange
-	"saturday"	? nagios_timerange
-	"sunday"	? nagios_timerange
+    "alias" ? string
+    "monday" ? nagios_timerange
+    "tuesday" ? nagios_timerange
+    "wednesday" ? nagios_timerange
+    "thursday" ? nagios_timerange
+    "friday" ? nagios_timerange
+    "saturday" ? nagios_timerange
+    "sunday" ? nagios_timerange
 };
 
 # Extended information for services
 # Deprecated in Nagios 3
 type structure_nagios_serviceextinfo = {
-	"host_name" ? nagios_hoststring[]
-	"service_description" : string
-	"hostgroup_name" ? nagios_hostgroupstring[]
-	"notes" ? string
-	"notes_url" ? type_absoluteURI
-	"action_url" ? type_absoluteURI
-	"icon_image" ? string
-	"icon_image_alt" ? string
+    "host_name" ? nagios_hoststring[]
+    "service_description" : string
+    "hostgroup_name" ? nagios_hostgroupstring[]
+    "notes" ? string
+    "notes_url" ? type_absoluteURI
+    "action_url" ? type_absoluteURI
+    "icon_image" ? string
+    "icon_image_alt" ? string
 } with has_host_or_hostgroup (SELF);
 
 # CGI configuration
 type structure_nagios_cgi_cfg = {
-	"physical_html_path"    : string = "/usr/share/nagios"
-	"url_html_path"         : string = "/nagios"
-	"show_context_help"     : boolean = false
-	"nagios_check_command"  ? string
-	"use_authentication"    : boolean = true
-	"default_user_name"     ? string
-	"authorized_for_system_information" ? string
-	"authorized_for_configuration_information"  ? string
-	"authorized_for_system_commands"    ? string
-	"authorized_for_all_services"   ? string
-	"authorized_for_all_hosts"      ? string
-	"authorized_for_all_service_commands"   ? string
-	"authorized_for_all_host_commands"      ? string
-	"statusmap_background_image"    ? string
-	"default_statusmap_layout"  : long = 5
-	"default_statuswrl_layout"  : long = 4
-	"statuswrl_include"         ? string
-	"ping_syntax"               : string = "/bin/ping -n -U -c 5 $HOSTADDRESS$"
-	"refresh_rate"              : long = 90
-	"host_unreachable_sound"    ? string
-	"host_down_sound"           ? string
-	"service_critical_sound"    ? string
-	"service_warning_sound"     ? string
-	"service_unknown_sound"     ? string
-	"normal_sound"              ? string
+    "physical_html_path" : string = "/usr/share/nagios"
+    "url_html_path" : string = "/nagios"
+    "show_context_help" : boolean = false
+    "nagios_check_command" ? string
+    "use_authentication" : boolean = true
+    "default_user_name" ? string
+    "authorized_for_system_information" ? string
+    "authorized_for_configuration_information" ? string
+    "authorized_for_system_commands" ? string
+    "authorized_for_all_services" ? string
+    "authorized_for_all_hosts" ? string
+    "authorized_for_all_service_commands" ? string
+    "authorized_for_all_host_commands" ? string
+    "statusmap_background_image" ? string
+    "default_statusmap_layout" : long = 5
+    "default_statuswrl_layout" : long = 4
+    "statuswrl_include" ? string
+    "ping_syntax" : string = "/bin/ping -n -U -c 5 $HOSTADDRESS$"
+    "refresh_rate" : long = 90
+    "host_unreachable_sound" ? string
+    "host_down_sound" ? string
+    "service_critical_sound" ? string
+    "service_warning_sound" ? string
+    "service_unknown_sound" ? string
+    "normal_sound" ? string
 };
 
 # General options
 type structure_nagios_nagios_cfg = {
-	"log_file" : string = "/var/log/nagios/nagios.log"
-	"object_cache_file" : string = "/var/log/nagios/objects.cache"
-	"resource_file" : string = "/etc/nagios/resource.cfg"
-	"status_file" : string = "/var/log/nagios/status.dat"
-	"nagios_user" : string = "nagios"
-	"nagios_group" : string = "nagios"
-	"check_external_commands" : boolean = false
-	"command_check_interval" : long = -1
-	"command_file" : string = "/var/log/nagios/rw/nagios.cmd"
-	"external_command_buffer_slots" : long = 4096
-	"comment_file" : string = "/var/log/nagios/comments.dat"    # deprecated in Nagios 3
-	"downtime_file" : string = "/var/log/nagios/downtime.dat"   # deprecated in Nagios 3
-	"lock_file" : string = "/var/run/nagios.pid"
-	"temp_file" : string = "/var/log/nagios/nagios.tmp"
-	"event_broker_options" : long = -1
-	"log_rotation_method" : string = "d"
-	"log_archive_path" : string = "/var/log/nagios/archives"
-	"use_syslog" : boolean = true
-	"log_notifications" : boolean = true
-	"log_service_retries" : boolean = true
-	"log_host_retries" : boolean = true
-	"log_event_handlers" : boolean = true
-	"log_initial_states" : boolean = false
-	"log_external_commands" : boolean = true
-	"log_passive_checks" : boolean = true
-	"global_host_event_handler" ? string
-	"service_inter_check_delay_method" : string = "s"
-	"max_service_check_spread" : long = 30
-	"service_interleave_factor" : string = "s"
-	"host_inter_check_delay_method" : string = "s"
-	"max_host_check_spread" : long = 30
-	"max_concurrent_checks" : long = 0
-	"service_reaper_frequency" : long = 10              # deprecated in Nagios 3
-    "check_result_reaper_frequency" ? long              # replaces check_result_reaper_frequency
+    "log_file" : string = "/var/log/nagios/nagios.log"
+    "object_cache_file" : string = "/var/log/nagios/objects.cache"
+    "resource_file" : string = "/etc/nagios/resource.cfg"
+    "status_file" : string = "/var/log/nagios/status.dat"
+    "nagios_user" : string = "nagios"
+    "nagios_group" : string = "nagios"
+    "check_external_commands" : boolean = false
+    "command_check_interval" : long = -1
+    "command_file" : string = "/var/log/nagios/rw/nagios.cmd"
+    "external_command_buffer_slots" : long = 4096
+    "comment_file" : string = "/var/log/nagios/comments.dat" # deprecated in Nagios 3
+    "downtime_file" : string = "/var/log/nagios/downtime.dat" # deprecated in Nagios 3
+    "lock_file" : string = "/var/run/nagios.pid"
+    "temp_file" : string = "/var/log/nagios/nagios.tmp"
+    "event_broker_options" : long = -1
+    "log_rotation_method" : string = "d"
+    "log_archive_path" : string = "/var/log/nagios/archives"
+    "use_syslog" : boolean = true
+    "log_notifications" : boolean = true
+    "log_service_retries" : boolean = true
+    "log_host_retries" : boolean = true
+    "log_event_handlers" : boolean = true
+    "log_initial_states" : boolean = false
+    "log_external_commands" : boolean = true
+    "log_passive_checks" : boolean = true
+    "global_host_event_handler" ? string
+    "service_inter_check_delay_method" : string = "s"
+    "max_service_check_spread" : long = 30
+    "service_interleave_factor" : string = "s"
+    "host_inter_check_delay_method" : string = "s"
+    "max_host_check_spread" : long = 30
+    "max_concurrent_checks" : long = 0
+    "service_reaper_frequency" : long = 10 # deprecated in Nagios 3
+    "check_result_reaper_frequency" ? long # replaces check_result_reaper_frequency
     "max_check_result_reaper_time" ? long
-	"check_result_buffer_slots" ? long
-	"auto_reschedule_checks" : boolean = false
-	"auto_rescheduling_interval" : long = 30
-	"auto_rescheduling_window" : long = 180
-	"sleep_time" : string = "0.25"
-	"service_check_timeout" : long = 40
-	"host_check_timeout" : long = 20
-	"event_handler_timeout" : long = 30
-	"notification_timeout" : long = 30
-	"ocsp_timeout" : long = 5
-	"perfdata_timeout" : long = 5
-	"retain_state_information" : boolean = true
-	"state_retention_file" : string = "/var/log/nagios/retention.dat"
-	"retention_update_interval" : long = 60
-	"use_retained_program_state" : boolean = true
-	"use_retained_scheduling_info" : boolean = false
-	"interval_length" : long = 60
-	"use_aggressive_host_checking" : boolean = false
-	"execute_service_checks" : boolean = true
-	"accept_passive_service_checks" : boolean = false
-	"execute_host_checks" : boolean = true
-	"accept_passive_host_checks" : boolean = true
-	"enable_notifications" : boolean = true
-	"enable_event_handlers" : boolean = true
-	"process_performance_data" : boolean = true
-	"service_perfdata_command" : nagios_commandstrings = list("process-service-perfdata")
-	"host_perfdata_command" : nagios_commandstrings = list("process-host-perfdata")
-	"host_perfdata_file" : string = "/var/log/nagios/host-perf.dat"
-	"service_perfdata_file" : string = "/var/log/nagios/service-perf.dat"
-	"host_perfdata_file_template" : string = "[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$"
-	"service_perfdata_file_template" : string = "[SERVICEPERFDATA]\t$TIMET$\t$HOSTNAME$\t$SERVICEDESC$\t$SERVICEEXECUTIONTIME$\t$SERVICELATENCY$\t$SERVICEOUTPUT$\t$SERVICEPERFDATA$"
-	"host_perfdata_file_mode" : string = "a"
-	"service_perfdata_file_mode" : string = "a"
-	"host_perfdata_file_processing_interval" : long = 0
-	"service_perfdata_file_processing_interval" : long = 0
-	"host_perfdata_file_processing_command" ? nagios_commandstrings
-	"service_perfdata_file_processing_command" ? nagios_commandstrings
-	"obsess_over_services" : boolean = false
-	"check_for_orphaned_services" : boolean = true
-	"check_service_freshness" : boolean = true
-	"service_freshness_check_interval" : long = 60
-	"check_host_freshness" : boolean = true
-	"host_freshness_check_interval" : long = 60
-	"aggregate_status_updates" : boolean = true             # deprecated in Nagios 3
-	"status_update_interval" : long = 30
-	"enable_flap_detection" : boolean = true
-	"low_service_flap_threshold" : long = 15
-	"high_service_flap_threshold" : long = 25
-	"low_host_flap_threshold" : long = 5
-	"high_host_flap_threshold" : long = 20
-	"date_format" : string = "euro"
-	"p1_file" : string = "/usr/bin/p1.pl"
-	"illegal_object_name_chars" : string = "`~!$%^&*|'<>?,()\"" 
-	"illegal_macro_output_chars" : string = "`~$^&|'<>\""
-	"use_regexp_matching" : boolean = true
-	"use_true_regexp_matching" : boolean = false
-	"admin_email" : string = "nagios"
-	"admin_pager" : string = "pagenagios"
-	"daemon_dumps_core" : boolean = false
-	# To be used on Nagios v3
-	"check_result_path" ? string
-	"precached_object_file" ? string
-	"temp_path" ? string
-	"retained_host_attribute_mask" ? long
-	"retained_service_attribute_mask" ? long
-	"retained_process_host_attribute_mask" ? long
-	"retained_process_service_attribute_mask" ? long
-	"retained_contact_host_attribute_mask" ? long
-	"retained_contact_service_attribute_mask" ? long
-	"max_check_result_file_age" ? long
-	"translate_passive_host_checks" ? boolean
-	"passive_host_checks_are_soft" ? boolean
-	"enable_predictive_host_dependency_checks" ? boolean
-	"enable_predictive_service_dependency_checks" ? boolean
-	"cached_host_check_horizon" ? long
-	"cached_service_check_horizon" ? long
-	"use_large_installation_tweaks" ? boolean
-	"free_child_process_memory" ? boolean
-	"child_processes_fork_twice" ? boolean
-	"enable_environment_macros" ? boolean
-	"soft_state_dependencies" ? boolean
-	"ochp_timeout" ? long
-	"ochp_command" ? string
-	"use_timezone" ? string
-	"broker_module" ? string[]
-	"debug_file" ? string
-	"debug_level" ? long
-	"debug_verbosity" ? long (0..2)
-	"max_debug_file_size" ? long
+    "check_result_buffer_slots" ? long
+    "auto_reschedule_checks" : boolean = false
+    "auto_rescheduling_interval" : long = 30
+    "auto_rescheduling_window" : long = 180
+    "sleep_time" : string = "0.25"
+    "service_check_timeout" : long = 40
+    "host_check_timeout" : long = 20
+    "event_handler_timeout" : long = 30
+    "notification_timeout" : long = 30
+    "ocsp_timeout" : long = 5
+    "perfdata_timeout" : long = 5
+    "retain_state_information" : boolean = true
+    "state_retention_file" : string = "/var/log/nagios/retention.dat"
+    "retention_update_interval" : long = 60
+    "use_retained_program_state" : boolean = true
+    "use_retained_scheduling_info" : boolean = false
+    "interval_length" : long = 60
+    "use_aggressive_host_checking" : boolean = false
+    "execute_service_checks" : boolean = true
+    "accept_passive_service_checks" : boolean = false
+    "execute_host_checks" : boolean = true
+    "accept_passive_host_checks" : boolean = true
+    "enable_notifications" : boolean = true
+    "enable_event_handlers" : boolean = true
+    "process_performance_data" : boolean = true
+    "service_perfdata_command" : nagios_commandstrings = list("process-service-perfdata")
+    "host_perfdata_command" : nagios_commandstrings = list("process-host-perfdata")
+    "host_perfdata_file" : string = "/var/log/nagios/host-perf.dat"
+    "service_perfdata_file" : string = "/var/log/nagios/service-perf.dat"
+    "host_perfdata_file_template" : string = "[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$"
+    "service_perfdata_file_template" : string = "[SERVICEPERFDATA]\t$TIMET$\t$HOSTNAME$\t$SERVICEDESC$\t$SERVICEEXECUTIONTIME$\t$SERVICELATENCY$\t$SERVICEOUTPUT$\t$SERVICEPERFDATA$"
+    "host_perfdata_file_mode" : string = "a"
+    "service_perfdata_file_mode" : string = "a"
+    "host_perfdata_file_processing_interval" : long = 0
+    "service_perfdata_file_processing_interval" : long = 0
+    "host_perfdata_file_processing_command" ? nagios_commandstrings
+    "service_perfdata_file_processing_command" ? nagios_commandstrings
+    "obsess_over_services" : boolean = false
+    "check_for_orphaned_services" : boolean = true
+    "check_service_freshness" : boolean = true
+    "service_freshness_check_interval" : long = 60
+    "check_host_freshness" : boolean = true
+    "host_freshness_check_interval" : long = 60
+    "aggregate_status_updates" : boolean = true # deprecated in Nagios 3
+    "status_update_interval" : long = 30
+    "enable_flap_detection" : boolean = true
+    "low_service_flap_threshold" : long = 15
+    "high_service_flap_threshold" : long = 25
+    "low_host_flap_threshold" : long = 5
+    "high_host_flap_threshold" : long = 20
+    "date_format" : string = "euro"
+    "p1_file" : string = "/usr/bin/p1.pl"
+    "illegal_object_name_chars" : string = "`~!$%^&*|'<>?,()\""
+    "illegal_macro_output_chars" : string = "`~$^&|'<>\""
+    "use_regexp_matching" : boolean = true
+    "use_true_regexp_matching" : boolean = false
+    "admin_email" : string = "nagios"
+    "admin_pager" : string = "pagenagios"
+    "daemon_dumps_core" : boolean = false
+    # To be used on Nagios v3
+    "check_result_path" ? string
+    "precached_object_file" ? string
+    "temp_path" ? string
+    "retained_host_attribute_mask" ? long
+    "retained_service_attribute_mask" ? long
+    "retained_process_host_attribute_mask" ? long
+    "retained_process_service_attribute_mask" ? long
+    "retained_contact_host_attribute_mask" ? long
+    "retained_contact_service_attribute_mask" ? long
+    "max_check_result_file_age" ? long
+    "translate_passive_host_checks" ? boolean
+    "passive_host_checks_are_soft" ? boolean
+    "enable_predictive_host_dependency_checks" ? boolean
+    "enable_predictive_service_dependency_checks" ? boolean
+    "cached_host_check_horizon" ? long
+    "cached_service_check_horizon" ? long
+    "use_large_installation_tweaks" ? boolean
+    "free_child_process_memory" ? boolean
+    "child_processes_fork_twice" ? boolean
+    "enable_environment_macros" ? boolean
+    "soft_state_dependencies" ? boolean
+    "ochp_timeout" ? long
+    "ochp_command" ? string
+    "use_timezone" ? string
+    "broker_module" ? string[]
+    "debug_file" ? string
+    "debug_level" ? long
+    "debug_verbosity" ? long (0..2)
+    "max_debug_file_size" ? long
     "ocsp_command" ? string
 };
-	
+
 type structure_nagios_service_list=structure_nagios_service[];
 
 # Everything that can be handled by this component
 type structure_component_nagios = {
-	include structure_component
-	"hosts"		: structure_nagios_host {}
-	"hosts_generic"  ? structure_nagios_host_generic {}
-	"hostgroups"	? structure_nagios_hostgroup {}
-	"hostdependencies" ? structure_nagios_hostdependency {}
-	"services"	: structure_nagios_service_list {}
-	"servicegroups"	? structure_nagios_servicegroup {}
-	"general"       : structure_nagios_nagios_cfg
-    	"cgi"           ? structure_nagios_cgi_cfg
-	"serviceextinfo" ? structure_nagios_serviceextinfo []
-        "servicedependencies" ?  structure_nagios_servicedependency []
-	"timeperiods"	: structure_nagios_timeperiod {}
-	"contacts"	: structure_nagios_contact {}
-	"contactgroups"	: structure_nagios_contactgroup {}
-	"commands"	: string {}
-	"macros"	? string {}
-	"external_files" ? string[]
-	"external_dirs" ? string[]
-	# Service escalations and dependencies are left for later
-	# versions.
+    include structure_component
+    "hosts" : structure_nagios_host {}
+    "hosts_generic" ? structure_nagios_host_generic {}
+    "hostgroups" ? structure_nagios_hostgroup {}
+    "hostdependencies" ? structure_nagios_hostdependency {}
+    "services" : structure_nagios_service_list {}
+    "servicegroups" ? structure_nagios_servicegroup {}
+    "general" : structure_nagios_nagios_cfg
+    "cgi" ? structure_nagios_cgi_cfg
+    "serviceextinfo" ? structure_nagios_serviceextinfo []
+    "servicedependencies" ?  structure_nagios_servicedependency []
+    "timeperiods" : structure_nagios_timeperiod {}
+    "contacts" : structure_nagios_contact {}
+    "contactgroups" : structure_nagios_contactgroup {}
+    "commands" : string {}
+    "macros" ? string {}
+    "external_files" ? string[]
+    "external_dirs" ? string[]
+    # Service escalations and dependencies are left for later
+    # versions.
 };
 
 bind "/software/components/nagios" = structure_component_nagios;

--- a/ncm-nagios/src/main/pan/components/nagios/schema.pan
+++ b/ncm-nagios/src/main/pan/components/nagios/schema.pan
@@ -4,7 +4,7 @@
 
 declaration template components/nagios/schema;
 
-include {'quattor/schema'};
+include 'quattor/schema';
 
 # Please note that the "use" directive is not supported in order to make
 # validation code easier. If you want hosts to inherit settings then use


### PR DESCRIPTION
Removes duplicate type definitions which allows both components to be included
which gets us one step closer to having unit tests pass on template-library-core.