### PR TITLE
ncm-metaconfig: lmod: scDescript needs quoted values

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/lmod/scDescript.tt
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/scDescript.tt
@@ -1,3 +1,3 @@
 [% FOREACH sc IN data.pairs -%]
-["[%    sc.key %]"] = [% sc.value %],
+["[%    sc.key %]"] = "[% sc.value %]",
 [% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/lmod/tests/regexps/default/base
+++ b/ncm-metaconfig/src/main/metaconfig/lmod/tests/regexps/default/base
@@ -91,11 +91,11 @@ Test default lmodrc file
 ^\}$
 ^scDescriptT = \{$
 ^\s{4}\{$
-^\s{8}\["dir"\] = /some/dir0,$
-^\s{8}\["timestamp"\] = /some/path0,$
+^\s{8}\["dir"\] = "/some/dir0",$
+^\s{8}\["timestamp"\] = "/some/path0",$
 ^\s{4}\},$
 ^\s{4}\{$
-^\s{8}\["dir"\] = /some/dir1,$
-^\s{8}\["timestamp"\] = /some/path1,$
+^\s{8}\["dir"\] = "/some/dir1",$
+^\s{8}\["timestamp"\] = "/some/path1",$
 ^\s{4}\},$
 ^\}$


### PR DESCRIPTION
Values without quotes generates an invalid lmod rc file.
