### PR TITLE
ncm-metaconfig: nginx fix ssl conf

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
@@ -26,9 +26,9 @@ type httpd_ssl = {
     "protocol" : cipherstring[] = list("TLSv1")
     "certificate" : string
     "key" : string
-    @{ssl_client_certificate specifies a file with trusted CA certificates in
-    the PEM format used to verify client certificates and OCSP responses if
-    ssl_stapling is enabled}
+    @{ca sets ssl_client_certificate which specifies a file with trusted
+    CA certificates in the PEM format used to verify client certificates and OCSP
+    responses if ssl_stapling is enabled}
     "ca"  ? string
     "certificate_chain_file" ? string
     "revocation_file" ? string

--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
@@ -16,6 +16,9 @@ type basic_ssl = {
     "require" ? string
 };
 
+@{
+    SSL nginx configuration
+}
 type httpd_ssl = {
     include basic_ssl
     "active" : boolean = true
@@ -23,6 +26,9 @@ type httpd_ssl = {
     "protocol" : cipherstring[] = list("TLSv1")
     "certificate" : string
     "key" : string
+    @{ssl_client_certificate specifies a file with trusted CA certificates in
+    the PEM format used to verify client certificates and OCSP responses if
+    ssl_stapling is enabled}
     "ca"  ? string
     "certificate_chain_file" ? string
     "revocation_file" ? string
@@ -137,4 +143,3 @@ type type_nginx = {
     "global" : nginx_global
     "http" : nginx_http[]
 };
-

--- a/ncm-metaconfig/src/main/metaconfig/nginx/ssl.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/ssl.tt
@@ -10,7 +10,9 @@ ssl_verify_client [% ssl.verify_client %]
 # Watch out!! This list is separated by whitespace!!
 ssl_protocols [% ssl.protocol.join(" ") %];
 ssl_certificate [% ssl.certificate %];
+[% IF ssl.ca.defined -%]
 ssl_client_certificate [% ssl.ca %];
+[%  END -%]
 ssl_certificate_key [% ssl.key %];
 # Watch out!! This list is separated by colons!!
 ssl_ciphers [% ssl.ciphersuite.join(":") %];


### PR DESCRIPTION
 * Fix #876 : ssl.tt file generates an empty ssl_client_certificate value