### PR TITLE
ncm-hostsfile: fix removal of old entries which were managed by NCM.

### DIFF
--- a/ncm-hostsfile/src/main/perl/hostsfile.pm
+++ b/ncm-hostsfile/src/main/perl/hostsfile.pm
@@ -218,7 +218,7 @@ sub Configure {
             if (exists $newncmhosts{$h}) {
                 $le = delete $newncmhosts{$h};
             } elsif (exists $ncmhosts{$h}) {
-                $le = delete $ncmhosts{$h};
+                next;
             } else {
                 $le = delete $non_ncm_hosts{$h};
             }


### PR DESCRIPTION
The logging declares its intent to remove some entries which were
previously managed by NCM, but then adds them into the file output
instead of skipping them.