### PR TITLE
ncm-spma: Backport changes from reverting yumng schema

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/config-ips.pan
+++ b/ncm-spma/src/main/pan/components/spma/config-ips.pan
@@ -5,8 +5,6 @@
 
 unique template components/${project.artifactId}/config-ips;
 
-'/software/groups/names' ?= list();
-
 # Set prefix to root of component configuration.
 prefix '/software/components/${project.artifactId}';
 
@@ -20,4 +18,3 @@ prefix '/software/components/${project.artifactId}';
                          '/software/requests',
                          '/software/uninstall');
 'flagfile' = '/var/tmp/spma-run-flag';
-

--- a/ncm-spma/src/main/pan/components/spma/config-rpm.pan
+++ b/ncm-spma/src/main/pan/components/spma/config-rpm.pan
@@ -6,7 +6,8 @@ unique template components/spma/config-rpm;
 
 # Prefix for packages/groups
 prefix '/software';
-'groups/names' ?= list();
+'groups' ?= dict();
+'groups/yumng/names' ?= list();
 # Package to install
 'packages' = pkg_repl("ncm-${project.artifactId}", "${no-snapshot-version}-${rpm.release}", "noarch");
 

--- a/ncm-spma/src/main/pan/components/spma/software.pan
+++ b/ncm-spma/src/main/pan/components/spma/software.pan
@@ -50,4 +50,5 @@ type SOFTWARE_GROUP = {
     "default" : boolean = true
     "mandatory" : boolean = true
     "optional" : boolean = false
+    "names" ? string[]  # used by yumng only
 };


### PR DESCRIPTION
Fixes #797.

`yumng` properties have no business being anywhere near `ips` either.