### PR TITLE
ncm-dirperm: add 'accounts' to list of pre dependencies

### DIFF
--- a/ncm-dirperm/src/main/pan/components/dirperm/config.pan
+++ b/ncm-dirperm/src/main/pan/components/dirperm/config.pan
@@ -12,7 +12,7 @@ include "components/dirperm/schema";
 
 prefix '/software/components/${project.artifactId}';
 
-'dependencies/pre' ?= list('spma');
+'dependencies/pre' ?= list('spma', 'accounts');
 'register_change' ?= list('/system/filesystems');
 'version' = '${no-snapshot-version}';
 'active' ?= true;


### PR DESCRIPTION
I think the accounts component should be added to the list of pre dependencies for the dirperm component. If a new profile arrives on a host with dirperm config for accounts that do not exist, the component will err. If the accounts component were to run beforehand and create new accounts for which new dirperm config has been written, the dirperm component will run successfully.

I doubt this will introduce any backwards incompatibility.