### PR TITLE
metaconfig: service logstash: support escaped add_field keys

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
@@ -118,7 +118,19 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
             "convert", dict(
                 "success", "boolean"
                 ),
+            )),
+        nlist("mutate", nlist(
             "add_field", nlist(
+                escape("[@metadata][target_index]"), "longterm-%{+YYYY.MM.dd}",
+                ),
+            )),
+        nlist("mutate", nlist(
+            "_conditional", nlist("expr", list(nlist(
+                "left", "[program]",
+                "test", "==",
+                "right", "\"jube\"",
+                ))),
+            "update", nlist(
                 escape("[@metadata][target_index]"), "longterm-%{+YYYY.Q}",
                 ),
             )),

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/profiles/server.pan
@@ -13,7 +13,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
 
 # gelf input
 "input/plugins" = append(nlist("gelf", nlist(
-    # type is/can be set in output gelf filter. 
+    # type is/can be set in output gelf filter.
     # this will not forcefully overwrtie in 1.2.2
     "type", "remotegelf",
     "port", 12201,
@@ -25,7 +25,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
     "ssl_certificate", "/software/components/ccm/cert_file",
     "ssl_key", "/software/components/ccm/key_file",
 )));
-    
+
 "input/plugins" = append(nlist("beats", nlist(
     "type", "beats",
     "port", 5043,
@@ -57,7 +57,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
     "plugins", list(
         nlist("grok", nlist(
             "match", list(nlist(
-                "name", "message", 
+                "name", "message",
                 "pattern", list("%{RSYSLOGCUSTOM}", "%{OTHERPATTERN}"),
                 )),
             "patterns_dir", list("/usr/share/grok"),
@@ -68,7 +68,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
             )),
         nlist("kv", nlist(
             "default_keys", nlist(
-                "key1", "value1", 
+                "key1", "value1",
                 "key2", "value2",
                 ),
             "exclude_keys", list("key1e", "key2e"),
@@ -82,7 +82,7 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
             )),
         nlist("date", nlist(
             "match", nlist(
-                "name", "syslog_timestamp", 
+                "name", "syslog_timestamp",
                 "pattern", list("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ", "yyyy-MM-dd'T'HH:mm:ssZZ"),
                 ),
             )),
@@ -94,10 +94,10 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
                 ))),
             "replace", list(
                 nlist(
-                    "name", "@source_host", 
+                    "name", "@source_host",
                     "pattern", "%{syslog_hostname}"),
                 nlist(
-                    "name", "@message", 
+                    "name", "@message",
                     "pattern", "%{syslog_message}"),
                 ),
             )),
@@ -117,7 +117,11 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
                 ))),
             "convert", dict(
                 "success", "boolean"
-            ))),
+                ),
+            "add_field", nlist(
+                escape("[@metadata][target_index]"), "longterm-%{+YYYY.Q}",
+                ),
+            )),
         nlist("bytes2human", nlist(
             "convert", nlist(
                 "field1", "bytes",
@@ -136,4 +140,3 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
         "template_overwrite", true,
         ),
 )));
-

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/server/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/server/base
@@ -79,6 +79,9 @@ filter \{$
 ^\s{8}\}$
 ^\s{8}if \('_grokparsefailure' not in \[tags\] and \[jube_id\]\) \{$
 ^\s{12}mutate \{$
+^\s{16}add_field => \{$
+^\s{20}"\[@metadata\]\[target_index\]" => "longterm-%\{\+YYYY\.Q\}"$
+^\s{16}\}$
 ^\s{16}convert => \{$
 ^\s{20}"success" => "boolean"$
 ^\s{16}\}$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/server/base
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/2.0/tests/regexps/server/base
@@ -79,11 +79,20 @@ filter \{$
 ^\s{8}\}$
 ^\s{8}if \('_grokparsefailure' not in \[tags\] and \[jube_id\]\) \{$
 ^\s{12}mutate \{$
-^\s{16}add_field => \{$
-^\s{20}"\[@metadata\]\[target_index\]" => "longterm-%\{\+YYYY\.Q\}"$
-^\s{16}\}$
 ^\s{16}convert => \{$
 ^\s{20}"success" => "boolean"$
+^\s{16}\}$
+^\s{12}\}$
+^\s{8}\}$
+^\s{8}mutate \{$
+^\s{12}add_field => \{$
+^\s{16}"\[@metadata\]\[target_index\]" => "longterm-%\{\+YYYY\.MM\.dd\}"$
+^\s{12}\}$
+^\s{8}\}$
+^\s{8}if \(\[program\] == "jube"\) \{$
+^\s{12}mutate \{$
+^\s{16}update => \{$
+^\s{20}"\[@metadata\]\[target_index\]" => "longterm-%\{\+YYYY\.Q\}"$
 ^\s{16}\}$
 ^\s{12}\}$
 ^\s{8}\}$

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/filter/mutate.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/filter/mutate.tt
@@ -1,3 +1,4 @@
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringarray" names=['exclude_tags'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="name_pattern" names=['replace'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['split', 'rename', 'convert'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="escstringhash" names=['update'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/filter/plugin.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/filter/plugin.tt
@@ -1,4 +1,5 @@
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="boolean" names=['negate', 'drop'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringarray" names=['add_tag', 'remove_tag', 'remove_field', 
     'exclude_keys', 'include_keys'] -%]
-[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['add_field', 'default_keys'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['default_keys'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="escstringhash" names=['add_field'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/input/plugin.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/input/plugin.tt
@@ -1,6 +1,7 @@
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="boolean" names=['debug', 'ssl_enable', 'ssl_verify'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringarray" names=['tags'] -%]
-[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['add_field', 'codec'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['codec'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="escstringhash" names=['add_field'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="string" 
         names=['type', 'host', 'ssl_cacert', 'ssl_cert', 'ssl_certificate', 'ssl_key', 'ssl_key_passhrase'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="exact" names=['port'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/output/plugin.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/output/plugin.tt
@@ -1,6 +1,7 @@
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="boolean" names=['debug', 'ssl_enable', 'ssl_verify'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringarray" names=['tags'] -%]
-[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['add_field', 'codec'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="stringhash" names=['codec'] -%]
+[%- INCLUDE "metaconfig/logstash/config/type.tt" type="escstringhash" names=['add_field'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="string" 
         names=['type', 'host', 'ssl_cacert', 'ssl_cert', 'ssl_key', 'ssl_key_passhrase'] -%]
 [%- INCLUDE "metaconfig/logstash/config/type.tt" type="exact" names=['workers'] -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/config/types/escstringhash.tt
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/config/types/escstringhash.tt
@@ -1,0 +1,7 @@
+[%- key %] => {
+[% FILTER indent -%]
+[%-     FOREACH p IN value.pairs -%]
+"[%         CCM.unescape(p.key) %]" => "[% p.value %]"
+[%     END -%]
+[%- END %]
+}[%- -%]

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -201,6 +201,7 @@ type logstash_filter_mutate = {
     "replace" ? logstash_name_pattern[]
     "rename" ? string{}
     "split" ? string{}
+    "update" ? string{}
     "exclude_tags" ? string[] with {deprecated(0, 'replace with _conditional e.g. <"tagname" not in [tags]> in 2.0'); true;}
 };
 


### PR DESCRIPTION
Based on #691 and #660