### PR TITLE
ncm-download: config-rpm is not part of the templates anymore

### DIFF
--- a/ncm-download/src/main/pan/components/download/config.pan
+++ b/ncm-download/src/main/pan/components/download/config.pan
@@ -9,8 +9,6 @@ include 'components/${project.artifactId}/schema';
 
 bind "/software/components/download" = component_download_type;
 
-include { 'components/${project.artifactId}/config-rpm' };
-
 # Set prefix to root of component configuration.
 prefix '/software/components/${project.artifactId}';
 'active' ?= true;


### PR DESCRIPTION
After #833, a reference to a previous template still existed 

