### PR TITLE
ncm-ccm: add missing "use CAF::FileReader"

### DIFF
--- a/ncm-ccm/src/main/perl/ccm.pm
+++ b/ncm-ccm/src/main/perl/ccm.pm
@@ -10,6 +10,7 @@ use base qw(NCM::Component);
 use vars qw(@ISA $EC);
 use CAF::Process;
 use CAF::FileWriter;
+use CAF::FileReader;
 use LC::Exception;
 
 use File::Temp qw(tempdir);


### PR DESCRIPTION
ncm-ccm: add missing "use CAF::FileReader"

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.

Component fails if the noquattor file is present, and some other component has not already loaded FileReader (eg. only this compoent was run).

* What backwards incompatibility it may introduce.

None.