### PR TITLE
ncm-metaconfig: add service lmod

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/lmod/main.tt
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/main.tt
@@ -1,0 +1,20 @@
+propT = {
+[%-  FOREACH prop IN prop.pairs %]
+[%      FILTER indent -%]
+[%          prop.key %] = {
+[%          INCLUDE 'metaconfig/lmod/prop.tt' data=prop.value FILTER indent -%]
+},
+[%       END -%]
+[%-  END %]
+}
+[% IF scDescript.defined %]
+scDescriptT = {
+[%      FOREACH scdescript IN scDescript -%]
+[%-         FILTER indent -%]
+{
+[%              INCLUDE 'metaconfig/lmod/scDescript.tt' data=scdescript FILTER indent -%]
+},
+[%          END -%]
+[%-      END %]
+}
+[% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/lmod/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/pan/config.pan
@@ -1,0 +1,9 @@
+unique template metaconfig/lmod/config;
+
+include 'metaconfig/lmod/schema';
+
+bind "/software/components/metaconfig/services/{/etc/lmodrc.lua}/contents" = lmod_service;
+
+prefix "/software/components/metaconfig/services/{/etc/lmodrc.lua}";
+"module" = "lmod/main";
+"mode" = 0644;

--- a/ncm-metaconfig/src/main/metaconfig/lmod/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/pan/schema.pan
@@ -1,0 +1,23 @@
+declaration template metaconfig/lmod/schema;
+
+include 'pan/types';
+
+@{ generate single displayT entry, all keys or names are considered valid }
+type lmod_prop = {
+    "short" : string[]
+    "long" : string[]
+    "doc" : string
+    "color" ? string with match(SELF, '^(black|red|green|yellow|blue|magenta|cyan|white)$')
+    @{override the key with name joined using ':'}
+    "names" ? string[]
+};
+
+type lmod_scdescript = {
+    "timestamp" : string
+    "dir" : string
+};
+    
+type lmod_service = {
+    "prop" : lmod_prop{}{}
+    "scDescript" ? lmod_scdescript[]
+};

--- a/ncm-metaconfig/src/main/metaconfig/lmod/prop.tt
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/prop.tt
@@ -1,0 +1,33 @@
+[%- valid = {} -%]
+displayT = {
+[%- FOREACH display IN data.pairs %]
+[%     IF display.value.names.defined;
+            FOREACH n IN display.value.names;
+                valid.$n = 1;
+            END;
+            name = display.value.names.join(':');
+        ELSE;
+            name = display.key;
+            valid.$name = 1;
+        END; -%]
+[%-      FILTER indent -%]
+["[%        name %]"] = {
+[%         FILTER indent -%]
+short = "([%    display.value.short.join(',') %])",
+long = "([%     display.value.long.join(',') %])",
+[%              IF display.value.color.defined -%]
+color = "[%         display.value.color %]",
+[%-             END %]
+doc = "[%       display.value.doc %]",
+[%-         END %]
+},
+[%-     END %]
+[%- END %]
+},
+validT = {
+[%  FOREACH v IN valid.pairs %]
+[%      FILTER indent -%]
+[%          v.key %] = [% v.value %],
+[%-      END -%]
+[%-  END %]
+},

--- a/ncm-metaconfig/src/main/metaconfig/lmod/scDescript.tt
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/scDescript.tt
@@ -1,0 +1,3 @@
+[% FOREACH sc IN data.pairs -%]
+["[%    sc.key %]"] = [% sc.value %],
+[% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/lmod/tests/profiles/default.pan
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/tests/profiles/default.pan
@@ -1,0 +1,77 @@
+object template default;
+
+include 'metaconfig/lmod/config';
+
+prefix "/software/components/metaconfig/services/{/etc/lmodrc.lua}/contents/prop";
+"state/experimental" = dict(
+    "short", list("E"),
+    "long", list("E"),
+    "color", "blue",
+    "doc", "Experimental",
+);
+"state/testing" = dict(
+    "short", list("T"),
+    "long", list("T"),
+    "color", "green",
+    "doc", "Testing",
+);
+"state/obsolete" = dict(
+    "short", list("O"),
+    "long", list("O"),
+    "color", "red",
+    "doc", "Obsolete",
+);
+"lmod/sticky" = dict(
+    "short", list("S"),
+    "long", list("S"),
+    "color", "red",
+    "doc", "Module is Sticky, requires --force to unload or purge",
+);
+"arch/mic" = dict(
+    "short", list("m"),
+    "long", list("m"),
+    "color", "blue",
+    "doc", "built for host and native MIC",
+);
+"arch/offload" = dict(
+    "short", list("o"),
+    "long", list("o"),
+    "color", "blue",
+    "doc", "built for offload to the MIC only",
+);
+"arch/gpu" = dict(
+    "short", list("g"),
+    "long", list("g"),
+    "color", "red",
+    "doc", "built for GPU",
+);
+"arch/mo" = dict(
+    "names", list("mic", "offload"),
+    "short", list("*"),
+    "long", list("m", "o"),
+    "color", "blue",
+    "doc", "built for host, native MIC and offload to the MIC",
+);
+"arch/gm" = dict(
+    "names", list("gpu", "mic"),
+    "short", list("g", "m"),
+    "long", list("g", "m"),
+    "color", "red",
+    "doc", "built natively for MIC and GPU",
+);
+"arch/gmo" = dict(
+    "names", list("gpu", "mic", "offload"),
+    "short", list("@"),
+    "long", list("g", "m", "o"),
+    "color", "red",
+    "doc", "built natively for MIC and GPU and offload to the MIC",
+);
+prefix "/software/components/metaconfig/services/{/etc/lmodrc.lua}/contents";
+"scDescript/0" = dict(
+    "timestamp", "/some/path0",
+    "dir", "/some/dir0",
+);
+"scDescript/1" = dict(
+    "timestamp", "/some/path1",
+    "dir", "/some/dir1",
+);

--- a/ncm-metaconfig/src/main/metaconfig/lmod/tests/regexps/default/base
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/tests/regexps/default/base
@@ -1,0 +1,101 @@
+Test default lmodrc file
+---
+/etc/lmodrc.lua
+---
+^propT = \{$
+^\s{4}arch = \{$
+^\s{8}displayT = \{$
+^\s{12}\["gpu:mic"\] = \{$
+^\s{16}short = "\(g,m\)",$
+^\s{16}long = "\(g,m\)",$
+^\s{16}color = "red",$
+^\s{16}doc = "built natively for MIC and GPU",$
+^\s{12}\},$
+^\s{12}\["gpu:mic:offload"\] = \{$
+^\s{16}short = "\(@\)",$
+^\s{16}long = "\(g,m,o\)",$
+^\s{16}color = "red",$
+^\s{16}doc = "built natively for MIC and GPU and offload to the MIC",$
+^\s{12}\},$
+^\s{12}\["gpu"\] = \{$
+^\s{16}short = "\(g\)",$
+^\s{16}long = "\(g\)",$
+^\s{16}color = "red",$
+^\s{16}doc = "built for GPU",$
+^\s{12}\},$
+^\s{12}\["mic"\] = \{$
+^\s{16}short = "\(m\)",$
+^\s{16}long = "\(m\)",$
+^\s{16}color = "blue",$
+^\s{16}doc = "built for host and native MIC",$
+^\s{12}\},$
+^\s{12}\["mic:offload"\] = \{$
+^\s{16}short = "\(\*\)",$
+^\s{16}long = "\(m,o\)",$
+^\s{16}color = "blue",$
+^\s{16}doc = "built for host, native MIC and offload to the MIC",$
+^\s{12}\},$
+^\s{12}\["offload"\] = \{$
+^\s{16}short = "\(o\)",$
+^\s{16}long = "\(o\)",$
+^\s{16}color = "blue",$
+^\s{16}doc = "built for offload to the MIC only",$
+^\s{12}\},$
+^\s{8}\},$
+^\s{8}validT = {$
+^\s{12}gpu = 1,$
+^\s{12}mic = 1,$
+^\s{12}offload = 1,$
+^\s{8}\},$
+^\s{4}\},$
+^\s{4}lmod = \{$
+^\s{8}displayT = \{$
+^\s{12}\["sticky"\] = \{$
+^\s{16}short = "\(S\)",$
+^\s{16}long = "\(S\)",$
+^\s{16}color = "red",$
+^\s{16}doc = "Module is Sticky, requires --force to unload or purge",$
+^\s{12}\},$
+^\s{8}},$
+^\s{8}validT = \{$
+^\s{12}sticky = 1,$
+^\s{8}\},$
+^\s{4}\},$
+^\s{4}state = \{$
+^\s{8}displayT = \{$
+^\s{12}\["experimental"\] = \{$
+^\s{16}short = "\(E\)",$
+^\s{16}long = "\(E\)",$
+^\s{16}color = "blue",$
+^\s{16}doc = "Experimental",$
+^\s{12}\},$
+^\s{12}\["obsolete"\] = \{$
+^\s{16}short = "\(O\)",$
+^\s{16}long = "\(O\)",$
+^\s{16}color = "red",$
+^\s{16}doc = "Obsolete",$
+^\s{12}\},$
+^\s{12}\["testing"\] = \{$
+^\s{16}short = "\(T\)",$
+^\s{16}long = "\(T\)",$
+^\s{16}color = "green",$
+^\s{16}doc = "Testing",$
+^\s{12}\},$
+^\s{8}\},$
+^\s{8}validT = \{$
+^\s{12}experimental = 1,$
+^\s{12}obsolete = 1,$
+^\s{12}testing = 1,$
+^\s{8}\},$
+^\s{4}\},$
+^\}$
+^scDescriptT = \{$
+^\s{4}\{$
+^\s{8}\["dir"\] = /some/dir0,$
+^\s{8}\["timestamp"\] = /some/path0,$
+^\s{4}\},$
+^\s{4}\{$
+^\s{8}\["dir"\] = /some/dir1,$
+^\s{8}\["timestamp"\] = /some/path1,$
+^\s{4}\},$
+^\}$

--- a/ncm-metaconfig/src/test/perl/service-lmod.t
+++ b/ncm-metaconfig/src/test/perl/service-lmod.t
@@ -1,0 +1,14 @@
+use Test::Quattor::ProfileCache qw(set_json_typed get_json_typed);
+BEGIN {
+    set_json_typed()
+}
+use Test::More;
+use Test::Quattor::TextRender::Metaconfig;
+
+ok(get_json_typed(), "json_typed enabled for lmod render");
+
+my $u = Test::Quattor::TextRender::Metaconfig->new(
+    service => 'lmod',
+)->test();
+
+done_testing;


### PR DESCRIPTION
New metaconfig service for site global configuration of [lmod](https://github.com/TACC/Lmod)