### PR TITLE
ncm-metaconfig: publish component version

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/config.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/config.pan
@@ -17,3 +17,4 @@ prefix '/software/components/${project.artifactId}';
 'active' ?= true;
 'dispatch' ?= true;
 'dependencies/pre' ?= list('spma');
+'version' = '${no-snapshot-version}';


### PR DESCRIPTION
Not having the version published makes `metaconfig` usage complicated in templates that must still support Quattor 13.1. It'd be great to have it fixed in 15.12 but I don't dare to ask for it...!!!