### PR TITLE
ncm-metaconfig: cgroups: change default cgconfig location

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/cgroups/cgconfig.tt
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/cgconfig.tt
@@ -1,6 +1,6 @@
 [% FOREACH pair IN CCM.contents.pairs -%]
 [%      SWITCH pair.key %]
-[%-         CASE ['group'] -%]
+[%-         CASE ['group', 'template'] -%]
 [%-             FOREACH group IN pair.value.pairs %]
 [%                  pair.key %] [% CCM.unescape(group.key) %] {
 [%                  INCLUDE "metaconfig/cgroups/config/${pair.key}.tt" data=group.value FILTER indent -%]

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/config/template.tt
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/config/template.tt
@@ -1,0 +1,1 @@
+[%- INCLUDE "metaconfig/cgroups/config/group.tt" -%]

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/pan/cgconfig.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/pan/cgconfig.pan
@@ -8,4 +8,7 @@ bind "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/co
 prefix  "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}";
 "mode" = 0644;
 "module" = "cgroups/cgconfig";
-"daemons" = dict("cgconfig", "restart");
+"daemons" = dict(
+    "cgconfig", "restart",
+    "cgred", "restart",
+);

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/pan/cgconfig.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/pan/cgconfig.pan
@@ -3,9 +3,9 @@ unique template metaconfig/cgroups/cgconfig;
 include 'metaconfig/cgroups/schema';
 
 # Can only pass a dict as CCM.contents
-bind "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents" = cgroups_cgconfig_service;
+bind "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents" = cgroups_cgconfig_service;
 
-prefix  "/software/components/metaconfig/services/{/etc/cgconfig.conf}";
+prefix  "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}";
 "mode" = 0644;
 "module" = "cgroups/cgconfig";
 "daemons" = dict("cgconfig", "restart");

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/pan/cgrules.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/pan/cgrules.pan
@@ -1,6 +1,6 @@
 unique template metaconfig/cgroups/cgrules;
 
-@{cgrules are applied via cgrulesengd}
+@{cgrules are applied via cgred service}
 variable CGROUPS_CGRULESENGD ?= true;
 
 include 'metaconfig/cgroups/schema';
@@ -14,7 +14,7 @@ prefix  "/software/components/metaconfig/services/{/etc/cgrules.conf}";
 # rules can also be used by pam module, in which case the cgrulesengd shouldn't be used
 "daemons" = {
     if (CGROUPS_CGRULESENGD) {
-        SELF["cgrulesengd"] = "restart";
+        SELF["cgred"] = "restart";
     };
     SELF;
 };

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/pan/schema.pan
@@ -78,5 +78,6 @@ type cgroups_cgconfig_default = {
 type cgroups_cgconfig_service = {
     'mount' ? cgroups_cgconfig_mount
     'group' ? cgroups_cgconfig_group{}
+    'template' ? cgroups_cgconfig_group{}
     'default' ? cgroups_cgconfig_default
 };

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig.pan
@@ -39,3 +39,9 @@ prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/
 "admin/gid" = "group4";
 "admin/fperm" = "077";
 "admin/dperm" = "077";
+
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/template/{my/users/%u}/controllers";
+"memory" = dict();
+"cpu" = dict(
+    "cpu.shares", "250",
+);

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig.pan
@@ -12,11 +12,11 @@ prefix '/software/components/accounts';
 
 include 'metaconfig/cgroups/cgconfig';
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents";
 "mount/{name=abc}" = 'a/b/c';
 "mount/ns" = 'ns/abc';
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/default/perm";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/default/perm";
 "task/uid" = "user1";
 "task/gid" = "group1";
 "task/fperm" = "022";
@@ -25,13 +25,13 @@ prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/d
 "admin/fperm" = "077";
 "admin/dperm" = "077";
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/group/{my/special}/controllers";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/group/{my/special}/controllers";
 "cpu" = dict(); # empty
 "cpuacct" = dict(
     'cpu.shares', '100',
 );
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/group/{my/special}/perm";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/group/{my/special}/perm";
 "task/uid" = "user3";
 "task/gid" = "group3";
 "task/fperm" = "022";

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig_example2.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig_example2.pan
@@ -2,10 +2,10 @@ object template cgconfig_example2;
 
 include 'metaconfig/cgroups/cgconfig';
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents";
 "mount/{name=scheduler}" = '/mnt/cgroups/cpu';
 "mount/{name=noctrl}" = '/mnt/cgroups/noctrl';
 "mount/cpu" = '/mnt/cgroups/cpu';
 
-"/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/group/{daemons}/controllers/cpu/cpu.shares" = '1000';
-"/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/group/{test}/controllers/{name=noctrl}" = dict();
+"/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/group/{daemons}/controllers/cpu/cpu.shares" = '1000';
+"/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/group/{test}/controllers/{name=noctrl}" = dict();

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig_example3.pan
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/profiles/cgconfig_example3.pan
@@ -8,11 +8,11 @@ prefix '/software/components/accounts';
 
 include 'metaconfig/cgroups/cgconfig';
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents";
 "mount/cpuacct" = '/mnt/cgroups/cpu';
 "mount/cpu" = '/mnt/cgroups/cpu';
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/group/{daemons/www}";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/group/{daemons/www}";
 "controllers/cpu/cpu.shares" = '1000';
 "perm/task" = dict(
     'uid', 'root',
@@ -26,7 +26,7 @@ prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/g
     "fperm", "744",
 );
 
-prefix "/software/components/metaconfig/services/{/etc/cgconfig.conf}/contents/group/{daemons/ftp}";
+prefix "/software/components/metaconfig/services/{/etc/cgconfig.d/quattor.conf}/contents/group/{daemons/ftp}";
 "controllers/cpu/cpu.shares" = '500';
 "perm/task" = dict(
     'uid', 'root',

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig/value
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig/value
@@ -1,6 +1,6 @@
-Test cgconfig.conf
+Test cgconfig.d/quattor.conf
 ---
-/etc/cgconfig.conf
+/etc/cgconfig.d/quattor.conf
 ---
 ^default \{$
 ^\s{4}perm \{$

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig/value
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig/value
@@ -41,3 +41,10 @@ Test cgconfig.d/quattor.conf
 ^\s{4}"name=abc" = a/b/c;$
 ^\s{4}ns = ns/abc;$
 ^\}$
+^template my/users/%u \{$
+^\s{4}cpu \{$
+^\s{8}cpu.shares = "250";$
+^\s{4}\}$
+^\s{4}memory \{$
+^\s{4}\}$
+^\}$

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig_example2
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig_example2
@@ -1,6 +1,6 @@
-cgconfig.conf example2
+cgconfig.d/quattor.conf example2
 ---
-/etc/cgconfig.conf
+/etc/cgconfig.d/quattor.conf
 ---
 ^group daemons \{$
 ^\s{4}cpu \{$

--- a/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig_example3
+++ b/ncm-metaconfig/src/main/metaconfig/cgroups/tests/regexps/cgconfig_example3
@@ -1,6 +1,6 @@
-cgconfig.conf example3
+cgconfig.d/quattor.conf example3
 ---
-/etc/cgconfig.conf
+/etc/cgconfig.d/quattor.conf
 ---
 ^group daemons/ftp \{$
 ^\s{4}cpu \{$


### PR DESCRIPTION
Also fixes the usage of correct `cgred` services for cgrules