### PR TITLE
ncm-ccm: use --cfgfile instead of -cfgfile to test new config file

### DIFF
--- a/ncm-ccm/src/main/perl/ccm.pm
+++ b/ncm-ccm/src/main/perl/ccm.pm
@@ -18,7 +18,7 @@ our $EC = LC::Exception::Context->new->will_store_all;
 
 our $NoActionSupported = 1;
 
-use constant TEST_COMMAND => qw(/usr/sbin/ccm-fetch -cfgfile /proc/self/fd/0);
+use constant TEST_COMMAND => qw(/usr/sbin/ccm-fetch --cfgfile /proc/self/fd/0);
 
 # simple private method to test NOQUATTOR (allows mocking)
 sub _is_noquattor


### PR DESCRIPTION
ccm-fetch should be used with --cfgfile instead of -cfgfile, as advertised by CAF::Application (although -cfgfile should work for Appconfig)

partially fixes https://github.com/quattor/release/issues/109#issuecomment-144091675