### PR TITLE
ncm-metaconfig: beats: allow more than one output

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/beats/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/pan/schema.pan
@@ -80,7 +80,9 @@ type beats_output = {
     'logstash' ? beats_output_logstash
     'file' ? beats_output_file
     'console' ? beats_output_console
-} with length(SELF) == 1;
+} with {
+    length(SELF) >= 1 || error('At least one beat output must be specified');
+};
 
 
 @documentation{

--- a/ncm-metaconfig/src/main/metaconfig/beats/tests/profiles/filebeat.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/tests/profiles/filebeat.pan
@@ -17,3 +17,5 @@ prefix "/software/components/metaconfig/services/{/etc/filebeat/filebeat.yml}/co
 "hosts" = list('localhost:1234', 'otherhost:5678');
 "loadbalance" = true;
 
+prefix "/software/components/metaconfig/services/{/etc/filebeat/filebeat.yml}/contents/output/console";
+"pretty" = true;

--- a/ncm-metaconfig/src/main/metaconfig/beats/tests/regexps/filebeat/base
+++ b/ncm-metaconfig/src/main/metaconfig/beats/tests/regexps/filebeat/base
@@ -16,9 +16,10 @@ Filebeat basic value based test
 ^    - /path/1b$
 ^    - /path/2b/\*$
 ^output:$
+^  console:$
+^    pretty: true$
 ^  logstash:$
 ^    hosts:$
 ^    - localhost:1234$
 ^    - otherhost:5678$
 ^    loadbalance: true$
-


### PR DESCRIPTION
Fixes #825

