### PR TITLE
ncm-filecopy, ncm-metaconfig: validate file paths

### DIFF
--- a/ncm-filecopy/src/main/pan/components/filecopy/schema.pan
+++ b/ncm-filecopy/src/main/pan/components/filecopy/schema.pan
@@ -38,7 +38,7 @@ type structure_filecopy = {
 
 type component_filecopy = {
     include structure_component
-    'services'    ? structure_filecopy{}
+    'services' ? structure_filecopy{} with valid_absolute_file_paths(SELF)
     'forceRestart' : boolean = false
 };
 

--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -25,5 +25,5 @@ type ${project.artifactId}_config =  {
 
 type ${project.artifactId}_component = {
     include structure_component
-    'services' : ${project.artifactId}_config{}
+    'services' : ${project.artifactId}_config{} with valid_absolute_file_paths(SELF)
 };


### PR DESCRIPTION
Checks for trailing slashes and throws a helpful error.

Fixes #627, requires quattor/template-library-core#96.