### PR TITLE
ncm-*: Remove variants of yesno pseudo-boolean

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -13,8 +13,6 @@ include 'components/${project.artifactId}/sssd-sudo';
 include 'components/${project.artifactId}/sssd-sasl';
 include 'components/${project.artifactId}/sssd-tls';
 
-type yesnostring = string with match(SELF, "yes|no");
-
 type authconfig_pamadditions_line_type = {
   "order"       : string with match(SELF, '^(first|last)$')
   "entry"       : string with match(SELF, '^\s*(required|requisite|sufficient|optional|include|substack)\s+\S+\.so(\s|$)')
@@ -111,7 +109,7 @@ type authconfig_method_ldap_type = {
   "nss_initgroups_ignoreusers"     ? string
   "debug"                          ? long
   "log_dir"                        ? string
-  "nss_paged_results"              : yesnostring = "yes"
+  "nss_paged_results"              : legacy_binary_affirmation_string = "yes"
   "pagesize"                       ? long
   "nss_connect_policy"             ? connect_policy = "oneshot"
 };

--- a/ncm-spma/src/main/pan/components/spma/schema.pan
+++ b/ncm-spma/src/main/pan/components/spma/schema.pan
@@ -11,8 +11,6 @@ include 'components/spma/ips/schema';
 include 'components/spma/yum/schema';
 include 'components/spma/software';
 
-type boolean_yes_no = string with match (SELF, '^(yes|no)$'); 
-
 type component_spma_type = {
     include structure_component
     include component_spma_ips
@@ -25,22 +23,22 @@ type component_spma_type = {
     "debug"         ? string with match (SELF, '^(0|1|2|3|4|5)$') # debug level (0-5)
     "flagfile"      ? string # touch this file if there is work to do (i.e. spma-run --execute)
     "headnode"      ? boolean # use head node
-    "localcache"    ? boolean_yes_no # Use SPMA package cache
-    "protectkernel" ? boolean_yes_no # Prevent currrent kernel from being removed
-    "proxy"         ? boolean_yes_no # Enable proxy
+    "localcache"    ? legacy_binary_affirmation_string # Use SPMA package cache
+    "protectkernel" ? legacy_binary_affirmation_string # Prevent currrent kernel from being removed
+    "proxy"         ? legacy_binary_affirmation_string # Enable proxy
     "proxyhost"     ? string # comma-separated list of proxy hosts
     "proxyport"     ? string # proxy port number
-    "proxyrandom"   ? boolean_yes_no # randomize proxyhost
+    "proxyrandom"   ? legacy_binary_affirmation_string # randomize proxyhost
     "proxytype"     ? string with match (SELF, '^(forward|reverse)$') # select proxy type, forward or reverse
-    "rpmexclusive"  ? boolean_yes_no # stop other processes using rpm db
-    "run"           ? boolean_yes_no # Run the SPMA after configuring it
+    "rpmexclusive"  ? legacy_binary_affirmation_string # stop other processes using rpm db
+    "run"           ? legacy_binary_affirmation_string # Run the SPMA after configuring it
     "tmpdir"        ? string # path to the temporary directory
     "trailprefix"   ? boolean # if no escape function, use underscore prefix
     "unescape"      ? boolean # use escape function
     "uninstpaths"   ? string[] # where to find uninstall definitions
-    "userpkgs"      ? boolean_yes_no # Allow user packages
-    "userprio"      ? boolean_yes_no # Priority to user packages
-    "usespmlist"    ? boolean_yes_no # Have SPMA controlling any packages
+    "userpkgs"      ? legacy_binary_affirmation_string # Allow user packages
+    "userprio"      ? legacy_binary_affirmation_string # Priority to user packages
+    "usespmlist"    ? legacy_binary_affirmation_string # Have SPMA controlling any packages
     "verbose"       ? string with match (SELF, '^(0|1)$') # verbose (0,1)
 };
 

--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -8,40 +8,38 @@ declaration template components/ssh/schema;
 include 'quattor/types/component';
 include 'pan/types';
 
-type ssh_yesnostring = string with match(SELF, "^(yes|no)$");
-
 type ssh_preferred_authentication = string with match(SELF, '^(gssapi-with-mic|hostbased|publickey|keyboard-interactive|password)$');
 
 type ssh_core_options_type = {
     "AddressFamily"                     ? string with match (SELF, '^(any|inet6?)$')
-    "ChallengeResponseAuthentication"   ? ssh_yesnostring
+    "ChallengeResponseAuthentication"   ? legacy_binary_affirmation_string
     "Ciphers"                           ? string
     "Compression"                       ? string with match (SELF, '^(yes|delayed|no)$')
-    "GSSAPIAuthentication"              ? ssh_yesnostring
-    "GSSAPICleanupCredentials"          ? ssh_yesnostring
-    "GSSAPIKeyExchange"                 ? ssh_yesnostring
-    "GatewayPorts"                      ? ssh_yesnostring
-    "HostbasedAuthentication"           ? ssh_yesnostring
+    "GSSAPIAuthentication"              ? legacy_binary_affirmation_string
+    "GSSAPICleanupCredentials"          ? legacy_binary_affirmation_string
+    "GSSAPIKeyExchange"                 ? legacy_binary_affirmation_string
+    "GatewayPorts"                      ? legacy_binary_affirmation_string
+    "HostbasedAuthentication"           ? legacy_binary_affirmation_string
     "LogLevel"                          ? string with match (SELF, '^(QUIET|FATAL|ERROR|INFO|VERBOSE|DEBUG[123]?)$')
     "MACs"                              ? string
-    "PasswordAuthentication"            ? ssh_yesnostring
+    "PasswordAuthentication"            ? legacy_binary_affirmation_string
     "Protocol"                          ? string
-    "PubkeyAuthentication"              ? ssh_yesnostring
-    "RSAAuthentication"                 ? ssh_yesnostring
-    "RhostsRSAAuthentication"           ? ssh_yesnostring
-    "SendEnv"                           ? ssh_yesnostring
-    "TCPKeepAlive"                      ? ssh_yesnostring
+    "PubkeyAuthentication"              ? legacy_binary_affirmation_string
+    "RSAAuthentication"                 ? legacy_binary_affirmation_string
+    "RhostsRSAAuthentication"           ? legacy_binary_affirmation_string
+    "SendEnv"                           ? legacy_binary_affirmation_string
+    "TCPKeepAlive"                      ? legacy_binary_affirmation_string
     "XAuthLocation"                     ? string
 };
 
 type ssh_daemon_options_type = {
     include ssh_core_options_type
-    "AFSTokenPassing"                   ? ssh_yesnostring
+    "AFSTokenPassing"                   ? legacy_binary_affirmation_string
     @{AcceptEnv, one per line}
     "AcceptEnv"                         ? string[]
-    "AllowAgentForwarding"              ? ssh_yesnostring
+    "AllowAgentForwarding"              ? legacy_binary_affirmation_string
     "AllowGroups"                       ? string
-    "AllowTcpForwarding"                ? ssh_yesnostring
+    "AllowTcpForwarding"                ? legacy_binary_affirmation_string
     "AllowUsers"                        ? string
     "AuthorizedKeysFile"                ? string
     "AuthorizedKeysCommand"             ? string
@@ -51,66 +49,66 @@ type ssh_daemon_options_type = {
     "ClientAliveInterval"               ? long
     "DenyGroups"                        ? string
     "DenyUsers"                         ? string
-    "GSSAPIStrictAcceptorCheck"         ? ssh_yesnostring
+    "GSSAPIStrictAcceptorCheck"         ? legacy_binary_affirmation_string
     @{HostKey, one per line}
     "HostKey"                           ? string[]
-    "HPNDisabled"                       ? ssh_yesnostring
+    "HPNDisabled"                       ? legacy_binary_affirmation_string
     "HPNBufferSize"                     ? long
-    "IgnoreRhosts"                      ? ssh_yesnostring
-    "IgnoreUserKnownHosts"              ? ssh_yesnostring
-    "KbdInteractiveAuthentication"      ? ssh_yesnostring
-    "KerberosAuthentication"            ? ssh_yesnostring
-    "KerberosGetAFSToken"               ? ssh_yesnostring
-    "KerberosOrLocalPasswd"             ? ssh_yesnostring
-    "KerberosTgtPassing"                ? ssh_yesnostring
-    "KerberosTicketAuthentication"      ? ssh_yesnostring
-    "KerberosTicketCleanup"             ? ssh_yesnostring
+    "IgnoreRhosts"                      ? legacy_binary_affirmation_string
+    "IgnoreUserKnownHosts"              ? legacy_binary_affirmation_string
+    "KbdInteractiveAuthentication"      ? legacy_binary_affirmation_string
+    "KerberosAuthentication"            ? legacy_binary_affirmation_string
+    "KerberosGetAFSToken"               ? legacy_binary_affirmation_string
+    "KerberosOrLocalPasswd"             ? legacy_binary_affirmation_string
+    "KerberosTgtPassing"                ? legacy_binary_affirmation_string
+    "KerberosTicketAuthentication"      ? legacy_binary_affirmation_string
+    "KerberosTicketCleanup"             ? legacy_binary_affirmation_string
     "KeyRegenerationInterval"           ? long
     @{ListenAddress, one per line}
     "ListenAddress"                     ? type_hostport[]
     "LoginGraceTime"                    ? long
     "MaxAuthTries"                      ? long
     "MaxStartups"                       ? long
-    "NoneEnabled"                       ? ssh_yesnostring
-    "PermitEmptyPasswords"              ? ssh_yesnostring
+    "NoneEnabled"                       ? legacy_binary_affirmation_string
+    "PermitEmptyPasswords"              ? legacy_binary_affirmation_string
     "PermitRootLogin"                   ? string with match (SELF, '^(yes|without-password|forced-commands-only|no)$')
     "PermitTunnel"                      ? string with match (SELF, '^(yes|point-to-point|ethernet|no)$')
-    "PermitUserEnvironment"             ? ssh_yesnostring
+    "PermitUserEnvironment"             ? legacy_binary_affirmation_string
     "PidFile"                           ? string
     "Port"                              ? long
-    "PrintLastLog"                      ? ssh_yesnostring
-    "PrintMotd"                         ? ssh_yesnostring
-    "RhostsAuthentication"              ? ssh_yesnostring
+    "PrintLastLog"                      ? legacy_binary_affirmation_string
+    "PrintMotd"                         ? legacy_binary_affirmation_string
+    "RhostsAuthentication"              ? legacy_binary_affirmation_string
     "ServerKeyBits"                     ? long
-    "ShowPatchLevel"                    ? ssh_yesnostring
-    "StrictModes"                       ? ssh_yesnostring
+    "ShowPatchLevel"                    ? legacy_binary_affirmation_string
+    "StrictModes"                       ? legacy_binary_affirmation_string
     "Subsystem"                         ? string
     "SyslogFacility"                    ? string with match (SELF, '^(AUTH(PRIV)?|DAEMON|USER|KERN|UUCP|NEWS|MAIL|SYSLOG|LPR|FTP|CRON|LOCAL[0-7])$')
     "TcpRcvBuf"                         ? long
-    "TcpRcvBufPoll"                     ? ssh_yesnostring
-    "UseDNS"                            ? ssh_yesnostring
-    "UseLogin"                          ? ssh_yesnostring
-    "UsePAM"                            ? ssh_yesnostring
-    "UsePrivilegeSeparation"            ? ssh_yesnostring
-    "VerifyReverseMapping"              ? ssh_yesnostring
+    "TcpRcvBufPoll"                     ? legacy_binary_affirmation_string
+    "UseDNS"                            ? legacy_binary_affirmation_string
+    "UseLogin"                          ? legacy_binary_affirmation_string
+    "UsePAM"                            ? legacy_binary_affirmation_string
+    "UsePrivilegeSeparation"            ? legacy_binary_affirmation_string
+    "VerifyReverseMapping"              ? legacy_binary_affirmation_string
     "X11DisplayOffset"                  ? long
-    "X11Forwarding"                     ? ssh_yesnostring
-    "X11UseLocalhost"                   ? ssh_yesnostring
+    "X11Forwarding"                     ? legacy_binary_affirmation_string
+    "X11UseLocalhost"                   ? legacy_binary_affirmation_string
 };
 
 type ssh_client_options_type = {
     include ssh_core_options_type
-    "BatchMode"                         ? ssh_yesnostring
+    "BatchMode"                         ? legacy_binary_affirmation_string
     "ConnectTimeout"                    ? long
-    "EnableSSHKeysign"                  ? ssh_yesnostring
-    "ForwardAgent"                      ? ssh_yesnostring
-    "ForwardX11"                        ? ssh_yesnostring
-    "GSSAPIDelegateCredentials"         ? ssh_yesnostring
+    "EnableSSHKeysign"                  ? legacy_binary_affirmation_string
+    "ForwardAgent"                      ? legacy_binary_affirmation_string
+    "ForwardX11"                        ? legacy_binary_affirmation_string
+    "GSSAPIDelegateCredentials"         ? legacy_binary_affirmation_string
     "Port"                              ? long
     "PreferredAuthentications"          ? ssh_preferred_authentication[]
-    "RhostsAuthentication"              ? ssh_yesnostring
-    "StrictHostKeyChecking"             ? ssh_yesnostring
-    "UsePrivilegedPort"                 ? ssh_yesnostring
+    "RhostsAuthentication"              ? legacy_binary_affirmation_string
+    "StrictHostKeyChecking"             ? legacy_binary_affirmation_string
+    "UsePrivilegedPort"                 ? legacy_binary_affirmation_string
 };
 
 type ssh_daemon_type = {


### PR DESCRIPTION
Standardise on new type from pan/legacy

quattor/template-library-core#111 introduced a common type for the variously named versions of a string containing either yes or no, this switches the components to use the new common version rather than their own differently named types.

It does not yes address the components that define types of string with a validation rule to essentially do the same thing, but without defining an explicit type.

Turns out coding on a train isn't that easy... just left Stirling, next stop Gleneagles.
