### PR TITLE
ncm-metaconfig: icinga-web - Use FILTER to convert to uppercase, not string method

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/icinga-web/manager_attrs.tt
+++ b/ncm-metaconfig/src/main/metaconfig/icinga-web/manager_attrs.tt
@@ -1,3 +1,3 @@
 [% FOREACH pair IN data.pairs %]
-<ae:parameter name="Doctrine_Core::[% pair.key.upper %]">[% pair.value %]</ae:parameter>
+<ae:parameter name="Doctrine_Core::[% pair.key FILTER upper %]">[% pair.value %]</ae:parameter>
 [%- END %]


### PR DESCRIPTION
upper() is not available in earlier versions of template toolkit so this breaks pre SL7 support.