### PR TITLE
Resolver list lengths

### DIFF
--- a/ncm-named/src/main/pan/components/named/schema.pan
+++ b/ncm-named/src/main/pan/components/named/schema.pan
@@ -17,11 +17,11 @@ function component_named_valid = {
   if ( ARGC != 1 ) {
     error(function_name+': this function requires 1 argument');
   };
-  
+
   if ( exists(SELF['serverConfig']) && exists(SELF['configfile']) ) {
     error(function_name+": properties 'serverConfig' and 'configfile' are mutually exclusive.");
   };
-  
+
   true;
 };
 

--- a/ncm-named/src/main/pan/components/named/schema.pan
+++ b/ncm-named/src/main/pan/components/named/schema.pan
@@ -31,9 +31,9 @@ type component_named = {
     "configfile"    ? string
     "use_localhost" : boolean = true
     "start"         ? boolean
-    "servers"       ? string[]
+    "servers"       ? type_ip[..3]
     "options"       ? string[]
-    "search"        ? type_fqdn[]
+    "search"        ? type_fqdn[..6] with { length(replace('(^\[ )|,|( \])$', '', to_string(SELF))) <= 256 }
 } with component_named_valid(SELF);
 
 bind "/software/components/named" = component_named;

--- a/ncm-resolver/src/main/pan/components/resolver/schema.pan
+++ b/ncm-resolver/src/main/pan/components/resolver/schema.pan
@@ -34,8 +34,8 @@ include { 'quattor/schema' };
 
 type component_resolver_type = {
     include structure_component
-    'servers' : string[]
-    'search'  ? string[]
+    'servers' : type_ip[..3]
+    'search'  ? type_fqdn[..6] with { length(replace('(^\[ )|,|( \])$', '', to_string(SELF))) <= 256 }
     'dnscache' : boolean = false
 };
 

--- a/ncm-resolver/src/main/pan/components/resolver/schema.pan
+++ b/ncm-resolver/src/main/pan/components/resolver/schema.pan
@@ -40,4 +40,3 @@ type component_resolver_type = {
 };
 
 bind "/software/components/resolver" = component_resolver_type;
-


### PR DESCRIPTION
All supported resolvers (GNU/glib/BIND and Solaris) support a maximum of:
* Three nameservers
* Six search domains with a total of 256 characters

This also switches the plain strings to network types.

Small chance of backwards incompatibility.

Fixes #785.