### PR TITLE
ncm-metaconfig: ganesha: add config_ces

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/ganesha/pan/config_ces.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ganesha/pan/config_ces.pan
@@ -1,0 +1,6 @@
+unique template metaconfig/ganesha/config_ces;
+
+# Nothing yet. Ganesha config should be set through 'mmnfs configuration change' commands
+# Only export file can be loaded through 'mmnfs export load' command
+
+variable GANESHA_MANAGES_GANESHA ?= false;


### PR DESCRIPTION
add dummy file to use ganesha with gpfs ces (Cluster Export Services)
With GPFS, you can configure a subset of nodes in the cluster to provide a highly available solution for exporting GPFS file systems by using the Network File System (NFS), Server Message Block (SMB), and Object protocols. The participating nodes are designated as Cluster Export Services (CES) nodes or protocol nodes. The set of CES nodes is frequently referred to as the CES cluster.

