### PR TITLE
ncm-metaconfig: add timestream basic config

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/xinetd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/pan/schema.pan
@@ -19,8 +19,8 @@ type xinetd_options = {
 
     "socket_type" : string with match(SELF,'^(stream|dgram|raw|seqpacket)$')
     "user" : string = 'root'
-    "server" : string
-    "protocol" : string with match(SELF,'^(udp|tcp)$') # actually, anything in /etc/protocols
+    "server" ? string
+    "protocol" ? string with match(SELF,'^(udp|tcp)$') # actually, anything in /etc/protocols
     "server_args" ? string
     "group" ? string
     "instances" ? long(0..) # if not defined, it's UNLIMITED

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/pan/services/time-stream.pan
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/pan/services/time-stream.pan
@@ -1,0 +1,15 @@
+unique template metaconfig/xinetd/services/time-stream;
+
+include 'metaconfig/xinetd/schema';
+
+bind "/software/components/metaconfig/services/{/etc/xinetd.d/time-stream}/contents" = xinetd_conf;
+
+"/software/components/metaconfig/services/{/etc/xinetd.d/time-stream}" = create('metaconfig/xinetd/metaconfig');
+
+prefix "/software/components/metaconfig/services/{/etc/xinetd.d/time-stream}/contents";
+"servicename" = "time";
+"options/disable" = false;
+"options/id" = "time-stream";
+"options/type" = list("INTERNAL");
+"options/wait"= false;
+"options/socket_type" = "stream";

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/tests/profiles/time-stream.pan
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/tests/profiles/time-stream.pan
@@ -1,0 +1,4 @@
+object template time-stream;
+
+include 'metaconfig/xinetd/services/time-stream';
+

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/time-stream/base
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/time-stream/base
@@ -1,0 +1,14 @@
+Base test for config
+---
+multiline
+metaconfigservice=/etc/xinetd.d/time-stream
+---
+^service\stime$
+^{$
+^\s{4}cps\s=\s100 2$
+^\s{4}disable\s=\sno$
+^\s{4}per_source\s=\s11$
+^\s{4}socket_type\s=\sstream$
+^\s{4}user\s=\sroot$
+^\s{4}wait\s=\sno$
+^}$


### PR DESCRIPTION
we used to enable time-stream through chkconfig. because of https://github.com/quattor/configuration-modules-core/issues/693 we now want it do it through metaconfig. So this adds support for time-stream.