### PR TITLE
ncm-systemd: always use systemctl show data for non-listed unit

### DIFF
--- a/ncm-systemd/src/main/perl/Systemd/Service/Unit.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service/Unit.pm
@@ -726,22 +726,23 @@ sub make_cache_alias
         if (! defined($data)) {
             my $log_method = "error";
             my $continue;
-            if (grep {$_ eq $unit} @$possible_missing) {
-                $self->debug(1, "Unit $unit is in possible_missing (and not found). ",
-                             "No error will be logged.");
+
+            # Always try to get show information, even for possible missing units
+            $show = systemctl_show($self, $unit);
+            if(defined($show->{$PROPERTY_ID})) {
+                $self->debug(1, "Unit $unit not listed but has show data.");
                 $log_method = "verbose";
+                $continue = "Found unit via systemctl show.";
+                # Insert unit in cache
+                $unit_cache->{$unit}->{showonly} = 1;
+                # Reassign $data
+                $data = $unit_cache->{$unit};
             } else {
-                $show = systemctl_show($self, $unit);
-                if(defined($show->{$PROPERTY_ID})) {
-                    $self->debug(1, "Unit $unit not listed but has show data.");
+                $self->debug(1, "Unit $unit not listed and has no show data.");
+                if (grep {$_ eq $unit} @$possible_missing) {
+                    $self->debug(1, "Unit $unit is in possible_missing (and not found). ",
+                                 "No error will be logged.");
                     $log_method = "verbose";
-                    $continue = "Found unit via systemctl show.";
-                    # Insert unit in cache
-                    $unit_cache->{$unit}->{showonly} = 1;
-                    # Reassign $data
-                    $data = $unit_cache->{$unit};
-                } else {
-                    $self->debug(1, "Unit $unit not listed but and has no show data.");
                 }
             }
 

--- a/ncm-systemd/src/test/perl/service-unit.t
+++ b/ncm-systemd/src/test/perl/service-unit.t
@@ -676,7 +676,8 @@ $unit->init_cache();
 $cmp->{ERROR} = 0;
 
 ($cache, $alias) = $unit->make_cache_alias(['netconsole.service']);
-ok(! defined($cache->{'netconsole.service'}), "no cache after unknown service (not listed, no show)");
+ok(! defined($cache->{'netconsole.service'}),
+   "no cache after unknown service (not listed, no show)");
 is($cmp->{ERROR}, 1, "an error was reported when handling unknown service (not listed, no show)");
 
 # set as possible missing
@@ -684,7 +685,8 @@ $unit->init_cache();
 $cmp->{ERROR} = 0;
 
 ($cache, $alias) = $unit->make_cache_alias(['netconsole.service'], ['netconsole.service']);
-ok(! defined($cache->{'netconsole.service'}), "no cache after unknown service (not listed, no show, possible missing)");
+ok(! defined($cache->{'netconsole.service'}),
+   "no cache after unknown service (not listed, no show, possible missing)");
 is($cmp->{ERROR}, 0, "no error was reported when handling unknown service (not listed, no show, possible missing)");
 
 # minimal show data
@@ -701,11 +703,22 @@ $unit->init_cache();
 $cmp->{ERROR} = 0;
 
 ($cache, $alias) = $unit->make_cache_alias(['netconsole.service']);
-ok($cache->{'netconsole.service'}->{showonly}, 'showonly cache attribute set when handling unknown service (not listed, with show)');
+ok($cache->{'netconsole.service'}->{showonly},
+   'showonly cache attribute set when handling unknown service (not listed, with show)');
 is_deeply($cache->{'netconsole.service'}->{show}, {
     Id => 'netconsole.service',
     Names => ['netconsole.service'],
 }, "cache after unknown service (not listed, with show)");
 is($cmp->{ERROR}, 0, "no error was reported when handling unknown service (not listed, with show)");
+
+# also with netconsole as possible_missing service
+($cache, $alias) = $unit->make_cache_alias(['netconsole.service'], ['netconsole.service']);
+ok($cache->{'netconsole.service'}->{showonly},
+   'showonly cache attribute set when handling unknown service (not listed, with show, possible_missing)');
+is_deeply($cache->{'netconsole.service'}->{show}, {
+    Id => 'netconsole.service',
+    Names => ['netconsole.service'],
+}, "cache after unknown service (not listed, with show, possible_missing)");
+is($cmp->{ERROR}, 0, "no error was reported when handling unknown service (not listed, with show, possible_missing)");
 
 done_testing();


### PR DESCRIPTION
Fixes #686