### PR TITLE
ncm-metaconfig: service logstash: filter grok: the match pattern support a list of patterns

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/config.pan
@@ -88,7 +88,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
         nlist("grok", nlist(
             "match", list(nlist(
                 "name", "message", 
-                "pattern", "%{GPFSLOG}"
+                "pattern", list("%{GPFSLOG}"),
                 )),
             "patterns_dir", list("/usr/share/grok"),
             "add_field", nlist("program", "gpfs"),

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/profiles/server.pan
@@ -48,7 +48,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
         nlist("grok", nlist(
             "match", list(nlist(
                 "name", "message", 
-                "pattern", "%{RSYSLOGCUSTOM}"
+                "pattern", list("%{RSYSLOGCUSTOM}"),
                 )),
             "patterns_dir", list("/usr/share/grok"),
             "add_field", nlist(

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/config/base
@@ -33,7 +33,7 @@ filter \{$
 ^\s{12}named_captures_only => true$
 ^\s{12}patterns_dir => \[ "/usr/share/grok" \]$
 ^\s{12}match => \{$
-^\s{16}"message" => "%\{GPFSLOG\}"$
+^\s{16}"message" => \["%\{GPFSLOG\}"\]$
 ^\s{12}\}$
 ^\s{8}\}$
 ^\s{8}date \{$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/server/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/1.2/tests/regexps/server/base
@@ -38,7 +38,7 @@ filter \{$
 ^\s{12}named_captures_only => true$
 ^\s{12}patterns_dir => \[ "/usr/share/grok" \]$
 ^\s{12}match => \{$
-^\s{16}"message" => "%\{RSYSLOGCUSTOM\}"$
+^\s{16}"message" => \["%\{RSYSLOGCUSTOM\}"\]$
 ^\s{12}}$
 ^\s{8}\}$
 ^\s{8}kv \{$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/config.pan
@@ -90,7 +90,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
         nlist("grok", nlist(
             "match", list(nlist(
                 "name", "message", 
-                "pattern", "%{GPFSLOG}"
+                "pattern", list("%{GPFSLOG}"),
                 )),
             "patterns_dir", list("/usr/share/grok"),
             "add_field", nlist("program", "gpfs"),

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
@@ -50,7 +50,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
         nlist("grok", nlist(
             "match", list(nlist(
                 "name", "message", 
-                "pattern", "%{RSYSLOGCUSTOM}"
+                "pattern", list("%{RSYSLOGCUSTOM}", "%{OTHERPATTERN}"),
                 )),
             "patterns_dir", list("/usr/share/grok"),
             "add_field", nlist(

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/config/base
@@ -33,7 +33,7 @@ filter \{$
 ^\s{12}named_captures_only => true$
 ^\s{12}patterns_dir => \[ "/usr/share/grok" \]$
 ^\s{12}match => \{$
-^\s{16}"message" => "%\{GPFSLOG\}"$
+^\s{16}"message" => \["%\{GPFSLOG\}"\]$
 ^\s{12}\}$
 ^\s{8}\}$
 ^\s{8}if \(\[sometag\] !~ '\^SOME_STRING'\) {

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/server/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/server/base
@@ -38,7 +38,7 @@ filter \{$
 ^\s{12}named_captures_only => true$
 ^\s{12}patterns_dir => \[ "/usr/share/grok" \]$
 ^\s{12}match => \{$
-^\s{16}"message" => "%\{RSYSLOGCUSTOM\}"$
+^\s{16}"message" => \["%\{RSYSLOGCUSTOM\}","%\{OTHERPATTERN\}"\]$
 ^\s{12}}$
 ^\s{8}\}$
 ^\s{8}kv \{$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/types/name_pattern.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/types/name_pattern.tt
@@ -1,7 +1,12 @@
 [%- key %] => {
 [% FILTER indent -%]
 [%-     FOREACH p IN value -%]
-"[%         p.name %]" => "[% p.pattern %]"
+"[%         p.name %]" => 
+[%-         IF CCM.is_list(p.pattern) -%]
+["[%            p.pattern.join('","') %]"]
+[%-         ELSE -%]
+"[%             p.pattern %]"
+[%-         END %]
 [%     END -%]
 [%- END %]
 }[%- -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -130,12 +130,18 @@ type logstash_input_plugin = {
 @{ Base for all filters }
 type logstash_name_pattern = {
     "name" : string
-    "pattern": string
+    "pattern" : string
 };
 
+type logstash_name_patterns = {
+    "name" : string
+    "pattern" : string[]
+};
+
+@{A name_patternlist is rendered differently than a name_patterns}
 type logstash_filter_name_patternlist = {
     "name" : string
-    "pattern": string[]
+    "pattern" : string[]
 };
 
 type logstash_filter_plugin_common = {
@@ -148,7 +154,7 @@ type logstash_filter_plugin_common = {
 
 type logstash_filter_grok = {
     include logstash_filter_plugin_common
-    "match" ? logstash_name_pattern[]
+    "match" ? logstash_name_patterns[]
     "break_on_match" : boolean = true
     "drop_if_match" ? boolean
     "keep_empty_captures" ? boolean


### PR DESCRIPTION
The logstash grok filter supports a list of patterns  as value for each match.