### PR TITLE
ncm-metaconfig: service logstash: use a sensible type for mutate convert

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
@@ -107,11 +107,8 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
                     "join", "and",
                     "left", "[jube_id]",
                 ))),
-            "convert", list(
-                nlist(
-                    "name", "success",
-                    "pattern", "boolean"
-                )
+            "convert", dict(
+                "success", "boolean"
             ))),
         nlist("bytes2human", nlist(
             "convert", nlist(

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/filter/mutate.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/filter/mutate.tt
@@ -1,3 +1,3 @@
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringarray" names=['exclude_tags'] -%]
-[%- INCLUDE "metaconfig/logstash/config/type.tt" type="name_pattern" names=['replace', 'convert'] -%]
-[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['split', 'rename'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="name_pattern" names=['replace'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['split', 'rename', 'convert'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -185,9 +185,11 @@ type logstash_filter_drop = {
     "periodic_flush" ? boolean
 };
 
+type logstash_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
+
 type logstash_filter_mutate = {
     include logstash_filter_plugin_common
-    "convert" ? logstash_name_pattern[]
+    "convert" ? logstash_filter_mutate_convert{}
     "replace" ? logstash_name_pattern[]
     "rename" ? string{}
     "split" ? string{}


### PR DESCRIPTION
Fixes #690 