### PR TITLE
ncm-sudo: missing elements in list of STRING_OPTS in sudo.pm

### DIFF
--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -88,9 +88,9 @@ use constant INT_OPTS => qw(
     umask
 );
 use constant STRING_OPTS => qw(
-    badpass_message
     env_keep
     env_delete
+    badpass_message
     timestampdir
     timestampowner
     passprompt

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -88,6 +88,7 @@ use constant INT_OPTS => qw(
     umask
 );
 use constant STRING_OPTS => qw(
+    mailsub
     env_keep
     env_delete
     badpass_message
@@ -106,6 +107,7 @@ use constant STRING_OPTS => qw(
     exempt_group
     verifypw
     listpw
+    secure_path
 );
 
 # generate_aliases method


### PR DESCRIPTION
* The configurables 'mailsub' and 'secure_path' are present in the schema but not in the perl.
* This should not introduce any incompatibility, it is a bug fix.
* Discussed in #773.
