### PR TITLE
ncm-cron: documentation fixes

### DIFF
--- a/ncm-cron/pom.xml
+++ b/ncm-cron/pom.xml
@@ -34,6 +34,10 @@
       <name>Mark Wilson</name>
       <email>Mark.Wilson@morganstanley.com</email>
     </developer>
+    <developer>
+      <name>Guillaume Philippon</name>
+      <email>philippo@lal.in2p3.fr</email>
+    </developer>
   </developers>
 
   

--- a/ncm-cron/src/main/perl/cron.pod
+++ b/ncm-cron/src/main/perl/cron.pod
@@ -19,7 +19,7 @@ and the /var/spool/cron/crontabs directory on Solaris.
 
 Files managed by ncm-cron will have the ncm-cron.cron suffix.  Other files in
 the directory are not affected by this component. The name of each file will be
-taken from the nlist name.
+taken from the nlist C<name>.
 
 =back
 
@@ -30,26 +30,26 @@ taken from the nlist name.
 Solaris uses an older version of cron that does not make use of a cron.d
 directory for crontabs. Ncm-cron B<shares> the crontab with each user. To make
 this work ncm-cron uses the concept of separate file B<sections> within the
-crontab.  Each B<section> is identified by the use of the tags NCM-CRON BEGIN:
-and NCM-CRON END:. Entries either side of these section identifiers are not
+crontab.  Each B<section> is identified by the use of the tags C<< NCM-CRON BEGIN: >>
+and C<< NCM-CRON END: >>. Entries either side of these section identifiers are not
 modified.
 
 Solaris B<does> have a /etc/cron.d directory, however it uses this directory
-for control files such as cron.allow and cron.deny.
+for control files such as C<cron.allow> and C<cron.deny>.
 
 =back
 
 =head1 MAIN RESOURCES
 
-=head2 /software/components/cron/entries
+=head2 C<< /software/components/cron/entries >>
 
 A list containing cron structures (described above).
 
 =head1 ENTRY RESOURCES
 
 Each cron entry in the /software/components/cron/entries list may
-contain the properties and resources described below. One of "frequency"
-or "timing" must be specified.
+contain the properties and resources described below. One of C<frequency>
+or C<timing> must be specified.
 
 =over 4
 
@@ -76,10 +76,10 @@ Default : None
 =item B<frequency> : string (optional)
 
 Execution frequency for the command, using standard cron syntax.
-Minutes field can be 'AUTO' : in this case,
+Minutes field can be C<< AUTO : >> in this case,
 a random value between 0 and 59 inclusive is generated.
 This can be used to avoid too many machines executing the same
-cron at the same time. See also the "timing" element.
+cron at the same time. See also the C<timing> element.
 
 Default : None
 
@@ -98,16 +98,16 @@ Supported attributes are :
 
 =item name
 
-name of the log file. If the name is not an absolute file name, file is created in /var/log.
-Default name is the cron file name with .log extension in /var/log.
+Name of the log file. If the name is not an absolute file name, file is created in C<< /var/log >>.
+Default name is the cron file name with .log extension in C<< /var/log >>.
 
 =item owner
 
-owner/group of the log file, using owner:group format. group can be ommitted.
+Owner/group of the log file, using C<< owner:group >> format. group can be ommitted.
 
 =item mode
 
-permissions of log file specified as a string interpreted as an octal number.
+Permissions of log file specified as a string interpreted as an octal number.
 
 =item disabled
 
@@ -123,9 +123,9 @@ Default : None
 
 =item B<timing> : nlist (optional)
 
-If the 'timing' nlist is used to specify the time, it can contain any of the
-keys: 'minute', 'hour', 'day', 'month' and 'weekday'. An unspecified key will
-have a value of '*'. A further key of 'smear' can be used to specify (in
+If the C<timing> nlist is used to specify the time, it can contain any of the
+keys: C<minute>, C<hour>, C<day>, C<month> and C<weekday>. An unspecified key will
+have a value of C<< * >>. A further key of 'smear' can be used to specify (in
 minutes) a maximum interval for smearing the start time, which can be as much
 as a day. When a smeared job is created, a random increment between zero and
 the smear time is applied to the start time of the job.  If the start time
@@ -170,31 +170,18 @@ Default : root
     );
 
 On Linux this will create three files in /etc/cron.d:
+
   ls.ncm-cron.cron
   hostname.ncm-cron.cron
   date.ncm-cron.cron
 
 On Solaris three extra entries will be added to the root crontab.
 
-=head1 DEPENDENCIES
-
-None.
-
-=head1 BUGS
-
-=head2 Linux
+=head1 Solaris
 
 =over
 
-None known.
-
-=back
-
-=head2 Solaris
-
-=over
-
-Editing the NCM-CRON BEGIN: and/or the NCM-CRON END: tag within a crontab will
+Editing the C<< NCM-CRON BEGIN: >> and/or the C<< NCM-CRON END: >> tag within a crontab will
 cause unpredictable behaviour. Possible behavours are duplicate entries or
 entries being removed altogether.
 
@@ -202,23 +189,5 @@ Editing BETWEEN the tags will cause the edits to be overwritten the next time
 ncm-cron runs.
 
 =back
-
-=head1 AUTHOR
-
-Charles Loomis <charles.loomis@cern.ch>
-
-=head1 MAINTAINERS
-
-Guillaume Philippon <philippo@lal.in2p3.fr>
-
-Mark Wilson <Mark.Wilson@MorganStanley.com>
-
-=head1 VERSION
-
-${project.version}
-
-=head1 SEE ALSO
-
-ncm-ncd(1)
 
 =cut


### PR DESCRIPTION
Documentation fixes and moved a developer to ```pom.xml```.