### PR TITLE
ncm-opennebula: Fix RPC history

### DIFF
--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -13,7 +13,7 @@ use vars qw(@ISA $EC);
 use LC::Exception;
 use CAF::TextRender;
 use CAF::Service;
-use Net::OpenNebula 0.300.0;
+use Net::OpenNebula 0.307.0;
 use Data::Dumper;
 use Readonly;
 

--- a/ncm-opennebula/src/test/perl/datastore.t
+++ b/ncm-opennebula/src/test/perl/datastore.t
@@ -22,9 +22,8 @@ ok(exists($tree->{datastores}), "Found datastore data");
 rpc_history_reset;
 $cmp->manage_something($one, "datastore", $tree->{datastores});
 ok(rpc_history_ok(["one.datastorepool.info",
-                   "one.datastore.info",
                    "one.datastore.update",
-                   "one.datastore.info",
+                   "one.datastorepool.info",
                    "one.datastore.allocate",
                    "one.datastore.info"]),
                    "manage_something datastore rpc history ok");

--- a/ncm-opennebula/src/test/perl/host.t
+++ b/ncm-opennebula/src/test/perl/host.t
@@ -27,11 +27,11 @@ rpc_history_reset;
 $cmp->manage_something($one, "kvm", $tree);
 #diag_rpc_history;
 ok(rpc_history_ok(["one.hostpool.info",
-                   "one.host.info",
                    "one.host.enable",
                    "one.datastorepool.info",
-                   "one.datastore.info",
-                   "one.host.allocate"]),
+                   "one.host.allocate",
+                   "one.host.info",
+                   "one.hostpool.info"]),
                    "manage_something host kvm history ok");
 ok(!exists($cmp->{ERROR}), "No errors found during host management execution");
 

--- a/ncm-opennebula/src/test/perl/user.t
+++ b/ncm-opennebula/src/test/perl/user.t
@@ -23,8 +23,13 @@ rpc_history_reset;
 $cmp->manage_something($one, "user", $tree->{users});
 #diag_rpc_history;
 ok(rpc_history_ok(["one.userpool.info",
+                   "one.user.update",
+                   "one.userpool.info",
+                   "one.user.update",
+                   "one.userpool.info",
+                   "one.user.allocate",
                    "one.user.info",
-                   "one.user.update"]),
+                   "one.userpool.info"]),
                    "manage_something users rpc history ok");
 ok(!exists($cmp->{ERROR}), "No errors found during user management execution");
 


### PR DESCRIPTION
New RPCClient.pm generates less calls to RPC endpoint. This PR updates RPC unittests to use this new version.