### PR TITLE
ncm-metaconfig: zkrsync: add timeout option

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/zkrsync/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zkrsync/pan/schema.pan
@@ -33,6 +33,7 @@ type zkrsync_config = {
     'delete' ? boolean = false
     'checksum' ? boolean = false
     'hardlinks' ? boolean = false
+    'timeout' ? long(0..)
     # client opts
     'verifypath' ? boolean = true
     'domain' ? string

--- a/ncm-metaconfig/src/main/metaconfig/zkrsync/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zkrsync/pan/schema.pan
@@ -40,6 +40,7 @@ type zkrsync_config = {
     'dropcache' ? boolean = false
     'verbose' ? boolean = false
     'info' ? boolean = false
+    'daemon' ? boolean = false
     # destination opts
     'startport' ? long = 4444
 } with zkrsync_has_one_role(SELF);

--- a/ncm-metaconfig/src/main/metaconfig/zkrsync/tests/profiles/testsession.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zkrsync/tests/profiles/testsession.pan
@@ -12,6 +12,7 @@ prefix "/software/components/metaconfig/services/{/etc/zkrs/default.conf}/conten
 'excl_usr' = '';
 'info' = true;
 'delete'= false;
+'timeout' = 600;
 'rsyncpath' = '/user/gent';
 'rsubpaths' = list('2_gent/test/1', '3_gent/test/2');
 'dropcache' = true;

--- a/ncm-metaconfig/src/main/metaconfig/zkrsync/tests/regexps/testsession
+++ b/ncm-metaconfig/src/main/metaconfig/zkrsync/tests/regexps/testsession
@@ -13,3 +13,4 @@ Base test for zkrsync config
 ^rsyncpath=/user/gent$
 ^servers=mds01.gent:2181,mds02.gent:2181,mds03.gent:2181$
 ^source=true$
+^timeout=600$


### PR DESCRIPTION

adding the timeout option for rsync to the zkrsync config file 