### PR TITLE
ncm-download: allow kinit to run in NoAction mode.

### DIFF
--- a/ncm-download/src/main/perl/download.pm
+++ b/ncm-download/src/main/perl/download.pm
@@ -76,7 +76,7 @@ sub Configure {
                 # Assume "kinit" is in the PATH.
                 my $errs = "";
                 my $proc = CAF::Process->new(["kinit", "-k"], stderr => \$errs,
-                        log => $self);
+                        log => $self, keeps_state => 1);
                 $proc->execute();
                 if (!POSIX::WIFEXITED($?) || POSIX::WEXITSTATUS($?) != 0) {
                     $self->error("could not get GSSAPI credentials: $errs");


### PR DESCRIPTION
to prevent failure to get timestamp if gssapi is required and enabled.