### PR TITLE
ncm-*: Update build tools to 1.50

### DIFF
--- a/ncm-accounts/pom.xml
+++ b/ncm-accounts/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-accounts/src/test/resources/ccm.cfg
+++ b/ncm-accounts/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-afsclt/pom.xml
+++ b/ncm-afsclt/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-afsclt/src/test/resources/ccm.cfg
+++ b/ncm-afsclt/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-aiiserver/pom.xml
+++ b/ncm-aiiserver/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-aiiserver/src/test/resources/ccm.cfg
+++ b/ncm-aiiserver/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-altlogrotate/pom.xml
+++ b/ncm-altlogrotate/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-altlogrotate/src/test/resources/ccm.cfg
+++ b/ncm-altlogrotate/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-amandaserver/pom.xml
+++ b/ncm-amandaserver/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-amandaserver/src/test/resources/ccm.cfg
+++ b/ncm-amandaserver/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-authconfig/pom.xml
+++ b/ncm-authconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-authconfig/src/test/resources/ccm.cfg
+++ b/ncm-authconfig/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-autofs/pom.xml
+++ b/ncm-autofs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-autofs/src/test/resources/ccm.cfg
+++ b/ncm-autofs/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ccm/pom.xml
+++ b/ncm-ccm/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ccm/src/test/resources/ccm.cfg
+++ b/ncm-ccm/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-cdp/pom.xml
+++ b/ncm-cdp/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-cdp/src/test/resources/ccm.cfg
+++ b/ncm-cdp/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ceph/pom.xml
+++ b/ncm-ceph/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ceph/src/test/resources/ccm.cfg
+++ b/ncm-ceph/src/test/resources/ccm.cfg
@@ -1,7 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1
-

--- a/ncm-chkconfig/pom.xml
+++ b/ncm-chkconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-chkconfig/src/test/resources/ccm.cfg
+++ b/ncm-chkconfig/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-cron/pom.xml
+++ b/ncm-cron/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-cron/src/test/resources/ccm.cfg
+++ b/ncm-cron/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-cups/pom.xml
+++ b/ncm-cups/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-cups/src/test/resources/ccm.cfg
+++ b/ncm-cups/src/test/resources/ccm.cfg
@@ -1,7 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1
-dbformat CDB_File

--- a/ncm-directoryservices/pom.xml
+++ b/ncm-directoryservices/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-directoryservices/src/test/resources/ccm.cfg
+++ b/ncm-directoryservices/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-dirperm/pom.xml
+++ b/ncm-dirperm/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-dirperm/src/test/resources/ccm.cfg
+++ b/ncm-dirperm/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-download/pom.xml
+++ b/ncm-download/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-download/src/test/resources/ccm.cfg
+++ b/ncm-download/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-etcservices/pom.xml
+++ b/ncm-etcservices/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-etcservices/src/test/resources/ccm.cfg
+++ b/ncm-etcservices/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-filecopy/pom.xml
+++ b/ncm-filecopy/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-filecopy/src/test/resources/ccm.cfg
+++ b/ncm-filecopy/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-filesystems/pom.xml
+++ b/ncm-filesystems/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-filesystems/src/test/resources/ccm.cfg
+++ b/ncm-filesystems/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-fmonagent/pom.xml
+++ b/ncm-fmonagent/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-fmonagent/src/test/resources/ccm.cfg
+++ b/ncm-fmonagent/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-fstab/pom.xml
+++ b/ncm-fstab/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-fstab/src/test/resources/ccm.cfg
+++ b/ncm-fstab/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ganglia/pom.xml
+++ b/ncm-ganglia/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ganglia/src/test/resources/ccm.cfg
+++ b/ncm-ganglia/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-gmetad/pom.xml
+++ b/ncm-gmetad/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-gmetad/src/test/resources/ccm.cfg
+++ b/ncm-gmetad/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-gmond/pom.xml
+++ b/ncm-gmond/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-gmond/src/test/resources/ccm.cfg
+++ b/ncm-gmond/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-gpfs/pom.xml
+++ b/ncm-gpfs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-gpfs/src/test/resources/ccm.cfg
+++ b/ncm-gpfs/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-grub/pom.xml
+++ b/ncm-grub/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-grub/src/test/resources/ccm.cfg
+++ b/ncm-grub/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-hostsaccess/pom.xml
+++ b/ncm-hostsaccess/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-hostsaccess/src/test/resources/ccm.cfg
+++ b/ncm-hostsaccess/src/test/resources/ccm.cfg
@@ -1,7 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1
-dbformat CDB_File

--- a/ncm-hostsfile/pom.xml
+++ b/ncm-hostsfile/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-hostsfile/src/test/resources/ccm.cfg
+++ b/ncm-hostsfile/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-icinga/pom.xml
+++ b/ncm-icinga/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-icinga/src/test/resources/ccm.cfg
+++ b/ncm-icinga/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-interactivelimits/pom.xml
+++ b/ncm-interactivelimits/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-interactivelimits/src/test/resources/ccm.cfg
+++ b/ncm-interactivelimits/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ipmi/pom.xml
+++ b/ncm-ipmi/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ipmi/src/test/resources/ccm.cfg
+++ b/ncm-ipmi/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-iptables/pom.xml
+++ b/ncm-iptables/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-iptables/src/test/resources/ccm.cfg
+++ b/ncm-iptables/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ldconf/pom.xml
+++ b/ncm-ldconf/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ldconf/src/test/resources/ccm.cfg
+++ b/ncm-ldconf/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-libvirtd/pom.xml
+++ b/ncm-libvirtd/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-libvirtd/src/test/resources/ccm.cfg
+++ b/ncm-libvirtd/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-mcx/pom.xml
+++ b/ncm-mcx/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-mcx/src/test/resources/ccm.cfg
+++ b/ncm-mcx/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-metaconfig/src/test/resources/ccm.cfg
+++ b/ncm-metaconfig/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-modprobe/pom.xml
+++ b/ncm-modprobe/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-modprobe/src/test/resources/ccm.cfg
+++ b/ncm-modprobe/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-mysql/pom.xml
+++ b/ncm-mysql/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-mysql/src/test/resources/ccm.cfg
+++ b/ncm-mysql/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-nagios/pom.xml
+++ b/ncm-nagios/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-nagios/src/test/resources/ccm.cfg
+++ b/ncm-nagios/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-named/pom.xml
+++ b/ncm-named/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-named/src/test/resources/ccm.cfg
+++ b/ncm-named/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-network/pom.xml
+++ b/ncm-network/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-network/src/test/resources/ccm.cfg
+++ b/ncm-network/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-nfs/pom.xml
+++ b/ncm-nfs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-nfs/src/test/perl/exports.t
+++ b/ncm-nfs/src/test/perl/exports.t
@@ -31,7 +31,7 @@ $cfg = get_config_for_profile('exports');
 $tree = $cfg->getTree($cmp->prefix());
 diag explain $tree;
 is($cmp->exports($tree), 1, "exports file changed (exports)");
-my $fh = get_file('/etc/exports');
+$fh = get_file('/etc/exports');
 
 diag "exports ", "$fh";
 Test::Quattor::RegexpTest->new(

--- a/ncm-nfs/src/test/perl/fstab.t
+++ b/ncm-nfs/src/test/perl/fstab.t
@@ -206,13 +206,13 @@ is($fstab_changed_2, $fstab_changed,
    "process_mounts returns fstab_changed from fstab method");
 ok($action, "process_mounts returns action_taken");
 
-command_history_ok([
+ok(command_history_ok([
     qr{^umount -l /mountX$},
     qr{^umount -l /mount0$},
     qr{^mount /mount000$},
     qr{^mount -o remount /mount1$},
     qr{^mount /amount2$},
-], "correct mount commands triggered in proper order");
+]), "correct mount commands triggered in proper order");
 
 
 done_testing();

--- a/ncm-nfs/src/test/resources/ccm.cfg
+++ b/ncm-nfs/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-nrpe/pom.xml
+++ b/ncm-nrpe/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-nrpe/src/test/resources/ccm.cfg
+++ b/ncm-nrpe/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-nsca/pom.xml
+++ b/ncm-nsca/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-nsca/src/test/resources/ccm.cfg
+++ b/ncm-nsca/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-nscd/pom.xml
+++ b/ncm-nscd/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-nscd/src/test/resources/ccm.cfg
+++ b/ncm-nscd/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-nss/pom.xml
+++ b/ncm-nss/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
   </parent>
 
   <licenses>

--- a/ncm-ntpd/pom.xml
+++ b/ncm-ntpd/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ntpd/src/test/resources/ccm.cfg
+++ b/ncm-ntpd/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ofed/pom.xml
+++ b/ncm-ofed/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ofed/src/test/resources/ccm.cfg
+++ b/ncm-ofed/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-openldap/pom.xml
+++ b/ncm-openldap/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-openldap/src/test/resources/ccm.cfg
+++ b/ncm-openldap/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-opennebula/pom.xml
+++ b/ncm-opennebula/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
   </parent>
   <licenses>
     <license>

--- a/ncm-opennebula/src/test/resources/ccm.cfg
+++ b/ncm-opennebula/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-openvpn/pom.xml
+++ b/ncm-openvpn/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-openvpn/src/test/resources/ccm.cfg
+++ b/ncm-openvpn/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-pam/pom.xml
+++ b/ncm-pam/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-pam/src/test/resources/ccm.cfg
+++ b/ncm-pam/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-pnp4nagios/pom.xml
+++ b/ncm-pnp4nagios/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-pnp4nagios/src/test/resources/ccm.cfg
+++ b/ncm-pnp4nagios/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-postfix/pom.xml
+++ b/ncm-postfix/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-postfix/src/test/resources/ccm.cfg
+++ b/ncm-postfix/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-postgresql/pom.xml
+++ b/ncm-postgresql/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-postgresql/src/test/resources/ccm.cfg
+++ b/ncm-postgresql/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-profile/pom.xml
+++ b/ncm-profile/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-profile/src/test/resources/ccm.cfg
+++ b/ncm-profile/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-puppet/pom.xml
+++ b/ncm-puppet/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-puppet/src/test/resources/ccm.cfg
+++ b/ncm-puppet/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-resolver/pom.xml
+++ b/ncm-resolver/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-resolver/src/test/resources/ccm.cfg
+++ b/ncm-resolver/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-sendmail/pom.xml
+++ b/ncm-sendmail/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-sendmail/src/test/resources/ccm.cfg
+++ b/ncm-sendmail/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-shorewall/pom.xml
+++ b/ncm-shorewall/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-shorewall/src/test/resources/ccm.cfg
+++ b/ncm-shorewall/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-spma/pom.xml
+++ b/ncm-spma/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-spma/src/test/resources/ccm.cfg
+++ b/ncm-spma/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-ssh/pom.xml
+++ b/ncm-ssh/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-ssh/src/test/resources/ccm.cfg
+++ b/ncm-ssh/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-sudo/pom.xml
+++ b/ncm-sudo/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-sudo/src/test/resources/ccm.cfg
+++ b/ncm-sudo/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-symlink/pom.xml
+++ b/ncm-symlink/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-symlink/src/test/resources/ccm.cfg
+++ b/ncm-symlink/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-sysconfig/pom.xml
+++ b/ncm-sysconfig/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-sysconfig/src/test/resources/ccm.cfg
+++ b/ncm-sysconfig/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-sysctl/pom.xml
+++ b/ncm-sysctl/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-sysctl/src/test/resources/ccm.cfg
+++ b/ncm-sysctl/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-syslog/pom.xml
+++ b/ncm-syslog/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-syslog/src/test/resources/ccm.cfg
+++ b/ncm-syslog/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-syslogng/pom.xml
+++ b/ncm-syslogng/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-syslogng/src/test/resources/ccm.cfg
+++ b/ncm-syslogng/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1

--- a/ncm-systemd/pom.xml
+++ b/ncm-systemd/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
   </parent>
 
   <licenses>

--- a/ncm-useraccess/pom.xml
+++ b/ncm-useraccess/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.49</version>
+    <version>1.50</version>
     <relativePath />
   </parent>
 

--- a/ncm-useraccess/src/test/resources/ccm.cfg
+++ b/ncm-useraccess/src/test/resources/ccm.cfg
@@ -1,6 +1,0 @@
-debug 0
-get_timeout 1
-profile https://www.google.com
-cache_root target/test/cache
-retrieve_wait 0
-retrieve_retries 1


### PR DESCRIPTION
Several PRs in this release rely on updated code in the 1.50 maven build tools.
