### PR TITLE
ncm-systemd: allow non-listed unit(file)s that have valid show data

### DIFF
--- a/ncm-systemd/src/main/perl/Systemd/Systemctl.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Systemctl.pm
@@ -137,7 +137,7 @@ sub systemctl_show
     # output is k=[v]
     # some keys will be split on whitespace
     #  - when extending this list, update the pod!
-    my $res={};
+    my $res = {};
     while($output =~ m/^([^=\s]+)\s*=(.*)?$/mg) {
         my ($k,$v) = ($1,"$2");
         if (grep {$_ eq $k} @PROPERTIES_ARRAY) {


### PR DESCRIPTION
Fixes #677 
Based on #615 