### PR TITLE
config-rpm: do not define groups/names/yumng by default

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/config-rpm.pan
+++ b/ncm-spma/src/main/pan/components/spma/config-rpm.pan
@@ -7,7 +7,6 @@ unique template components/spma/config-rpm;
 # Prefix for packages/groups
 prefix '/software';
 'groups' ?= dict();
-'groups/yumng/names' ?= list();
 # Package to install
 'packages' = pkg_repl("ncm-${project.artifactId}", "${no-snapshot-version}-${rpm.release}", "noarch");
 


### PR DESCRIPTION
Fixes #806.