### PR TITLE
Point all 'ncm' links at corresponding 'readthedocs' pages

### DIFF
--- a/ncm-accounts/src/main/perl/accounts.pod
+++ b/ncm-accounts/src/main/perl/accounts.pod
@@ -11,9 +11,9 @@ ncm-accounts: NCM component to manage the local accounts on the machine.
 
 The I<accounts> component manages the local accounts on a machine. LDAP
 authentication depends on the LDAP configuration, which is handled by
-L<ncm-authconfig>.
+L<authconfig|../authconfig/>.
 
-Shadowing of passwords is also controlled by L<ncm-authconfig>.
+Shadowing of passwords is also controlled by L<authconfig|../authconfig/>.
 
 =head1 FUNCTIONS
 
@@ -287,10 +287,10 @@ B<won't> be fixed.
 The component has been tested with C<files> as the primary source on
 /etc/nsswitch.conf for I<group> and I<passwd>. Different settings may
 produce strange behaviour. These settings are not controlled by
-ncm-accounts but by L<ncm-authconfig>.
+ncm-accounts but by L<authconfig|../authconfig/>.
 
 =head1 SEE ALSO
 
-L<authconfig|http://quattor-core.readthedocs.org/en/14.10.0/components/authconfig/>
+L<authconfig|../authconfig/>
 
 =cut

--- a/ncm-accounts/src/main/perl/accounts.pod
+++ b/ncm-accounts/src/main/perl/accounts.pod
@@ -90,7 +90,7 @@ It updates a structure_accounts (return value may be assigned to "/software/comp
 =head2 keep_user_group(user_or_group:string or list of string)
 
 This functions adds a user or group to the kept_users or kept_groups resources. The
-argument can be a string or list of strings. The return value can be assigned to 
+argument can be a string or list of strings. The return value can be assigned to
 /software/components/accounts/kept_users or /software/components/accounts/kept_groups.
 
 =head1 RESOURCES
@@ -141,7 +141,7 @@ be kept.
 
 the shell for the user. If it is defined as an empty string, the current shell
 is preserved for an existing account (for a new account, it will remain undefined,
-meaning that the default shell on the system will be used). 
+meaning that the default shell on the system will be used).
 
 Defaults to /bin/bash.
 
@@ -236,7 +236,7 @@ default is false.  The root account can never be removed.
 =head2 /software/components/accounts/preserved_accounts
 
 This property may have 3 values: 'none', 'system', 'dyn_user_group'. It controls
-the accounts/groups that have to be preserved when 'remove_unknown' is true 
+the accounts/groups that have to be preserved when 'remove_unknown' is true
 (it has no effect when remove_unknown=false).
 
 The effect of each possible value is
@@ -254,7 +254,7 @@ login_defs/gid_min properties to control the preserved ranges.
 
 all accounts/groups in the system range and in the
 range used for dynamic uid/gid allocation by useradd command, ie. all
-accounts/groups with uid/gid less or equal to GID/UID_MAX as defined in 
+accounts/groups with uid/gid less or equal to GID/UID_MAX as defined in
 /etc/login.defs, are preserved. The exact list of accounts preserved
 depends on UID/GID_MAX value. It is possible to use login_defs/uid_max and
 login_defs/gid_max properties to control the preserved ranges. Not that
@@ -291,6 +291,6 @@ ncm-accounts but by L<ncm-authconfig>.
 
 =head1 SEE ALSO
 
-L<ncm-authconfig>
+L<authconfig|http://quattor-core.readthedocs.org/en/14.10.0/components/authconfig/>
 
 =cut

--- a/ncm-aiiserver/src/main/perl/aiiserver.pod
+++ b/ncm-aiiserver/src/main/perl/aiiserver.pod
@@ -26,12 +26,12 @@ OPTIONS for more information.
 Configures the aii-dhcp legacy tool. See L<aii-dhcp(8)>, section
 OPTIONS for more information.
 
-This components also uses configuration parameters related to https from L<ncm-ccm>: ca_dir, ca_file, cert_file, key_file.
+This components also uses configuration parameters related to https from L<ccm|../ccm>: ca_dir, ca_file, cert_file, key_file.
 
 =back
 
 =head1 SEE ALSO
 
-L<aii-shellfe(8)>, L<aii-dhcp(8)>, L<aii>, L<ncm-ccm>
+L<aii-shellfe(8)>, L<aii-dhcp(8)>, L<aii>, L<ccm|../ccm>
 
 =cut

--- a/ncm-fstab/src/main/perl/fstab.pod
+++ b/ncm-fstab/src/main/perl/fstab.pod
@@ -21,6 +21,6 @@ https://twiki.cern.ch/twiki/bin/view/FIOgroup/TsiCDBBlockDevices
 
 =head1 SEE ALSO
 
-L<ncm-filesystems>
+L<filesystems|../filesystems>
 
 =cut


### PR DESCRIPTION
Partially resolves quattor/quattor.github.com#128