### PR TITLE
ncm-metaconfig: service ncm-ncd - do not try to restart daemons

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/ncm-ncd/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ncm-ncd/pan/config.pan
@@ -7,4 +7,3 @@ bind "/software/components/metaconfig/services/{/etc/ncm-ncd.conf}/contents" = n
 prefix "/software/components/metaconfig/services/{/etc/ncm-ncd.conf}";
 "module" = "ncm-ncd/main";
 "mode" = 0644;
-"daemons" = dict("ncm-ncd", "restart");


### PR DESCRIPTION
Don't try to restart ncm-ncd, it is not a demon, so there is no ncm-ncd service!