### PR TITLE
ncm-metaconfig: Add support for keepalived

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/keepalived/global.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/global.tt
@@ -1,0 +1,3 @@
+[% FOREACH item IN global_defs.pairs -%]
+[%     item.key %] [% item.value -%]
+[% END %]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/global.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/global.tt
@@ -1,3 +1,3 @@
 [% FOREACH item IN global_defs.pairs -%]
-[%     item.key %] [% item.value -%]
+[%     item.key %] [% item.value %]
 [% END %]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/main.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/main.tt
@@ -1,0 +1,13 @@
+global_defs {
+[% INCLUDE 'metaconfig/keepalived/global.tt' FILTER indent -%]
+}
+[% FOREACH vrrp_script IN vrrp_scripts -%]
+vrrp_script [% vrrp_script.name %] {
+[% INCLUDE 'metaconfig/keepalived/vrrp_script.tt' FILTER indent -%] 
+}
+[% END %]
+[% FOREACH vrrp_instance IN vrrp_instances -%]
+vrrp_instance [% vrrp_instance.name %] {
+[%- INCLUDE 'metaconfig/keepalived/vrrp_instance.tt' FILTER indent -%]
+}
+[%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/main.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/main.tt
@@ -3,11 +3,11 @@ global_defs {
 }
 [% FOREACH vrrp_script IN vrrp_scripts -%]
 vrrp_script [% vrrp_script.name %] {
-[% INCLUDE 'metaconfig/keepalived/vrrp_script.tt' FILTER indent -%] 
+[%     INCLUDE 'metaconfig/keepalived/vrrp_script.tt' FILTER indent -%] 
 }
 [% END %]
 [% FOREACH vrrp_instance IN vrrp_instances -%]
 vrrp_instance [% vrrp_instance.name %] {
-[%- INCLUDE 'metaconfig/keepalived/vrrp_instance.tt' FILTER indent -%]
+[%-     INCLUDE 'metaconfig/keepalived/vrrp_instance.tt' FILTER indent -%]
 }
 [%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/pan/config.pan
@@ -1,0 +1,13 @@
+unique template metaconfig/keepalived/config;
+
+include 'metaconfig/keepalived/schema';
+
+bind "/software/components/metaconfig/services/{/etc/keepalived/keepalived.conf}/contents" = keepalived_service;
+
+prefix "/software/components/metaconfig/services/{/etc/keepalived/keepalived.conf}";
+'daemons' = dict(
+    'keepalived', 'reload',
+);
+'module' = 'keepalived/main';
+
+

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/pan/schema.pan
@@ -1,0 +1,60 @@
+declaration template metaconfig/keepalived/schema;
+
+include 'pan/types';
+
+@documentation {
+    The global_defs section
+}
+type keepalived_service_global = {
+    'router_id' : string
+};
+
+@documentation {
+    The vrrp_script section
+}
+type keepalived_service_vrrpscript = {
+    'name' : string
+    'script' : string
+    'interval' : long = 2
+    'weight' : long = 2
+};
+
+@documentation {
+    The virtual_ipaddress section of the vrrp_instance
+}
+type keepalived_service_vip = {
+    'ipaddress' : string
+    'interface' : string
+};
+
+@documentation {
+    The vrrp_instance configuration
+}
+type keepalived_service_vrrpinstance_config = {
+    'virtual_router_id' : long
+    'advert_int' : long = 1
+    'priority' : long = 100
+    'state' : string
+    'interface' : string
+};
+
+@documentation {
+    The vrrp_instance section
+}
+type keepalived_service_vrrpinstance = {
+    'name' : string
+    'config' : keepalived_service_vrrpinstance_config
+    'virtual_ipaddresses' : keepalived_service_vip[]
+    'track_scripts' : string[]
+};
+
+@documentation {
+    Keepalived config
+    See: http://keepalived.org/
+}
+type keepalived_service = {
+    'global_defs' : keepalived_service_global
+    'vrrp_scripts' : keepalived_service_vrrpscript[]
+    'vrrp_instances' : keepalived_service_vrrpinstance[]
+};
+

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/tests/profiles/config.pan
@@ -1,0 +1,33 @@
+object template config;
+
+include 'metaconfig/keepalived/config';
+
+prefix '/software/components/metaconfig/services/{/etc/keepalived/keepalived.conf}';
+'contents/global_defs/router_id'='vm1';
+'contents/vrrp_scripts'=append(
+    dict(
+        'name' , 'haproxy',
+        'script' , '"killall -0 haproxy"',
+        'interval' , 2,
+        'weight' , 2
+    )
+);
+'contents/vrrp_instances'=append(
+    dict(
+        'name' , 'Testing',
+        'config' , dict(
+            'virtual_router_id' , 52,
+            'advert_int' , 1,
+            'priority' , 100,
+            'state' , 'BACKUP',
+            'interface' , 'eth0',
+        ),
+        'virtual_ipaddresses' , list(
+            dict(
+                'ipaddress' , '192.168.1.20',
+                'interface' , 'eth0',
+            ),
+        ),
+        'track_scripts' , list('haproxy'),
+    )
+); 

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/tests/regexps/config/base
@@ -1,0 +1,27 @@
+Test for config
+---
+/etc/keepalived/keepalived.conf
+unordered
+---
+^global_defs\s\{$
+^\s{4}router_id\s+vm1\s*$
+^\}$
+^vrrp_script haproxy\s\{\s*$
+^\s{4}script\s+"killall -0 haproxy"\s*$
+^\s{4}interval\s+2\s*$
+^\s{4}weight\s+2\s*$
+^\}\s*$
+^vrrp_instance Testing\s\{\s*$
+^\s{4}virtual_router_id\s+52\s*$
+^\s{4}advert_int\s+1\s*$
+^\s{4}priority\s+100\s*$
+^\s{4}state\s+BACKUP\s*$
+^\s{4}interface\s+eth0\s*$
+^\s{4}virtual_ipaddress\s+\{\s*$
+^\s{8}192\.168\.1\.20\s+dev\s+eth0\s*$
+^\s{4}\}\s*$
+^\s{4}track_script\s\{\s*$
+^\s{8}haproxy\s*$
+^\s{4}\}\s*$
+^\}\s*$
+

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/track_script.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/track_script.tt
@@ -1,0 +1,3 @@
+[% FOREACH track_script IN vrrp_instance.track_scripts -%]
+[%     track_script %]
+[% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/virtual_ipaddress.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/virtual_ipaddress.tt
@@ -1,0 +1,3 @@
+[% FOREACH vip IN vrrp_instance.virtual_ipaddresses -%]
+[% vip.ipaddress %] dev [% vip.interface %]
+[% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/virtual_ipaddress.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/virtual_ipaddress.tt
@@ -1,3 +1,3 @@
 [% FOREACH vip IN vrrp_instance.virtual_ipaddresses -%]
-[% vip.ipaddress %] dev [% vip.interface %]
+[%     vip.ipaddress %] dev [% vip.interface %]
 [% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_instance.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_instance.tt
@@ -1,0 +1,9 @@
+[% FOREACH item IN vrrp_instance.config.pairs %]
+[%     item.key %] [% item.value %]
+[%- END %]
+virtual_ipaddress {
+[% INCLUDE 'metaconfig/keepalived/virtual_ipaddress.tt' FILTER indent -%]
+}
+track_script {
+[% INCLUDE 'metaconfig/keepalived/track_script.tt' FILTER indent -%]
+}

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_script.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_script.tt
@@ -1,0 +1,3 @@
+[% FOREACH option IN vrrp_script.pairs -%]
+[%     option.key %] [% option.value %]
+[% END -%]

--- a/ncm-metaconfig/src/test/perl/service-keepalived.t
+++ b/ncm-metaconfig/src/test/perl/service-keepalived.t
@@ -1,0 +1,6 @@
+use Test::More;
+use Test::Quattor::TextRender::Metaconfig;
+my $u = Test::Quattor::TextRender::Metaconfig->new(
+        service => 'keepalived',
+        )->test();
+done_testing;


### PR DESCRIPTION
Adds support for Keepalived to provide floating IP Addresses for use in Load Balancers