### PR TITLE
ncm-metaconfig: increase default verbosity to track changes/actions at info level

### DIFF
--- a/ncm-metaconfig/src/test/perl/actions.t
+++ b/ncm-metaconfig/src/test/perl/actions.t
@@ -2,14 +2,16 @@
 # -*- mode: cperl -*-
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 22;
 use Test::Quattor qw(actions_daemons actions_nodaemons);
 use Test::MockModule;
 use NCM::Component::metaconfig;
 use CAF::Object;
 use CAF::FileWriter;
+use Readonly;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 my $mock = Test::MockModule->new('CAF::Service');
 our ($restart, $reload);
@@ -22,13 +24,6 @@ $mock->mock('reload', sub {
     $reload += scalar @{$self->{services}}; 
 });
 
-my $pretend_changed;
-
-no warnings 'redefine';
-*CAF::FileWriter::close = sub {
-    return $pretend_changed;
-};
-use warnings 'redefine';
 
 =pod
 
@@ -91,29 +86,59 @@ Test taking actions by whole Configure method
 
 =cut
 
+# Keep consistent with test profiles
+Readonly my $FILE1_NAME => '/foo/bar';
+Readonly my $FILE2_NAME => '/foo/bar2';
+Readonly my $FILE1_CONTENT => '{"foo":"bar"}
+';
+Readonly my $FILE2_CONTENT => '{"foo":"bar"}
+';
 
 my $cfg_d = get_config_for_profile('actions_daemons');
 my $cfg_nd = get_config_for_profile('actions_nodaemons');
+my $fh;
 
 $restart = $reload = 0;
+set_file_contents($FILE1_NAME, $FILE1_CONTENT);
+set_file_contents($FILE2_NAME, $FILE2_CONTENT);
+is($cmp->Configure($cfg_d), 1, 'Configure actions_daemons returned 1');
+# File contents is checked just to ensure that internal consistency is ok.
+# An error here is probably the sign of an inconsistency between the unit test
+# and the profiles used.
+# No need to check for both $cfg_d and $cfg_nd as file contents is identical.
+$fh = get_file($FILE1_NAME);
+is("$fh", $FILE1_CONTENT, "$FILE1_NAME has expected contents");
+$fh = get_file($FILE2_NAME);
+is("$fh", $FILE2_CONTENT, "$FILE2_NAME has expected contents");
 is($cmp->Configure($cfg_d), 1, 'Configure actions_daemons returned 1');
 is($restart, 0, '0 restarts triggered (daemons configured, no file changes)');
 is($reload, 0, '0 reload triggered (daemons configured, no file changes)');
 
 $restart = $reload = 0;
+set_file_contents($FILE1_NAME, $FILE1_CONTENT);
+set_file_contents($FILE2_NAME, $FILE2_CONTENT);
 is($cmp->Configure($cfg_nd), 1, 'Configure actions_nodaemons returned 1');
 is($restart, 0, '0 restarts triggered (no daemons configured, no file changes)');
 is($reload, 0, '0 reload triggered (no daemons configured, no file changes)');
 
-# all files are changed files
-$pretend_changed=1;
-
 $restart = $reload = 0;
+set_file_contents($FILE1_NAME, '');
+set_file_contents($FILE2_NAME, '');
 is($cmp->Configure($cfg_d), 1, 'Configure actions_daemons returned 1');
+# File contents is checked just to ensure that internal consistency is ok.
+# An error here is probably the sign of an inconsistency between the unit test
+# and the profiles used.
+# No need to check for both $cfg_d and $cfg_nd as file contents is identical.
+$fh = get_file($FILE1_NAME);
+is("$fh", $FILE1_CONTENT, "$FILE1_NAME has expected contents");
+$fh = get_file($FILE2_NAME);
+is("$fh", $FILE2_CONTENT, "$FILE2_NAME has expected contents");
 is($restart, 1, '1 restarts triggered (daemons configured, file changes)');
 is($reload, 1, '1 reload triggered (daemons configured, file changes)');
 
 $restart = $reload = 0;
+set_file_contents($FILE1_NAME, '');
+set_file_contents($FILE2_NAME, '');
 is($cmp->Configure($cfg_nd), 1, 'Configure actions_nodaemons returned 1');
 is($restart, 0, '0 restarts triggered (no daemons configured, file changes)');
 is($reload, 0, '0 reload triggered (no daemons configured, file changes)');

--- a/ncm-metaconfig/src/test/perl/choose-module.t
+++ b/ncm-metaconfig/src/test/perl/choose-module.t
@@ -10,6 +10,7 @@ use CAF::Object;
 
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 
 =pod

--- a/ncm-metaconfig/src/test/perl/configure.t
+++ b/ncm-metaconfig/src/test/perl/configure.t
@@ -11,6 +11,7 @@ use CAF::Object;
 use JSON::XS;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 my $mock = Test::MockModule->new('NCM::Component::metaconfig');
 

--- a/ncm-metaconfig/src/test/perl/error.t
+++ b/ncm-metaconfig/src/test/perl/error.t
@@ -8,6 +8,7 @@ use NCM::Component::metaconfig;
 use CAF::Object;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 
 =pod

--- a/ncm-metaconfig/src/test/perl/json.t
+++ b/ncm-metaconfig/src/test/perl/json.t
@@ -10,6 +10,7 @@ use CAF::Object;
 use JSON::Any;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 
 =pod

--- a/ncm-metaconfig/src/test/perl/properties.t
+++ b/ncm-metaconfig/src/test/perl/properties.t
@@ -10,6 +10,7 @@ use CAF::Object;
 use Config::Properties;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 =pod
 

--- a/ncm-metaconfig/src/test/perl/tiny.t
+++ b/ncm-metaconfig/src/test/perl/tiny.t
@@ -11,6 +11,7 @@ use Readonly;
 use Config::Tiny;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 Readonly my $STR => "An arbitrary string";
 

--- a/ncm-metaconfig/src/test/perl/tt.t
+++ b/ncm-metaconfig/src/test/perl/tt.t
@@ -15,6 +15,7 @@ use Template;
 use Readonly;
 
 $CAF::Object::NoAction = 1;
+set_caf_file_close_diff(1);
 
 my $mock = Test::MockModule->new('CAF::TextRender');
 $mock->mock('new', sub {


### PR DESCRIPTION
- Adapt unit tests to changes
- Fix #664