### PR TITLE
ncm-nfs: add cephfs share type to NFS component schema

### DIFF
--- a/ncm-nfs/src/main/pan/components/nfs/schema.pan
+++ b/ncm-nfs/src/main/pan/components/nfs/schema.pan
@@ -15,7 +15,7 @@ type structure_nfs_exports = {
 type structure_nfs_mounts = {
     'device'     : string
     'mountpoint' : string
-    'fstype'     : string with match(SELF, '^(nfs4?|panfs|none)$')
+    'fstype'     : string with match(SELF, '^(nfs4?|(pan|ceph)fs|none)$')
     'options'    ? string
     'freq'       ? long(0..)
     'passno'     ? long(0..)

--- a/ncm-nfs/src/main/perl/nfs.pm
+++ b/ncm-nfs/src/main/perl/nfs.pm
@@ -244,7 +244,7 @@ The current managed entries are
 
 =over
 
-=item devices with filesystems C<nfs>, C<nfs4> or C<panfs>.
+=item devices with filesystems C<nfs>, C<nfs4>, C<panfs> or C<cephfs>.
 
 =item bind mounts (filesystem C<none> and mount option C<bind>)
 
@@ -285,7 +285,7 @@ sub fstab
     my $fh = CAF::FileWriter->new($FSTAB, backup => ".old", log => $self);
 
     # Keep updated with filter below
-    my $mngd_by = "nfs/nfs4/panfs filesystems and bind mounts";
+    my $mngd_by = "nfs/nfs4/panfs/cephfs filesystems and bind mounts";
 
     # Collect information for fstab file.
     print $fh "# File edited by ncm-nfs\n";
@@ -298,7 +298,7 @@ sub fstab
         # line does not end in newline (see split above)
         my $fstab = parse_fstab_line($line);
         if ($fstab) {
-            if ( ($fstab->{$FSTAB_FSTYPE} =~ m/^(nfs4?|panfs)$/) ||
+            if ( ($fstab->{$FSTAB_FSTYPE} =~ m/^(nfs4?|(pan|ceph)fs)$/) ||
                  (($fstab->{$FSTAB_FSTYPE} eq 'none') && ($fstab->{$FSTAB_OPTIONS} eq 'bind')) ) {
                 # It is an ncm-nfs managed entry, save the information.
                 $old{$fstab->{$FSTAB_DEVICE}} = $fstab;

--- a/ncm-nfs/src/test/perl/fstab.t
+++ b/ncm-nfs/src/test/perl/fstab.t
@@ -159,14 +159,25 @@ my $nfs2 = {
     action => 'mount',
 };
 
+my $nfs3 = {
+    device => "mydev3",
+    mountpoint => "/mount3",
+    fstype => "cephfs",
+    options => "name=user,secretfile=/etc/ceph/secret",
+    freq => 0,
+    passno => 0,
+    action => 'mount',
+};
+
+
 is(NCM::Component::nfs::mount_action_new_old($nfs0, $fs2),
    'umount/mount', 'Different mountpoint returns umount/mount');
 
-is_deeply($new, { '/mydev0' => $nfs0, mydev1 => $nfs1, amydev2 => $nfs2 },
+is_deeply($new, { '/mydev0' => $nfs0, mydev1 => $nfs1, amydev2 => $nfs2, mydev3 => $nfs3 },
           "new hashref as expected");
-is_deeply($new_order, [qw(/mydev0 mydev1 amydev2)], "new order as expected");
+is_deeply($new_order, [qw(/mydev0 mydev1 amydev2 mydev3)], "new order as expected");
 
-is_deeply($mkdir, [qw(/mount000 /mount1 /amount2)], "fstab triggered _make_directory (no directories existed)");
+is_deeply($mkdir, [qw(/mount000 /mount1 /amount2 /mount3)], "fstab triggered _make_directory (no directories existed)");
 
 
 =head2 do_mount

--- a/ncm-nfs/src/test/resources/fstab_simple.pan
+++ b/ncm-nfs/src/test/resources/fstab_simple.pan
@@ -21,3 +21,8 @@ prefix "/software/components/nfs/mounts/2";
 "fstype" = "none";
 "options" = "bind";
 
+prefix "/software/components/nfs/mounts/3";
+"device" = "mydev3";
+"mountpoint" = "/mount3";
+"fstype" = "cephfs";
+"options" = "name=user,secretfile=/etc/ceph/secret";

--- a/ncm-nfs/src/test/resources/regexps/fstab
+++ b/ncm-nfs/src/test/resources/regexps/fstab
@@ -3,7 +3,7 @@ modified fstab entry
 quote
 ---
 # File edited by ncm-nfs
-# Only nfs/nfs4/panfs filesystems and bind mounts managed by ncm-nfs component.
+# Only nfs/nfs4/panfs/cephfs filesystems and bind mounts managed by ncm-nfs component.
 # Comment
 /dev00 /mntpt00       ext4                special,defaults                1
 /dev01 /mntpt01 ext3
@@ -11,3 +11,4 @@ quote
 /mydev0 /mount000 nfs defaults 0 0
 mydev1 /mount1 panfs super,awesome 5 100
 amydev2 /amount2 none bind 0 0
+mydev3 /mount3 cephfs name=user,secretfile=/etc/ceph/secret 0 0


### PR DESCRIPTION
Adding the ability to add CephFS network shares into fstab using ncm-nfs.

