### PR TITLE
ncm-opennebula: opennebula schema minor fix

### DIFF
--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -470,6 +470,7 @@ Type that sets the OpenNebula
 sunstone_server.conf file
 }
 type opennebula_sunstone = {
+    "env" : string = 'prod' with match (SELF, '^(prod|dev)$')
     "tmpdir" : directory = '/var/tmp'
     "one_xmlrpc" : type_absoluteURI = 'http://localhost:2633/RPC2'
     "host" : type_ipv4 = '127.0.0.1'

--- a/ncm-opennebula/src/main/resources/tests/regexps/sunstone/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/sunstone/simple
@@ -4,6 +4,7 @@ OpenNebula sunstone_server test
 ^:auth:\s{1}.+$
 ^:core_auth:\s{1}.+$
 ^:debug_level:\s{1}\d+$
+^:env:\s{1}.+$
 ^:host:\s{1}.+$
 ^:instance_types:$
 ^\s{4}-\s{1}:cpu:\s{1}\d+$

--- a/ncm-opennebula/src/main/resources/tests/regexps/sunstone/sunstone_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/sunstone/sunstone_template
@@ -4,6 +4,7 @@ OpenNebula sunstone_server full test
 ^:auth:\s{1}opennebula$
 ^:core_auth:\s{1}cipher$
 ^:debug_level:\s{1}3$
+^:env:\s{1}prod$
 ^:host:\s{1}0.0.0.0$
 ^:instance_types:$
 ^\s{4}-\s{1}:cpu:\s{1}1$


### PR DESCRIPTION
 * Fix #872 : env option is missing in opennebula_sunstone schema

Include a missing value in `sunstone-server.conf`

