### PR TITLE
ncm-ssh: make config checks configurable.

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -117,6 +117,8 @@ type ssh_daemon_type = {
     "options" ? ssh_daemon_options_type
     "comment_options" ? ssh_daemon_options_type
     "sshd_path" ? string
+    @{if false and sshd doesn't exist, skip config validation}
+    "always_validate" : boolean = true
     "config_path" ? string
 };
 

--- a/ncm-ssh/src/main/perl/ssh.pm
+++ b/ncm-ssh/src/main/perl/ssh.pm
@@ -30,9 +30,16 @@ sub valid_sshd_file
 {
     my ($self, $file, $cfg) = @_;
 
+    my $sshd_bin = $cfg->{sshd_path} || DEFAULT_SSHD_PATH;
+    
+    if (defined($cfg->{always_validate}) && !$cfg->{always_validate} && ! -x $sshd_bin) {
+        $self->info("$sshd_bin doesn't exist with always_validate=0, skipping sshd config test.");
+        return 1;
+    }
+
     # Use /dev/stdin, instead of /proc/self/fd/0 (which is used in some other components).
     # This is because /proc/self/fd/0 does not exist on Solaris. 
-    my $cmdline = [ $cfg->{sshd_path} || DEFAULT_SSHD_PATH, '-t', '-f', '/dev/stdin' ];
+    my $cmdline = [ $sshd_bin, '-t', '-f', '/dev/stdin' ];
 
     my $cmd = CAF::Process->new(
         $cmdline,


### PR DESCRIPTION
small oversight on my part in the previous PR regarding this component during build time for us. sshd is on a network FS which isn't available at build time, so I've added a new param where you can make this check skip if sshd isn't existing.

existing behaviour, to always check, is still the default.