### PR TITLE
ncm-metaconfig: httpd auth require add shibboleth

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
@@ -257,7 +257,7 @@ type httpd_proxy_directive = {
 
 type httpd_auth_require = {
     # require type who.join(' ')
-    "type" : string with match(SELF,'^(valid-user|user|group)$')
+    "type" : string with match(SELF, '^(valid-user|user|group|shibboleth)$')
     "who" ? string[]
 };
 


### PR DESCRIPTION
Add shibboleth as a supported value of httpd_auth_require.