### PR TITLE
ncm-ceph: ceph uid for infernalis

### DIFF
--- a/ncm-ceph/src/main/pan/components/ceph/ceph-user.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/ceph-user.pan
@@ -12,7 +12,7 @@ include 'components/accounts/config';
 variable CEPH_OLD_UID ?= true; # set to false for new clusters, especially infernalis and above
 variable CEPH_USER_ID = {
     if (CEPH_OLD_UID) {
-        deprecated(0, 'ceph user should get a new uid');
+        deprecated(0, 'ceph user should get a new uid. set final CEPH_OLD_UID = false');
         111;
     } else {
         167;

--- a/ncm-ceph/src/main/pan/components/ceph/ceph-user.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/ceph-user.pan
@@ -6,14 +6,25 @@
 
 unique template components/${project.artifactId}/ceph-user;
 
-include { 'components/accounts/config' };
+include 'components/accounts/config';
+
+# do not change uids of existing cluster
+variable CEPH_OLD_UID ?= true; # set to false for new clusters, especially infernalis and above
+variable CEPH_USER_ID = {
+    if (CEPH_OLD_UID) {
+        deprecated(0, 'ceph user should get a new uid');
+        111;
+    } else {
+        167;
+    };
+};
 
 prefix '/software/components/accounts';
 
-"groups/ceph" = nlist("gid", 111);
+"groups/ceph" = nlist("gid", CEPH_USER_ID);
 
 "users/ceph" = nlist(
-    "uid", 111,
+    "uid", CEPH_USER_ID,
     "groups", list("ceph"),
     "comment","ceph",
     "shell", "/bin/sh",


### PR DESCRIPTION
Infernalis wants a specific uid for the ceph user. To be backwards compatible with running cluster, by default nothing changes, but a deprecated message is added. When installing new clusters, or going to infernalis, you should set CEPH_OLD_UID to false