### PR TITLE
Unittest hotfixes

### DIFF
--- a/ncm-nfs/src/test/perl/compare.t
+++ b/ncm-nfs/src/test/perl/compare.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Quattor;
 
 use NCM::Component::nfs;
 

--- a/ncm-postgresql/src/main/resources/tests/regexps/main_config/value
+++ b/ncm-postgresql/src/main/resources/tests/regexps/main_config/value
@@ -6,12 +6,12 @@ contentspath=/config
 ---
 ^archive_command = 'my archive command'$
 ^archive_mode = yes$
-^archive_timeout = '10'$
+^archive_timeout = 10$
 ^listen_addresses = 'a,b,c'$
 ^log_destination = 'stderr'$
 ^log_directory = 'pg_log'$
 ^log_filename = 'postgresql-%a.log'$
 ^log_rotation_age = '1d'$
-^log_rotation_size = '0'$
+^log_rotation_size = 0$
 ^log_truncate_on_rotation = yes$
 ^logging_collector = yes$

--- a/ncm-postgresql/src/test/perl/01-tt.t
+++ b/ncm-postgresql/src/test/perl/01-tt.t
@@ -1,6 +1,11 @@
 use strict;
 use warnings;
 
+use Test::Quattor::ProfileCache qw(set_json_typed get_json_typed);
+BEGIN {
+    set_json_typed()
+}
+
 use Test::More;
 use Test::Quattor::TextRender::Component;
 

--- a/ncm-spma/src/test/perl/yum-make-cache.t
+++ b/ncm-spma/src/test/perl/yum-make-cache.t
@@ -20,8 +20,8 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use NCM::Component::spma::yum;
 use Test::Quattor;
+use NCM::Component::spma::yum;
 use CAF::Object;
 
 $CAF::Object::NoAction = 1;


### PR DESCRIPTION
Handle ncm-postgres unittest failure due to new json_typed default ; and prepare ncm-spma and ncm-nfs for new buildtools