### PR TITLE
ncm-network: change type of nisdomain to something closer to reality

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -213,7 +213,7 @@ type structure_network = {
     "gatewaydev"       ? string with exists ("/system/network/interfaces/" + SELF)
     "interfaces"       : structure_interface{}
     "nameserver"       ? type_ip[]
-    "nisdomain"        ? type_fqdn
+    "nisdomain"        ? string(1..64) with match(SELF, '^\S+$')
     "nozeroconf"       ? boolean
     "set_hwaddr"       ? boolean
     "nmcontrolled"     ? boolean


### PR DESCRIPTION
A valid NIS domain is (as far as anyone can tell) a string of up to sixty-four non-whitespace characters.

Fixes #604