### PR TITLE
Add templates for new issues and pull-requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Ensure the title of this issue starts with the component name followed by a colon, e.g.
+> ncm-example: demonstrate what titles should look like
+
+Describe the problem here.
+
+If this is a bug report, remember to include:
+
+* The version of the component you are using (rpm -q $component)
+* What OS version you are using (/etc/redhat-release or similar)
+* Steps required to reproduce the problem
+* Actual result versus expected result

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Ensure the title of this pull-request starts with the component name followed by a colon, e.g.
+> ncm-example: demonstrate what titles should look like
+
+Describe the change you are making here, in particular we would like to know:
+
+* Why the change is necessary.
+* What backwards incompatibility it may introduce.


### PR DESCRIPTION
The practices we have adopted for managing issues and pull-requests on GitHub have not been documented anywhere, this has the advantage of both documenting those practices and then directly exposing them to everyone.

See https://github.com/blog/2111-issue-and-pull-request-templates