### PR TITLE
ncm-symlink: fix message for duplicated links

### DIFF
--- a/ncm-symlink/src/main/perl/symlink.pm
+++ b/ncm-symlink/src/main/perl/symlink.pm
@@ -81,7 +81,8 @@ sub Configure($$@) {
                 my $link_name = $link_options{name}->getValue();
 
                 if ( exists($links{$link_name}) ) {
-                    $self->warn("Duplicate link $link_name defined in profile. Replacing previous definition target ".$links{$link_name}{target});
+                    $self->warn("Duplicate link $link_name defined in profile. Replacing previous definition target ",
+                                $links{$link_name}{target}->getValue());
                 }
                 $links{$link_name} = \%link_options;
             }


### PR DESCRIPTION
This is a quick fix for a component that deserves a full rewrite (#683) using the `getTree()` API...