### PR TITLE
ncm-modprobe: close the mocked filehandles in the test 

### DIFF
--- a/ncm-modprobe/src/test/perl/process_aliases.t
+++ b/ncm-modprobe/src/test/perl/process_aliases.t
@@ -24,7 +24,7 @@ $CAF::Object::NoAction = 1;
 
 my $cmp = NCM::Component::modprobe->new("modprobe");
 
-my $fh = CAF::FileWriter->new("/etc/modprobe.d");
+my $fh = CAF::FileWriter->new("target/modprobe_process_aliases");
 
 Readonly::Hash my %TREE => (modules => [
         {
@@ -42,3 +42,5 @@ $cmp->process_alias(\%TREE, $fh);
 like($fh, qr{^alias\s+module_alias1\s+module_name1$}m,
      "First alias line rendered correctly");
 unlike($fh, qr{module_name2$}m, "Module without aliases not printed");
+
+$fh->close();

--- a/ncm-modprobe/src/test/perl/process_blacklist.t
+++ b/ncm-modprobe/src/test/perl/process_blacklist.t
@@ -24,7 +24,7 @@ $CAF::Object::NoAction = 1;
 
 my $cmp = NCM::Component::modprobe->new("modprobe");
 
-my $fh = CAF::FileWriter->new("/etc/modprobe.d");
+my $fh = CAF::FileWriter->new("target/modprobe_process_blacklist");
 
 Readonly::Hash my %TREE => (modules => [
         {
@@ -45,3 +45,5 @@ like($fh, qr{^blacklist\s+module_name1$}m,
 like($fh, qr{^blacklist\s+module_name2$}m,
      "Second blacklist line rendered correctly");
 unlike($fh, qr{module_string$}m, "Module string correctly ignored");
+
+$fh->close();

--- a/ncm-modprobe/src/test/perl/process_install.t
+++ b/ncm-modprobe/src/test/perl/process_install.t
@@ -27,7 +27,7 @@ $CAF::Object::NoAction = 1;
 
 my $cmp = NCM::Component::modprobe->new("modprobe");
 
-my $fh = CAF::FileWriter->new("/etc/modprobe.d");
+my $fh = CAF::FileWriter->new("target/modprobe_process_install");
 
 Readonly::Hash my %TREE => (modules => [
         {
@@ -45,3 +45,5 @@ $cmp->process_install(\%TREE, $fh);
 like($fh, qr{^install\s+module_name1\s+module_command$}m,
      "First install line rendered correctly");
 unlike($fh, qr{module_name2$}m, "Module without command not printed");
+
+$fh->close();


### PR DESCRIPTION
Avoids DESTROY issue (see #432)