### PR TITLE
ncm-metaconfig: httpd support GSSAPI auth

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_profiles.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_profiles.pan
@@ -1,0 +1,73 @@
+object template krb5_profiles;
+
+include 'metaconfig/httpd/schema';
+
+bind "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_profiles.conf}/contents" = httpd_vhosts;
+
+prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_profiles.conf}";
+"module" = "httpd/2.4/generic_server";
+"daemons/httpd" = "restart";
+
+variable FULL_HOSTNAME = 'myhost.domain';
+variable HOSTNAME = 'myhost';
+variable DB_IP = nlist(HOSTNAME, '1.2.3.4');
+
+final variable QUATTOR_SERVER_PROFILE_PORT ?= 444;
+variable KRB5_REALM ?= 'YOUR.REALM';
+variable KRB5_QUATTOR_SERVICE ?= 'host';
+
+prefix '/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_profiles.conf}';
+'module' = "httpd/generic_server";
+'daemons' = dict("httpd", "restart");
+
+'contents/modules' = list();
+'contents/encodings/0/mime' = 'x-gzip';
+'contents/encodings/0/extensions' = list('.gz', '.tgz');
+'contents/listen/0' = dict(
+    'name', DB_IP[HOSTNAME],
+    'port', QUATTOR_SERVER_PROFILE_PORT,
+);
+
+prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_profiles.conf}/contents/vhosts/profiles";
+'port' = QUATTOR_SERVER_PROFILE_PORT;
+'documentroot' = "/var/www/https";
+'servername' = format("%s:%d", FULL_HOSTNAME, QUATTOR_SERVER_PROFILE_PORT);
+'rewrite/maps/0/name' = "ACLmap";
+'rewrite/maps/0/type' = "txt";
+'rewrite/maps/0/source' = "/var/www/acl/ACLmap.txt";
+'hostnamelookups' = true;
+'ip/0' = DB_IP[HOSTNAME];
+
+'nss/engine' = true;
+# SSL 3 ciphers. SSL 2 is disabled by default.
+'nss/ciphersuite' = list('+rsa_rc4_128_md5', '+rsa_rc4_128_sha', '+rsa_3des_sha', '-rsa_des_sha', '-rsa_rc4_40_md5', '-rsa_rc2_40_md5', '-rsa_null_md5', '-rsa_null_sha', '+fips_3des_sha','-fips_des_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-rsa_des_56_sha', '-rsa_rc4_56_sha', '+rsa_aes_128_sha', '+rsa_aes_256_sha');
+'nss/protocol' = list('TLSv1.0', 'TLSv1.1', 'TLSv1.2');
+'nss/nickname' = 'Server-Cert';
+'nss/certificatedatabase' = '/etc/httpd/alias';
+
+'log/level' = 'warn';
+'log/error' = format('logs/%s_error_log', 'profiles');
+'log/transfer' = format('logs/%s_access_log', 'profiles');
+'log/custom' = append(dict(
+    'location', format("logs/%s_request_log", 'profiles'),
+    'name', "ssl_combined",
+));
+
+prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_profiles.conf}/contents/vhosts/profiles/directories/0";
+"name" = "/var/www/https/profiles";
+"rewrite/rules/0/conditions/0" = dict(
+    "test", "${ACLmap:%{REMOTE_HOST}|NO}",
+    "pattern", "NO",
+);
+"rewrite/rules/0/conditions/1" = dict(
+    "test", "%{REMOTE_USER}",
+    "pattern", format("^%s/(.+)@%s$", KRB5_QUATTOR_SERVICE, KRB5_REALM),
+);
+'rewrite/rules/0/regexp' = '^(.*/)?.*\.(xml|json)(\.gz)?$';
+'rewrite/rules/0/destination' = '$1%1.$2$3';
+'rewrite/rules/0/flags/0' = "L";
+'auth/require' = nlist("type", "valid-user");
+'auth/name' = "Quattor Kerberos Login";
+'auth/type' = "GSSAPI";
+'gssapi/sslonly' = true;
+'gssapi/credstore' = list('keytab:/etc/httpd/conf/ipa.keytab');

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_sunstone.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_sunstone.pan
@@ -1,0 +1,56 @@
+object template krb5_sunstone;
+
+include 'metaconfig/httpd/schema';
+
+bind "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_sunstone.conf}/contents" = httpd_vhosts;
+
+prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_sunstone.conf}";
+"module" = "httpd/2.4/generic_server";
+"daemons/httpd" = "restart";
+
+variable FULL_HOSTNAME = 'myhost.domain';
+variable HOSTNAME = 'myhost';
+variable DB_IP = nlist(HOSTNAME, '1.2.3.4');
+
+variable KRB5_REALM ?= 'YOUR.REALM';
+variable KRB5_QUATTOR_SERVICE ?= 'host';
+
+variable SUNSTONE_PUBLIC_DIR = "/usr/lib/one/sunstone/public";
+
+prefix '/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_sunstone.conf}';
+'module' = "httpd/generic_server";
+'daemons' = dict("httpd", "restart");
+
+prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_sunstone.conf}/contents/vhosts/sunstone";
+'port' = 443;
+'documentroot' = SUNSTONE_PUBLIC_DIR;
+'servername' = format("%s:%d", FULL_HOSTNAME, 443);
+'passenger/user' = 'oneadmin';
+
+    'hostnamelookups' = true;
+'ip/0' = DB_IP[HOSTNAME];
+
+'nss/engine' = true;
+# SSL 3 ciphers. SSL 2 is disabled by default.
+'nss/ciphersuite' = list('+rsa_rc4_128_md5', '+rsa_rc4_128_sha', '+rsa_3des_sha', '-rsa_des_sha', '-rsa_rc4_40_md5', '-rsa_rc2_40_md5', '-rsa_null_md5', '-rsa_null_sha', '+fips_3des_sha','-fips_des_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-rsa_des_56_sha', '-rsa_rc4_56_sha', '+rsa_aes_128_sha', '+rsa_aes_256_sha');
+'nss/protocol' = list('TLSv1.0', 'TLSv1.1', 'TLSv1.2');
+'nss/nickname' = 'Server-Cert';
+'nss/certificatedatabase' = '/etc/httpd/alias';
+
+'log/level' = 'warn';
+'log/error' = format('logs/%s_error_log', 'sunstone');
+'log/transfer' = format('logs/%s_access_log', 'sunstone');
+'log/custom' = append(dict(
+    'location', format("logs/%s_request_log", 'sunstone'),
+    'name', "ssl_combined",
+));
+
+prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_sunstone.conf}/contents/vhosts/sunstone/directories/0";
+"name" = SUNSTONE_PUBLIC_DIR;
+'auth/require' = nlist("type", "valid-user");
+'auth/name' = "Sunstone Kerberos Login";
+'auth/type' = "GSSAPI";
+'gssapi/sslonly' = true;
+'gssapi/credstore' = list('keytab:/etc/http.keytab');
+'access' = dict('allowoverride', list('None'));
+'options' = list('-MultiViews');

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_profiles/base
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_profiles/base
@@ -1,0 +1,32 @@
+Base test for krb5_profiles.conf config
+---
+/etc/httpd/conf.d/krb5_profiles.conf
+---
+^addencoding x-gzip .gz .tgz$
+^listen 1.2.3.4:444 $
+^<virtualhost    1.2.3.4:444>$
+^\s{4}servername myhost.domain:444$
+^\s{4}documentroot /var/www/https$
+^\s{4}hostnamelookups on$
+^\s{4}nsscertificatedatabase /etc/httpd/alias$
+^\s{4}nssciphersuite \+rsa_rc4_128_md5,\+rsa_rc4_128_sha,\+rsa_3des_sha,-rsa_des_sha,-rsa_rc4_40_md5,-rsa_rc2_40_md5,-rsa_null_md5,-rsa_null_sha,\+fips_3des_sha,-fips_des_sha,-fortezza,-fortezza_rc4_128_sha,-fortezza_null,-rsa_des_56_sha,-rsa_rc4_56_sha,\+rsa_aes_128_sha,\+rsa_aes_256_sha\s+
+^\s{4}nssengine on$
+^\s{4}nssnickname "Server-Cert"$
+^\s{4}nssprotocol TLSv1.0,TLSv1.1,TLSv1.2$
+^\s{4}rewriteengine on$
+^\s{4}rewritemap ACLmap txt:/var/www/acl/ACLmap.txt $
+^\s{4}loglevel warn$
+^\s{4}errorlog logs/profiles_error_log$
+^\s{4}transferlog logs/profiles_access_log$
+^\s{4}customlog logs/profiles_request_log ssl_combined$
+^\s{4}<directory /var/www/https/profiles>$
+^\s{8}authname "Quattor Kerberos Login"$
+^\s{8}require valid-user $
+^\s{8}authtype GSSAPI$
+^\s{8}gssapicredstore keytab:/etc/httpd/conf/ipa.keytab$
+^\s{8}gssapisslonly on$
+^\s{8}rewritecond \$\{ACLmap:%\{REMOTE_HOST\}\|NO\} NO$
+^\s{8}rewritecond %\{REMOTE_USER\} \^host/\(\.\+\)@YOUR\.REALM\$$
+^\s{8}rewriterule \^\(\.\*/\)\?\.\*\\\.\(xml\|json\)\(\\\.gz\)\?\$ \$1%1\.\$2\$3 \[L\]$
+^\s{4}</directory>$
+^</virtualhost>$

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_sunstone/base
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_sunstone/base
@@ -1,0 +1,28 @@
+Base test for krb5_sunstone.conf config
+---
+/etc/httpd/conf.d/krb5_sunstone.conf
+---
+^<virtualhost    1.2.3.4:443>$
+^\s{4}servername myhost.domain:443$
+^\s{4}documentroot /usr/lib/one/sunstone/public$
+^\s{4}hostnamelookups on$
+^\s{4}nsscertificatedatabase /etc/httpd/alias$
+^\s{4}nssciphersuite \+rsa_rc4_128_md5,\+rsa_rc4_128_sha,\+rsa_3des_sha,-rsa_des_sha,-rsa_rc4_40_md5,-rsa_rc2_40_md5,-rsa_null_md5,-rsa_null_sha,\+fips_3des_sha,-fips_des_sha,-fortezza,-fortezza_rc4_128_sha,-fortezza_null,-rsa_des_56_sha,-rsa_rc4_56_sha,\+rsa_aes_128_sha,\+rsa_aes_256_sha\s+
+^\s{4}nssengine on$
+^\s{4}nssnickname "Server-Cert"$
+^\s{4}nssprotocol TLSv1.0,TLSv1.1,TLSv1.2$
+^\s{4}loglevel warn$
+^\s{4}errorlog logs/sunstone_error_log$
+^\s{4}transferlog logs/sunstone_access_log$
+^\s{4}customlog logs/sunstone_request_log ssl_combined$
+^\s{4}passengeruser oneadmin$
+^\s{4}<directory /usr/lib/one/sunstone/public>$
+^\s{8}options -MultiViews$
+^\s{8}allowoverride None$
+^\s{8}authname "Sunstone Kerberos Login"$
+^\s{8}require valid-user $
+^\s{8}authtype GSSAPI$
+^\s{8}gssapicredstore keytab:/etc/http.keytab$
+^\s{8}gssapisslonly on$
+^\s{4}</directory>$
+^</virtualhost>$

--- a/ncm-metaconfig/src/main/metaconfig/httpd/config/ssl_nss.tt
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/config/ssl_nss.tt
@@ -1,7 +1,7 @@
-[%- booleans = ['engine', 
+[%- booleans = ['engine',
                 'renegotiation', 'requiresafenegotiation', 'ocsp',
                 ] -%]
-[%- list = ["protocol", "options"] -%]
+[%- list = ["options"] -%]
 [%- colon_list = ["ciphersuite"] -%]
 [%- list_of_val = ["cryptodevice"] -%]
 [%- list_of_list = ["randomseed"] -%]
@@ -9,12 +9,9 @@
 [%- FOREACH pair IN desc.pairs %]
 [%-     SWITCH pair.key -%]
 [%-         CASE "ciphersuite" -%]
-[%              ssl_nss %][% pair.key %]
-[%-             IF ssl_nss == 'nss' -%]
- [%                 pair.value.join(',') %]
-[%-             ELSE -%]
- [%                 pair.value.join(':') %]
-[%-             END %]
+[%              ssl_nss %][% pair.key %] [% pair.value.join(ssl_nss == 'nss' ? ',' : ':') %]
+[%-         CASE "protocol" -%]
+[%              ssl_nss %][% pair.key %] [% pair.value.join(ssl_nss == 'nss' ? ',' : ' ') %]
 [%-         CASE "mutex" -%]
 [%              (_httpdversion.0 >=2 && _httpdversion.1 >=4) ? '' : ssl_nss %][% pair.key %] [% pair.value %]
 [%-         CASE "requiressl" -%]

--- a/ncm-metaconfig/src/main/metaconfig/httpd/config/vhost.tt
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/config/vhost.tt
@@ -4,7 +4,7 @@ documentroot [% vhost.documentroot %]
 [% END -%]
 hostnamelookups [% vhost.hostnamelookups ? "on" : "off" %]
 
-[%- to_process = ['ssl', 'nss', 'env', 'aliases', 'rewrite', 'perl', 'wsgi', 'log', 'rails', 'browsermatch'] -%] 
+[%- to_process = ['ssl', 'nss', 'env', 'aliases', 'rewrite', 'perl', 'wsgi', 'log', 'rails', 'browsermatch', 'passenger'] -%]
 [%- FOREACH p IN  to_process -%]
 [%-      IF vhost.exists(p) -%]
 [%          INCLUDE "metaconfig/httpd/config/${p}.tt" desc=vhost.$p %]

--- a/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
@@ -4,10 +4,10 @@ declaration template metaconfig/httpd/schema;
 include 'pan/types';
 include 'components/accounts/functions';
 
-type httpd_cipherstring = string with match(SELF, "^(TLSv1|TLSv1.0|TLSv1.1|TLSv1.2)$")
+type httpd_cipherstring = string with match(SELF, '^(TLSv1|TLSv1\.[012])$')
     || error("Use a modern cipher suite, for Pete's sake!");
 
-type httpd_nss_protocol = string with match(SELF, "^(TLSv1.0|SSLv3|All)$");
+type httpd_nss_protocol = string with match(SELF, '^(TLSv1\.[012]|SSLv3|All)$');
 type httpd_nss_cipherstring = string with match(SELF, '^(\+|-)(rsa_3des_sha|rsa_des_56_sha|rsa_des_sha|rsa_null_md5|rsa_null_sha|rsa_rc2_40_md5|rsa_rc4_128_md5|rsa_rc4_128_sha|rsa_rc4_40_md5|rsa_rc4_56_sha|fortezza|fortezza_rc4_128_sha|fortezza_null|fips_des_sha|fips_3des_sha|rsa_aes_128_sha|rsa_aes_256_sha)$');
 
 @documentation{
@@ -266,7 +266,8 @@ type httpd_name_virtual_host = {
     "port" ? type_port
 };
 
-type httpd_auth_type = string with match(SELF,"^(Basic|Kerberos|Shibboleth)$");
+type httpd_auth_type = string with match(SELF,"^(Basic|Kerberos|Shibboleth|GSSAPI)$");
+
 type httpd_auth = {
     "name": string
     "require" : httpd_auth_require = nlist('type','valid-user')
@@ -342,10 +343,19 @@ type httpd_listen = {
     "protocol" ? string
 };
 
+type httpd_passenger_vhost = {
+    "maxinstances" ? long
+    "maxinstancesperapp" ? long
+    "mininstances" ? long
+    "user" ? string
+    "group" ? string
+};
+
 type httpd_passenger = {
+    include httpd_passenger_vhost
     "ruby" : string = "/usr/bin/ruby"
     "root" : string = "/usr/share/rubygems/gems/passenger-latest"
-    "maxpoolsize" : long
+    "maxpoolsize" : long = 6
 };
 
 type httpd_rails = {
@@ -455,6 +465,7 @@ type httpd_vhost = {
     "rails" ? httpd_rails
     "proxies" ? httpd_proxy_directive[]
     "browsermatch" ? httpd_browsermatch[]
+    "passenger" ? httpd_passenger_vhost
 };
 
 # system wide settings


### PR DESCRIPTION
Add support for GSSAPI auth and example/unittests of apache config for retrieving profiles using kerberos