### PR TITLE
ncm-metaconfig: add joincomma and joinspace convert options

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -27,6 +27,10 @@ type ${project.artifactId}_textrender_convert = {
     'doublequote' ? boolean
     @{Convert string to singlequoted string.}
     'singlequote' ? boolean
+    @{Convert list to comma-separated string}
+    'joincomma' ? boolean
+    @{Convert list to space-separated string}
+    'joinspace' ? boolean
 } with {
     # Only one boolean conversion can be true
     boolean_conversion = list('yesno', 'YESNO', 'truefalse', 'TRUEFALSE');
@@ -51,6 +55,19 @@ type ${project.artifactId}_textrender_convert = {
             found = true;
         };
     };
+
+    # Only one list conversion can be true
+    list_conversion = list('joincomma', 'joinspace');
+    found = false;
+    foreach (idx; name; list_conversion) {
+        if(exists(SELF[name]) && SELF[name]) {
+            if(found) {
+                error('metaconfig element can only have one list conversion enabled, got '+to_string(SELF));
+            };
+            found = true;
+        };
+    };
+
     true;
 };
 

--- a/ncm-metaconfig/src/test/perl/element.t
+++ b/ncm-metaconfig/src/test/perl/element.t
@@ -22,6 +22,6 @@ my $fh = get_file("/foo/bar");
 is("$fh", "boolean=1\nstring=mystring\n\n", "tiny with no element conversion as expected");
 
 my $fh2 = get_file("/foo/bar2");
-is("$fh2", "boolean=TRUE\nstring='mystring'\n\n", "tiny with element conversion as expected");
+is("$fh2", "boolean=TRUE\nlist='a','b'\nstring='mystring'\n\n", "tiny with element conversion as expected");
 
 done_testing();

--- a/ncm-metaconfig/src/test/resources/element.pan
+++ b/ncm-metaconfig/src/test/resources/element.pan
@@ -18,3 +18,7 @@ prefix "/software/components/metaconfig/services/{/foo/bar}";
 prefix "/software/components/metaconfig/services/{/foo/bar2}";
 "convert/TRUEFALSE" = true;
 "convert/singlequote" = true;
+
+"convert/joincomma" = true;
+# string elements will be single-quoted before the join
+"contents/list" = list("a","b");


### PR DESCRIPTION
In particular useful to use `tiny` with lists of scalars
Requires https://github.com/quattor/CCM/pull/96
