### PR TITLE
ncm-fstab: clean up documentation

### DIFF
--- a/ncm-fstab/src/main/perl/fstab.pod
+++ b/ncm-fstab/src/main/perl/fstab.pod
@@ -8,19 +8,12 @@
 =head1 DESCRIPTION
 
 The I<fstab> component manages the mount points in a node. It is able
-to manipulate the fstab, and remount filesystems as specified by the
+to manipulate C<< /etc/fstab >>, and remount filesystems as specified by the
 profile. It doesn't perform any dangerous operations, such as
 formatting or partitioning. If you need so, use ncm-filesystems in
 addition to this component.
 
 It doesn't remove any filesystems specified under
-C</software/components/fstab/protected_mounts>.
-
-It uses the definition of file systems described in
-https://twiki.cern.ch/twiki/bin/view/FIOgroup/TsiCDBBlockDevices
-
-=head1 SEE ALSO
-
-L<ncm-filesystems>
+C<< /software/components/fstab/protected_mounts >>.
 
 =cut


### PR DESCRIPTION
Mainly removed links to CERN as it requires authentication.