### PR TITLE
ncm-ccm: allow lowercase characters in trust realm.

### DIFF
--- a/ncm-ccm/src/main/pan/components/ccm/schema.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/schema.pan
@@ -36,7 +36,7 @@ type kerberos_principal_string = string with {
 
     realm = pc_r[len-1];
     # uppercase REALM
-    if (! match(realm, '^[A-Z][A-Z.-_]*$')) {
+    if (! match(realm, '^[a-zA-Z][a-zA-Z.-_]*$')) {
         error("Not a valid realm " + realm);
     };
 


### PR DESCRIPTION
Using upper case characters for Kerberos realms is the convention, but
some organisations may be using lower case realms without issue.