### PR TITLE
ncm-iptables: clean up documentation

### DIFF
--- a/ncm-iptables/src/main/perl/iptables.pod
+++ b/ncm-iptables/src/main/perl/iptables.pod
@@ -10,14 +10,10 @@ iptables: Setup the IPTABLES firewall rules.
 =head1 DESCRIPTION
 
 The I<IPTABLES> component perform the setup of the
-B</etc/sysconfig/iptables> configuration file and restarts the
+C<< /etc/sysconfig/iptables >> configuration file and restarts the
 iptables service.
 
 =head1 SYNOPSIS
-
-Note: a detailed HOWTO for this component, including examples, is
-found in /usr/share/doc/ncm-iptables-2.3.13/ncm-iptables-howto.html and in the FIO twiki pages
-at https://twiki.cern.ch/twiki/bin/view/FIOgroup/Iptables.
 
 =over
 
@@ -31,25 +27,21 @@ default targets are supported.
 
 User defined targets are supported. We recommend that users specify new
 targets as a rule in the profile but the system will create them if it
-needs to - N.B. This means that you need to spell targets names
-consistantly and with identical capitalisation otherwise you will end up
-with multiple chains E.g. chain "LocalRules" is not the same as
+needs to - N.B. This means that you need to spell target names
+consistently and with identical capitalisation otherwise you will end up
+with multiple chains. E.g. chain "LocalRules" is not the same as
 "localrules".
 
 Duplicated entries in the component resource declaration are
 ignored. For each configured table, the chains are added to the
-B</etc/sysconfig/iptable> in order, the relative order among the rules
+C<< /etc/sysconfig/iptables >> in order, the relative order among the rules
 belonging to the same chain is preserved.
-
-=item Unconfigure()
-
-Not implemented.
 
 =back
 
 =head1 RESOURCES
 
-=head2 /software/components/iptables
+=head2 * << /software/components/iptables >>
 
 Top component description with the following parameters:
 
@@ -59,39 +51,39 @@ Top component description with the following parameters:
 
 These parameters correspond to the three I<IPTABLES> table types.
 
-=head2 type component_iptables_acls
+=head2 * type component_iptables_acls
 
-The I<component_iptables_acls> type is defined as:
+The C<< component_iptables_acls >> type is defined as:
 
   "preamble"      ? component_iptables_preamble
   "rules"         ? component_iptables_rule[]
   "epilogue"      ? string
   "ordered_rules" ? string with match (self, 'yes|no')
 
-The B<"epilogue"> parameter is the "COMMIT" command at the end of
+The C<< epilogue >> parameter is the "COMMIT" command at the end of
 I<IPTABLES> table description. Presently, no check is performed upon
 the content of this parameter.
 
-If "ordered_rules" is set to yes, the ruleset will be written as
+If C<< ordered_rules >> is set to yes, the ruleset will be written as
 ordered in the original array. If set to no is is unset (the default),
-the rules will be ordered by target type (first, all the "log"  rules,
+the rules will be ordered by target type (first, all the "log" rules,
 then "accept","drop", and "logging").
 
-=head2 type component_iptables_preamble
+=head2 * type component_iptables_preamble
 
-The I<component_iptables_preamble> type is defined as:
+The C<< component_iptables_preamble >> type is defined as:
 
   "input"    ? string
   "output"   ? string
   "forward"  ? string
 
 These parameters contain the global rules for stated rules,
-e.g. ":INPUT ACCEPT [0:0]". Presently, no check is performed upon the
+e.g. C<< :INPUT ACCEPT [0:0] >>. Presently, no check is performed upon the
 content of this parameters.
 
-=head2 type component_iptables_rule
+=head2 * type component_iptables_rule
 
-The I<component_iptables_rule> type is defined as:
+The C<< component_iptables_rule >> type is defined as:
 
   "command"       ? string
   "chain"         : string
@@ -112,7 +104,7 @@ The I<component_iptables_rule> type is defined as:
   "in_interface"  ? string
   "out_interface" ? string
   "fragment"      ? boolean
-  "nofragment"  ? boolean
+  "nofragment"    ? boolean
   "target"        : string
   "reject-with"       ? string
   "log-prefix"        ? string
@@ -120,21 +112,23 @@ The I<component_iptables_rule> type is defined as:
   "log-tcp-options"   ? boolean
   "log-tcp-sequence"  ? boolean
   "log-ip-options"    ? boolean
-  "set-class"	    ? string
-  "limit-burst"     ? number
-  "length"          ? string
-  "set"             ? boolean
-  "rcheck"          ? boolean
-  "seconds"         ? number
+  "set-class"     ? string
+  "limit-burst"   ? number
+  "length"        ? string
+  "set"           ? boolean
+  "rcheck"        ? boolean
+  "seconds"       ? number
 
-The B<"command"> define the action to perform: "-A", "-D", "-I", "-N" or
+=over
+
+=item * The B<"command"> defines the action to perform: "-A", "-D", "-I", "-N" or
 "-R", it defaults to "-A".
 
-The B<"chain"> define the chain: "input", "output" or "forward".
+=item * The B<"chain"> defines the chain: "input", "output" or "forward".
 
-The B<"protocol"> define the packet protocol: "tcp", "udp" or "icmp".
+=item * The B<"protocol"> defines the packet protocol: "tcp", "udp" or "icmp".
 
-The B<"src_addr"> define the packet source address, it can be an IP
+=item * The B<"src_addr"> defines the packet source address, it can be an IP
 address, or a network in the form net/mask (CIDR notation or full mask), or a
 hostname (which will be resolved at configuration time, not at
 runtime) - all of which can be optionally prepended with "!" to negate
@@ -143,79 +137,148 @@ system for DDoS attacks it is worthwhile, for machines which are not
 being used as routers, to block packets which do not come from their
 IP address in the OUTPUT tables.
 
-The B<"src_port"> define the packet source port, it may be an integer
-or a service name included in the /etc/services file. This parameter
+=item * The B<"src_port"> defines the packet source port, it may be an integer
+or a service name included in the C<< /etc/services >> file. This parameter
 requires B<"protocol"> also be set.
 
-The B<"dst_addr"> define the packet destination address, it follow's the same
+=item * The B<"dst_addr"> defines the packet destination address, it follows the same
 rules as the src_addr parameter.
 
-The B<"dst_port"> define the packet destination port, it follow's the same
+=item * The B<"dst_port"> defines the packet destination port, it follows the same
 rules as the src_port parameter. This parameter requires B<"protocol"> also be set.
 
-The B<"syn"> define the TCP packet with the SYN bit set to one, it will be set
+=item * The B<"syn"> defines the TCP packet with the SYN bit set to one, it will be set
 if the parameter is true.
 
-The B<"match"> define the match extension module for the packet.
+=item * The B<"match"> defines the match extension module for the packet.
 
-The B<"state"> define the connection state.
+=item * The B<"state"> defines the connection state.
 
-The B<"limit"> defines the limit for logging.
+=item * The B<"limit"> defines the limit for logging.
 
-The B<"limit-burst"> defines the number of instances per time step to record.
+=item * The B<"limit-burst"> defines the number of instances per time step to record.
 
-The B<"icmp_type"> define the icmp type packet.
+=item * The B<"icmp_type"> defines the icmp type packet.
 
-The B<"in_interface"> define the input interface for the packet.
+=item * The B<"in_interface"> defines the input interface for the packet.
 
-The B<"out_interface"> define the output interface for the packet.
+=item * The B<"out_interface"> defines the output interface for the packet.
 
-The B<"target"> define the target for the packet: "log", "accept" or "drop".
+=item * The B<"target"> defines the target for the packet: "log", "accept" or "drop".
 
-=head2 function add_rule(<table>, <rule>)
+=back
+
+=head2 * function add_rule(<table>, <rule>)
 
 This function add a new entry rule to the resource list
 
     "/software/components/iptables/<table>/rules"
 
-
-=head1 DEPENDENCIES
-
-=over
-
-=item Pre-installation
-
-The iptables RPM package must be installed.
-
-=back
-
 =head1 FILES
 
-=head2 /etc/sysconfig/iptables:
+=head2 C<< /etc/sysconfig/iptables >>:
 
 I<IPTABLES> firewall configuration file policy.
 
-=head2 pro_declaration_component_iptables.tpl:
+=head1 EXAMPLES
 
-Component declaration.
+=head2 Simple example
 
-=head2 pro_declaration_functions_iptables.tpl:
+The following is a code snippet from a node profile.
+The lines have been numbered to aid the description.
+This sets up IPTables and adds the necessary rules to restrict access
+to SSH and allows all outgoing connections.
 
-Component functions declaration.
+  1  "/software/components/iptables/active"                  = true;
+  2  "/software/components/iptables/dispatch"                = default(true);
+  3  "/software/components/iptables/dependencies/pre"        = list("spma");
+  4  "/software/components/iptables/filter/preamble/input"   = "DROP [0:0]";
+  5  "/software/components/iptables/filter/preamble/output"  = "ACCEPT [0:0]";
+  6  "/software/components/iptables/filter/preamble/forward" = "DROP [0:0]";
+  7 "/software/components/iptables/filter/epilogue"         = "COMMIT";
+  8
+  9 "/software/components/iptables/filter/rules" = append(nlist(
+  10                        "command", "-A",
+  11                        "chain", "input",
+  12                        "target", "accept",
+  13                        "match", "state",
+  14                        "state", "ESTABLISHED"));
+  15 "/software/components/iptables/filter/rules" = append(nlist(
+  16                        "command", "-A",
+  17                        "chain", "input",
+  18                        "target", "accept",
+  19                        "match", "state",
+  20                        "state", "RELATED"));
+  21 "/software/components/iptables/filter/rules" = append(nlist(
+  22                        "command", "-A",
+  23                        "chain", "input",
+  24                        "target", "accept",
+  25                        "match", "state",
+  26                        "state", "NEW",
+  27                        "protocol", "tcp",
+  28                        "dst_port", "ssh"));
 
-=head1 BUGS
+=over
 
-Not all valid iptables options are implemented, and not all
-implemented options are properly documented.
-The component is overly strict in what it accepts, some legal combinations
-may be rejected.
+=item * Line 1 sets IPTables to be active and line 3 ensures that the software
+gets installed before the component tries to configure it.
 
+=item * Lines 4-6 set the default policy for the input, output and forward chains.
+These can be set to either accept or drop. We don't recommend that you set
+these to log unless you have a very, very large disk. The COMMIT in
+line 7 is required by IPTables otherwise the rule set will be generated but not acted on.
 
-=head1 SEE ALSO
+=item * Lines 9 to 14 sets a rule to allow established connections.
 
-See in particular the B<ncm-iptables> HOWTO as found in
-/usr/share/doc/ncm-iptables-2.3.13/ncm-iptables-howto.html, which includes usage examples.
+=item * Lines 15 to 20 sets a rule to allow related connections.
+These are used by multi-threaded applications, such as SSH, which move
+the connection to a random port after authentication.
 
-B<iptables> man page
+=item * Lines 21 to 28 creates a rule to allow the ssh service.
+The port number is set by the component querying C<< /etc/services >>.
+Alternatively you can specify the specific port number yourself.
+
+=back
+
+=head2 Additional rules
+
+=head3 DHCP
+
+ "/software/components/iptables/filter/rules" = append(nlist(
+                        "command", "-A",
+                        "chain", "input",
+                        "target", "accept",
+                        "protocol", "udp",
+                        "src_port", "67:68",
+                        "dst_port", "67:68"));
+
+=head3 NTP
+
+ "/software/components/iptables/filter/rules" = append(nlist(
+                        "command", "-A",
+                        "chain", "input",
+                        "target", "accept",
+                        "protocol", "udp",
+                        "src_port", "123",
+                        "dst_port", "123"));
+
+=head3 Samhain
+
+ "/software/components/iptables/filter/rules" = append(nlist(
+                        "command", "-A",
+                        "chain", "input",
+                        "target", "accept",
+                        "protocol", "tcp",
+                        "src_port", "49777",
+                        "dst_port", "49777"));
+
+=head3 GridFTP Server
+
+ "/software/components/iptables/filter/rules" = append(nlist(
+                        "command", "-A",
+                        "chain", "input",
+                        "target", "accept",
+                        "protocol", "tcp",
+                        "dst_port", "2811"));
 
 =cut


### PR DESCRIPTION
 - some structure work
 - cannot find extra documentation mentioned, so removed mentioning of it
 - some minor spelling fixes.