### PR TITLE
ncm-filecopy: Update filecopy.pod example to make it work

### DIFF
--- a/ncm-filecopy/src/main/perl/filecopy.pod
+++ b/ncm-filecopy/src/main/perl/filecopy.pod
@@ -116,7 +116,7 @@ Default: false
 =head3 scenario 2 : Create a script and execute it
 
  prefix '/software/components/filecopy/services/{/tmp/test.sh}';
- 'config' = '#!/bin/bash\n echo Hello World';
+ 'config' = "#!/bin/bash\n echo Hello World";
  'restart' = '/tmp/test.sh';
  'owner'='root:root';
  'perms'='0755';


### PR DESCRIPTION
The config value in the second example needs double quotes for the escape character to work