### PR TITLE
ncm-nss: wait for nscd to restart before returning

### DIFF
--- a/ncm-nss/src/main/perl/nss.pm
+++ b/ncm-nss/src/main/perl/nss.pm
@@ -113,6 +113,10 @@ sub Configure {
             my $nscdrestart = CAF::Process->new(
                 ['service', 'nscd', 'condrestart'], log => $self);
             $nscdrestart->execute();
+	    # wait for nscd to restart before returning in case
+	    # another component in the same ncm-ncd run depends on
+	    # any changed config
+	    sleep 2;
         } else {
             $self->warn("Unrecognised platform, $^O, not restarting nscd");
         }


### PR DESCRIPTION
This is a very simple change we'd like in 16.4. I have a another branch that replaces LC::Check with FileWriter and includes unit tests which I can push for 16.6.