### PR TITLE
ncm-spma: purge_rep_list - Do nothing if SELF is not defined

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/functions.pan
+++ b/ncm-spma/src/main/pan/components/spma/functions.pan
@@ -101,8 +101,10 @@ function resolve_pkg_rep = {
     arg = repository list
 }
 function purge_rep_list = {
-    foreach (i;rep;SELF) {
-        rep['contents'] = null;
+    if (is_defined(SELF)) {
+        foreach (i;rep;SELF) {
+            rep['contents'] = null;
+        };
     };
     SELF;
 };


### PR DESCRIPTION
Needed to get unit-tests passing on `template-library-core`