### PR TITLE
Adapt unittests to new buildtools

### DIFF
--- a/ncm-accounts/src/test/perl/00-load.t
+++ b/ncm-accounts/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::accounts");

--- a/ncm-afsclt/src/test/perl/00-load.t
+++ b/ncm-afsclt/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::afsclt");

--- a/ncm-aiiserver/src/test/perl/00-load.t
+++ b/ncm-aiiserver/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::aiiserver");

--- a/ncm-altlogrotate/src/test/perl/00-load.t
+++ b/ncm-altlogrotate/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::altlogrotate");

--- a/ncm-amandaserver/src/test/perl/00-load.t
+++ b/ncm-amandaserver/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::amandaserver");

--- a/ncm-authconfig/src/test/perl/00-load.t
+++ b/ncm-authconfig/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::authconfig");

--- a/ncm-autofs/src/test/perl/00-load.t
+++ b/ncm-autofs/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::autofs");

--- a/ncm-ccm/src/test/perl/00-load.t
+++ b/ncm-ccm/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ccm");

--- a/ncm-cdp/src/test/perl/00-load.t
+++ b/ncm-cdp/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::cdp");

--- a/ncm-cdp/src/test/perl/configure.t
+++ b/ncm-cdp/src/test/perl/configure.t
@@ -44,4 +44,7 @@ like($fh, qr{^port\s*=\s*7777\s*$}m, "Correct port line");
 my $c = get_command("service cdp-listend restart");
 ok($c, "Daemon was restarted when there were changes");
 
+$cf_mock->unmock("close");
+$fh->close();
+
 done_testing();

--- a/ncm-ceph/src/test/perl/00-load.t
+++ b/ncm-ceph/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything upstream without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ceph");

--- a/ncm-chkconfig/src/test/perl/00-load.t
+++ b/ncm-chkconfig/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::chkconfig");

--- a/ncm-cron/src/test/perl/00-load.t
+++ b/ncm-cron/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::cron");

--- a/ncm-cups/src/test/perl/00-load.t
+++ b/ncm-cups/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::cups");

--- a/ncm-directoryservices/src/test/perl/00-load.t
+++ b/ncm-directoryservices/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::directoryservices");

--- a/ncm-dirperm/src/test/perl/00-load.t
+++ b/ncm-dirperm/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::dirperm");

--- a/ncm-download/src/test/perl/00-load.t
+++ b/ncm-download/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::download");

--- a/ncm-etcservices/src/test/perl/00-load.t
+++ b/ncm-etcservices/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::etcservices");

--- a/ncm-filecopy/src/test/perl/00-load.t
+++ b/ncm-filecopy/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::filecopy");

--- a/ncm-filesystems/src/test/perl/00-load.t
+++ b/ncm-filesystems/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::filesystems");

--- a/ncm-fmonagent/src/test/perl/00-load.t
+++ b/ncm-fmonagent/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::fmonagent");

--- a/ncm-fstab/src/test/perl/00-load.t
+++ b/ncm-fstab/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::fstab");

--- a/ncm-fstab/src/test/perl/configure.t
+++ b/ncm-fstab/src/test/perl/configure.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -18,10 +17,12 @@ Readonly my $FSTAB => 'target/test/etc/fstab';
 
 BEGIN{
     # This only works because the constant of NCM::Filesystem is used in a ncm-fstab sub
+    use Test::Quattor;
     use NCM::Filesystem;
     undef &{NCM::Filesystem::FSTAB};
     *{NCM::Filesystem::FSTAB} =  sub () {$FSTAB} ;
 }
+
 use CAF::FileEditor;
 use CAF::Object;
 use File::Basename;

--- a/ncm-fstab/src/test/perl/protected.t
+++ b/ncm-fstab/src/test/perl/protected.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -17,6 +16,7 @@ use Readonly;
 Readonly my $FSTAB => 'target/test/etc/fstab';
 BEGIN{
     # This only works because the constant of NCM::Filesystem is used in a ncm-fstab sub
+    use Test::Quattor;
     use NCM::Filesystem;
     undef &{NCM::Filesystem::FSTAB};
     *{NCM::Filesystem::FSTAB} =  sub () {$FSTAB} ;

--- a/ncm-ganglia/src/test/perl/00-load.t
+++ b/ncm-ganglia/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to GitHub
-without having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ganglia");

--- a/ncm-gmetad/src/test/perl/00-load.t
+++ b/ncm-gmetad/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gmetad");

--- a/ncm-gmond/src/test/perl/00-load.t
+++ b/ncm-gmond/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gmond");

--- a/ncm-gpfs/src/test/perl/00-load.t
+++ b/ncm-gpfs/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gpfs");

--- a/ncm-grub/src/test/perl/00-load.t
+++ b/ncm-grub/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::grub");

--- a/ncm-hostsaccess/src/test/perl/00-load.t
+++ b/ncm-hostsaccess/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::hostsaccess");

--- a/ncm-hostsfile/src/test/perl/00-load.t
+++ b/ncm-hostsfile/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::hostsfile");

--- a/ncm-icinga/src/test/perl/00-load.t
+++ b/ncm-icinga/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::icinga");

--- a/ncm-icinga/src/test/perl/myIcinga.pm
+++ b/ncm-icinga/src/test/perl/myIcinga.pm
@@ -1,6 +1,8 @@
 use strict;
 use warnings;
 
+use Test::Quattor;
+
 use CAF::Object;
 $CAF::Object::NoAction = 1;
 

--- a/ncm-icinga/src/test/perl/test-cgi.t
+++ b/ncm-icinga/src/test/perl/test-cgi.t
@@ -22,3 +22,5 @@ like("$rs", qr(^main_config_file=.*),
      "The main config file is printed");
 like("$rs", qr{^hello=1$}m, "Key hello got printed");
 like("$rs", qr{^world=2$}m, "Key world got printed");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-commands.t
+++ b/ncm-icinga/src/test/perl/test-commands.t
@@ -14,9 +14,11 @@ my $rs = $comp->print_commands($t);
 isa_ok($rs, 'CAF::FileWriter', "Returned object is a FileWriter");
 is(*$rs->{filename}, NCM::Component::icinga::ICINGA_FILES->{commands},
    "Correct file was opened");
-chomp($rs);
-is($rs, q!define command {
+is("$rs", q!define command {
 	command_name acommand
 	command_line ls -lh
-}!,
+}
+!,
   'File contents properly written');
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-contacts.t
+++ b/ncm-icinga/src/test/perl/test-contacts.t
@@ -32,3 +32,5 @@ like(
 );
 like("$rs", qr(^\s*foo\s+4,5$)m, "Random array field properly written");
 like("$rs", qr(^\s*bar\s+6$)m,   "Random scalar field properly written");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-general.t
+++ b/ncm-icinga/src/test/perl/test-general.t
@@ -148,3 +148,5 @@ my $c = $t->{hosts_generic};
 delete($t->{hosts_generic});
 $rs = $comp->print_general($t);
 unlike("$rs", qr{^cfg_file\s*=\s*$c$}m, "Non-existing files don't get printed");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-hostdependencies.t
+++ b/ncm-icinga/src/test/perl/test-hostdependencies.t
@@ -28,3 +28,5 @@ is(
 like("$rs", qr(^\s*foo\s+1$)m,           "Scalar contents properly written");
 like("$rs", qr(^\s*bar\s+3,4$)m,         "List contents properly written");
 like("$rs", qr(^\s*host_name\s+ahost$)m, "Host name properly recorded");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-hostgroups.t
+++ b/ncm-icinga/src/test/perl/test-hostgroups.t
@@ -23,3 +23,5 @@ like("$rs", qr(^\s*members\s+1,2,3$)m,        "All members registered");
 
 $rs = $comp->print_hostgroups($t, [1]);
 like("$rs", qr(^\s*members\s+2,3$)m, "Unwanted member ignored");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-hosts-generic.t
+++ b/ncm-icinga/src/test/perl/test-hosts-generic.t
@@ -33,3 +33,5 @@ like("$rs", qr(^\s*event_handler\s+hello!world$)m, "Event handler properly regis
 like("$rs", qr(^\s*check_command\s+foo!bar!baz$)m, "Check command properly registered");
 like("$rs", qr(^\s*a\s+1$)m,                       "Random scalar key properly defined");
 like("$rs", qr(^\s*c\s+5,6,7$)m,                   "Random array key properly defined");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-hosts.t
+++ b/ncm-icinga/src/test/perl/test-hosts.t
@@ -33,3 +33,5 @@ $t = {"www.google.com" => $t->{ahost}};
 
 $rs = $comp->print_hosts($t);
 like("$rs", qr(address\s+\d+\.\d+\.\d+\.\d+), "IP address found for existing host");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-idodb.t
+++ b/ncm-icinga/src/test/perl/test-idodb.t
@@ -11,5 +11,6 @@ my $t = {foo => 'bar'};
 my $rs = $comp->print_ido2db_config($t);
 isa_ok($rs, 'CAF::FileWriter', "Returned object is a FileWriter");
 is(*$rs->{filename}, NCM::Component::icinga::ICINGA_FILES->{ido2db}, "Correct file was opened");
-chomp($rs);
-is($rs, "foo=bar", "Contents properly written");
+is("$rs", "foo=bar\n", "Contents properly written");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-macros.t
+++ b/ncm-icinga/src/test/perl/test-macros.t
@@ -12,5 +12,6 @@ my $rs = $comp->print_macros($t);
 
 isa_ok($rs, 'CAF::FileWriter', "Returned object is a FileWriter");
 is(*$rs->{filename}, NCM::Component::icinga::ICINGA_FILES->{macros}, "Correct file was opened");
-chomp($rs);
-is($rs, '$foo$=bar', 'File contents properly written');
+is("$rs", '$foo$=bar'."\n", 'File contents properly written');
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-other.t
+++ b/ncm-icinga/src/test/perl/test-other.t
@@ -17,6 +17,9 @@ is("$rs", q!define contactgroup {
 	bar	baz
 }
 !, "Contents properly written");
+$rs->close();
+
+
 $rs = $comp->print_other($t, "servicegroups");
 
 isa_ok($rs, 'CAF::FileWriter', "Returned object is a FileWriter");
@@ -27,3 +30,5 @@ is("$rs", q!define servicegroup {
 	bar	baz
 }
 !, "Contents properly written");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-servicedependencies.t
+++ b/ncm-icinga/src/test/perl/test-servicedependencies.t
@@ -22,3 +22,5 @@ is(*$rs->{filename},
    NCM::Component::icinga::ICINGA_FILES->{servicedependencies},
     "Correct file was opened");
 like("$rs", qr(^\s*foo\s+1$)m, "Contents properly written");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-serviceextinfo.t
+++ b/ncm-icinga/src/test/perl/test-serviceextinfo.t
@@ -27,3 +27,5 @@ is(
 );
 like("$rs", qr(^\s*foo\s+1$)m,   "Scalar contents properly written");
 like("$rs", qr(^\s*bar\s+3,4$)m, "List contents properly written");
+
+$rs->close();

--- a/ncm-icinga/src/test/perl/test-services.t
+++ b/ncm-icinga/src/test/perl/test-services.t
@@ -26,3 +26,5 @@ like("$rs", qr(^\s*check_command\s+1!2$)m,           "Check command properly reg
 like("$rs", qr(^\s*event_handler\s+3!4$)m,           "Event handler properly registered");
 like("$rs", qr(^\s*event_handler_enabled\s+1$)m,     "Event handler is enabled");
 like("$rs", qr(^\s*foo\s+5,6$)m,                     "Random array field is properly displayed");
+
+$rs->close();

--- a/ncm-interactivelimits/src/test/perl/00-load.t
+++ b/ncm-interactivelimits/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::interactivelimits");

--- a/ncm-ipmi/src/test/perl/00-load.t
+++ b/ncm-ipmi/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ipmi");

--- a/ncm-iptables/src/test/perl/00-load.t
+++ b/ncm-iptables/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::iptables");

--- a/ncm-ldconf/src/test/perl/00-load.t
+++ b/ncm-ldconf/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ldconf");

--- a/ncm-libvirtd/src/test/perl/00-load.t
+++ b/ncm-libvirtd/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to GitHub
-without having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::libvirtd");

--- a/ncm-mcx/src/test/perl/00-load.t
+++ b/ncm-mcx/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::mcx");

--- a/ncm-metaconfig/src/test/perl/00-load.t
+++ b/ncm-metaconfig/src/test/perl/00-load.t
@@ -1,6 +1,18 @@
-#!/usr/bin/perl
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+=pod
+
+=head1 Smoke test
+
+Basic test that ensures that our module will load correctly.
+
+=cut
+
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::metaconfig");

--- a/ncm-modprobe/src/test/perl/00-load.t
+++ b/ncm-modprobe/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything upstream without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::modprobe");

--- a/ncm-modprobe/src/test/perl/generator.t
+++ b/ncm-modprobe/src/test/perl/generator.t
@@ -17,6 +17,7 @@ ensure they are there.
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 use NCM::Component::modprobe;
 
 my $cmp = NCM::Component::modprobe->new("modprobe");

--- a/ncm-modprobe/src/test/perl/mkinitrd.t
+++ b/ncm-modprobe/src/test/perl/mkinitrd.t
@@ -18,10 +18,10 @@ use strict;
 use warnings;
 use Test::More;
 use Test::MockModule;
+use Test::Quattor;
 use LC::File;
 use subs 'NCM::Component::modprobe::directory_contents';
 use NCM::Component::modprobe;
-use Test::Quattor;
 use CAF::FileWriter;
 use CAF::Object;
 

--- a/ncm-mysql/src/test/perl/00-load.t
+++ b/ncm-mysql/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::mysql");

--- a/ncm-nagios/src/test/perl/00-load.t
+++ b/ncm-nagios/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::nagios");

--- a/ncm-named/src/test/perl/00-load.t
+++ b/ncm-named/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::named");

--- a/ncm-network/src/test/perl/00-load.t
+++ b/ncm-network/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::network");

--- a/ncm-nfs/src/test/perl/00-load.t
+++ b/ncm-nfs/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::nfs");

--- a/ncm-nrpe/src/test/perl/00-load.t
+++ b/ncm-nrpe/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::nrpe");

--- a/ncm-nsca/src/test/perl/00-load.t
+++ b/ncm-nsca/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::nsca");

--- a/ncm-nscd/src/test/perl/00-load.t
+++ b/ncm-nscd/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::nscd");

--- a/ncm-nss/src/test/perl/00-load.t
+++ b/ncm-nss/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -14,5 +13,6 @@ Basic test that ensures that our module will load correctly.
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
-use_ok('NCM::Component::nss');
+use_ok("NCM::Component::nss");

--- a/ncm-ntpd/src/test/perl/00-load.t
+++ b/ncm-ntpd/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ntpd");

--- a/ncm-ofed/src/test/perl/00-load.t
+++ b/ncm-ofed/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ofed");

--- a/ncm-openldap/src/test/perl/00-load.t
+++ b/ncm-openldap/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::openldap");

--- a/ncm-opennebula/src/test/perl/00-load.t
+++ b/ncm-opennebula/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::opennebula");

--- a/ncm-openvpn/src/test/perl/00-load.t
+++ b/ncm-openvpn/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::openvpn");

--- a/ncm-pam/src/test/perl/00-load.t
+++ b/ncm-pam/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::pam");

--- a/ncm-pnp4nagios/src/test/perl/00-load.t
+++ b/ncm-pnp4nagios/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::pnp4nagios");

--- a/ncm-postfix/src/test/perl/00-load.t
+++ b/ncm-postfix/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::postfix");

--- a/ncm-postgresql/src/test/perl/00-load.t
+++ b/ncm-postgresql/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::postgresql");

--- a/ncm-profile/src/test/perl/00-load.t
+++ b/ncm-profile/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::profile");

--- a/ncm-puppet/src/test/perl/00-load.t
+++ b/ncm-puppet/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,14 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything upstream without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::puppet");
-

--- a/ncm-puppet/src/test/perl/apply.t
+++ b/ncm-puppet/src/test/perl/apply.t
@@ -11,9 +11,9 @@
 
 use strict;
 use warnings;
-use NCM::Component::puppet;
 use Test::More tests => 12;
 use Test::Quattor;
+use NCM::Component::puppet;
 use CAF::Object;
 
 $CAF::Object::NoAction = 1;

--- a/ncm-puppet/src/test/perl/functions.t
+++ b/ncm-puppet/src/test/perl/functions.t
@@ -25,9 +25,9 @@ Tests the functionality of the lower function of the puppet component:
 
 use strict;
 use warnings;
-use NCM::Component::puppet;
 use Test::More tests => 4;
 use Test::Quattor;
+use NCM::Component::puppet;
 use Test::Deep;
 use CAF::Object;
 

--- a/ncm-puppet/src/test/perl/install_modules.t
+++ b/ncm-puppet/src/test/perl/install_modules.t
@@ -13,9 +13,9 @@ Tests that the install_modules function does its job properly. Three possible sc
 
 use strict;
 use warnings;
-use NCM::Component::puppet;
 use Test::More tests => 9;
 use Test::Quattor;
+use NCM::Component::puppet;
 use CAF::Object;
 
 $CAF::Object::NoAction = 1;

--- a/ncm-resolver/src/test/perl/00-load.t
+++ b/ncm-resolver/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::resolver");

--- a/ncm-sendmail/src/test/perl/00-load.t
+++ b/ncm-sendmail/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::sendmail");

--- a/ncm-shorewall/src/test/perl/00-load.t
+++ b/ncm-shorewall/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::shorewall");

--- a/ncm-spma/src/test/perl/00-load.t
+++ b/ncm-spma/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,15 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::spma");
-use_ok("NCM::Component::spma::yum");
-use_ok("NCM::Component::spma::ips");

--- a/ncm-spma/src/test/perl/ips-configure.t
+++ b/ncm-spma/src/test/perl/ips-configure.t
@@ -20,8 +20,8 @@ commands would have been executed as expected.
 use strict;
 use warnings;
 use Test::More tests => 12;
-use NCM::Component::spma::ips;
 use Test::Quattor qw(ips-core ips-run);
+use NCM::Component::spma::ips;
 use Readonly;
 
 use constant CMP_TREE => "/software/components/spma";

--- a/ncm-spma/src/test/perl/ips-freshpkgs.t
+++ b/ncm-spma/src/test/perl/ips-freshpkgs.t
@@ -20,8 +20,8 @@ command outputs and then verifies the returned package set.
 use strict;
 use warnings;
 use Test::More tests => 3;
-use NCM::Component::spma::ips;
 use Test::Quattor;
+use NCM::Component::spma::ips;
 use Readonly;
 use File::Path;
 

--- a/ncm-spma/src/test/perl/ips-frozen.t
+++ b/ncm-spma/src/test/perl/ips-frozen.t
@@ -20,8 +20,8 @@ verifies the output of the method.
 use strict;
 use warnings;
 use Test::More tests => 4;
-use NCM::Component::spma::ips;
 use Test::Quattor;
+use NCM::Component::spma::ips;
 use Readonly;
 
 Readonly my $PKG_LIST_V => join(" ",

--- a/ncm-spma/src/test/perl/ips-imagecreate.t
+++ b/ncm-spma/src/test/perl/ips-imagecreate.t
@@ -21,8 +21,8 @@ to verify the contents of the pkg-publisher.conf file.
 use strict;
 use warnings;
 use Test::More tests => 4;
-use NCM::Component::spma::ips;
 use Test::Quattor;
+use NCM::Component::spma::ips;
 use Readonly;
 use File::Path;
 

--- a/ncm-spma/src/test/perl/ips-loadset.t
+++ b/ncm-spma/src/test/perl/ips-loadset.t
@@ -20,8 +20,8 @@ verifies the output of the method.
 use strict;
 use warnings;
 use Test::More tests => 2;
-use NCM::Component::spma::ips;
 use Test::Quattor;
+use NCM::Component::spma::ips;
 use Readonly;
 
 Readonly my $PKG_LIST => join(" ", @{NCM::Component::spma::ips::PKG_LIST()});

--- a/ncm-spma/src/test/perl/ips-mergepaths.t
+++ b/ncm-spma/src/test/perl/ips-mergepaths.t
@@ -21,8 +21,8 @@ verifies the output.
 use strict;
 use warnings;
 use Test::More tests => 8;
-use NCM::Component::spma::ips;
 use Test::Quattor qw(ips-core);
+use NCM::Component::spma::ips;
 
 use constant CMP_TREE => "/software/components/spma";
 

--- a/ncm-spma/src/test/perl/ips-pkgkeys.t
+++ b/ncm-spma/src/test/perl/ips-pkgkeys.t
@@ -21,6 +21,7 @@ verifies the output.
 use strict;
 use warnings;
 use Test::More tests => 4;
+use Test::Quattor;
 use NCM::Component::spma::ips;
 use Readonly;
 

--- a/ncm-spma/src/test/perl/ips-rejectidrs.t
+++ b/ncm-spma/src/test/perl/ips-rejectidrs.t
@@ -21,6 +21,7 @@ the IDRs are correctly added to the supplied hash.
 use strict;
 use warnings;
 use Test::More tests => 3;
+use Test::Quattor;
 use NCM::Component::spma::ips;
 use Set::Scalar;
 

--- a/ncm-spma/src/test/perl/ips-toremove.t
+++ b/ncm-spma/src/test/perl/ips-toremove.t
@@ -21,6 +21,7 @@ verifies the output.
 use strict;
 use warnings;
 use Test::More tests => 2;
+use Test::Quattor;
 use NCM::Component::spma::ips;
 use Readonly;
 use Set::Scalar;

--- a/ncm-spma/src/test/perl/ips-uniquebe.t
+++ b/ncm-spma/src/test/perl/ips-uniquebe.t
@@ -21,6 +21,7 @@ and some test BE names, verifying the output.
 use strict;
 use warnings;
 use Test::More tests => 3;
+use Test::Quattor;
 use NCM::Component::spma::ips;
 use Readonly;
 use Set::Scalar;

--- a/ncm-spma/src/test/perl/yum-execute-cmd.t
+++ b/ncm-spma/src/test/perl/yum-execute-cmd.t
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
+use Test::Quattor;
 use NCM::Component::spma::yum;
 use Test::Quattor;
 use CAF::Object;

--- a/ncm-spma/src/test/perl/yum-expire-caches.t
+++ b/ncm-spma/src/test/perl/yum-expire-caches.t
@@ -21,8 +21,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use CAF::Object;
 
 $CAF::Object::NoAction = 1;

--- a/ncm-spma/src/test/perl/yum-groups.t
+++ b/ncm-spma/src/test/perl/yum-groups.t
@@ -18,8 +18,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use CAF::Object;
 use Set::Scalar;
 

--- a/ncm-spma/src/test/perl/yum-list-installed.t
+++ b/ncm-spma/src/test/perl/yum-list-installed.t
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
+use Test::Quattor;
 use NCM::Component::spma::yum;
 
 

--- a/ncm-spma/src/test/perl/yum-locked-all.t
+++ b/ncm-spma/src/test/perl/yum-locked-all.t
@@ -18,8 +18,8 @@ Verifies that all the packages we wanted to lock down are actually locked down.
 use strict;
 use warnings;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use Set::Scalar;
 
 my $cmp = NCM::Component::spma::yum->new("spma");

--- a/ncm-spma/src/test/perl/yum-prepare-lock-lists.t
+++ b/ncm-spma/src/test/perl/yum-prepare-lock-lists.t
@@ -18,8 +18,8 @@ Verifies that all the packages we wanted to lock down are actually locked down.
 use strict;
 use warnings;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use Set::Scalar;
 
 my $cmp = NCM::Component::spma::yum->new("spma");

--- a/ncm-spma/src/test/perl/yum-purge-metadata.t
+++ b/ncm-spma/src/test/perl/yum-purge-metadata.t
@@ -21,8 +21,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use CAF::Object;
 
 $CAF::Object::NoAction = 1;

--- a/ncm-spma/src/test/perl/yum-schedule.t
+++ b/ncm-spma/src/test/perl/yum-schedule.t
@@ -18,8 +18,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 
 
 my $cmp = NCM::Component::spma::yum->new("spma");

--- a/ncm-spma/src/test/perl/yum-solve.t
+++ b/ncm-spma/src/test/perl/yum-solve.t
@@ -20,8 +20,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 
 
 my $cmp = NCM::Component::spma::yum->new("spma");

--- a/ncm-spma/src/test/perl/yum-spare-dependencies.t
+++ b/ncm-spma/src/test/perl/yum-spare-dependencies.t
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
+use Test::Quattor;
 use NCM::Component::spma::yum;
 use CAF::Object;
 use Test::MockModule;

--- a/ncm-spma/src/test/perl/yum-spare-requires.t
+++ b/ncm-spma/src/test/perl/yum-spare-requires.t
@@ -20,9 +20,9 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
+use Test::Quattor;
 use NCM::Component::spma::yum;
 use CAF::Object;
-use Test::Quattor;
 use Set::Scalar;
 
 my $install = Set::Scalar->new('pkg;noarch');

--- a/ncm-spma/src/test/perl/yum-spare-whatreq.t
+++ b/ncm-spma/src/test/perl/yum-spare-whatreq.t
@@ -20,9 +20,9 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
+use Test::Quattor;
 use NCM::Component::spma::yum;
 use CAF::Object;
-use Test::Quattor;
 use Set::Scalar;
 
 my $rm = Set::Scalar->new('dep;noarch', 'nodep;noarch');

--- a/ncm-spma/src/test/perl/yum-versionlock.t
+++ b/ncm-spma/src/test/perl/yum-versionlock.t
@@ -18,8 +18,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use CAF::Object;
 use Set::Scalar;
 

--- a/ncm-spma/src/test/perl/yum-wanted.t
+++ b/ncm-spma/src/test/perl/yum-wanted.t
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
+use Test::Quattor;
 use NCM::Component::spma::yum;
 
 

--- a/ncm-ssh/src/test/perl/00-load.t
+++ b/ncm-ssh/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::ssh");

--- a/ncm-sudo/src/test/perl/00-load.t
+++ b/ncm-sudo/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::sudo");

--- a/ncm-sudo/src/test/perl/valid_sudoers.t
+++ b/ncm-sudo/src/test/perl/valid_sudoers.t
@@ -1,10 +1,10 @@
-#!/usr/bin/perl
-# -*- mode: cperl -*-
 use strict;
 use warnings;
 use Test::More;
-# Don't use Test::Quattor here. We really need to run the visudo
+use Test::Quattor;
+# Don't mock CAF::Process here. We really need to run the visudo
 # command to ensure valid configurations get detected.
+$Test::Quattor::procs->unmock_all();
 use NCM::Component::sudo;
 
 use constant INVALID => "123445";

--- a/ncm-symlink/src/test/perl/00-load.t
+++ b/ncm-symlink/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::symlink");

--- a/ncm-sysconfig/src/test/perl/00-load.t
+++ b/ncm-sysconfig/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::sysconfig");

--- a/ncm-sysctl/src/test/perl/00-load.t
+++ b/ncm-sysctl/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::sysctl");

--- a/ncm-syslog/src/test/perl/00-load.t
+++ b/ncm-syslog/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::syslog");

--- a/ncm-syslogng/src/test/perl/00-load.t
+++ b/ncm-syslogng/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::syslogng");

--- a/ncm-systemd/src/test/perl/00-load.t
+++ b/ncm-systemd/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::systemd");

--- a/ncm-useraccess/src/test/perl/00-load.t
+++ b/ncm-useraccess/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::useraccess");


### PR DESCRIPTION
New testtools will not provide `NCM::` via prove include path, but it will be handled via `Test::Quattor`
(this requires no new buildtools)