### PR TITLE
ncm-sudo: add boolean option 'visiblepw' to ncm-sudo.

### DIFF
--- a/ncm-sudo/src/main/pan/components/sudo/schema.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/schema.pan
@@ -71,6 +71,7 @@ type structure_sudo_default_options = {
     "stay_setuid"           ? boolean
     "env_reset"             ? boolean
     "use_loginclass"        ? boolean
+    "visiblepw"             ? boolean
     "passwd_tries"          ? long
     "loglinelen"            ? long
     "timestamp_timeout"     ? long

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -79,6 +79,7 @@ use constant BOOLEAN_OPTS => qw(
     stay_setuid
     env_reset
     use_loginclass
+    visiblepw
 );
 use constant INT_OPTS => qw(
     passwd_tries


### PR DESCRIPTION
* The configurable 'visiblepw' is a default setting in the /etc/sudoers file as installed via the RPM in Scientific Linux 5,6&7.
* Having this option added to ncm-sudo will allow a system administrator to reconstruct the /etc/sudoers file if they so wished. This is currently not possible.
* This should not introduce any incompatibility, it is a simple enhancement.