### PR TITLE
ncm-afsclt: use FileEditor not FileReader (for old CAF).

### DIFF
--- a/ncm-afsclt/src/main/perl/afsclt.pm
+++ b/ncm-afsclt/src/main/perl/afsclt.pm
@@ -122,7 +122,8 @@ sub Configure_Cache {
         $self->warn("Cannot determine current AFS cache size, changing only config file");
     }
 
-    my $afs_cacheinfo_fh = CAF::FileReader->new( $AFS_CACHEINFO, log => $self );
+    my $afs_cacheinfo_fh = CAF::FileEditor->new( $AFS_CACHEINFO, log => $self );
+    $afs_cacheinfo_fh->cancel();
     $self->debug(2, "$AFS_CACHEINFO current contents: >>>$afs_cacheinfo_fh<<<");
     if ( "$afs_cacheinfo_fh" =~ m;^([^:]+):([^:]+):(\d+|AUTOMATIC)$; ) {
         $file_afsmount   = $1 if $file_afsmount eq "";


### PR DESCRIPTION
Found a small issue with @jouvin's refactoring - a missing use FileReader (it didn't use FileReader before). I think this only happens if you run ncm-afsclt alone (as we do at one point in our build) presumably because another components hasn't loaded it already.

I've changed the new use of FileReader to a FileEditor with explicit cancel so it's essentially the same, and consistent with another read in the component. Sorry, we have an old version of CAF on older builds, they will hopefully go away soon.

Ensure the title of this pull-request starts with the component name followed by a colon, e.g.
> ncm-example: demonstrate what titles should look like

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
* What backwards incompatibility it may introduce.

