### PR TITLE
ncm-symlink: do not make changes if symlink is correct

### DIFF
--- a/ncm-symlink/src/main/perl/symlink.pm
+++ b/ncm-symlink/src/main/perl/symlink.pm
@@ -353,6 +353,11 @@ sub process_link {
             return 0;
         }
 
+        if ( -l $link and readlink($link) eq $target ) {
+            $self->verbose("symlink $link already defined as $target nothing to do");
+            return 1;
+        }
+
         # 'replace' flag : define existing file type that can be replaced
 
         # First copy global defaults


### PR DESCRIPTION
If the symlink exists and points to the right location then do nothing and log
success.