### PR TITLE
ncm-network: documentation cleanup

### DIFF
--- a/ncm-network/src/main/perl/network.pod
+++ b/ncm-network/src/main/perl/network.pod
@@ -108,7 +108,7 @@ Set the TCP segment offload parameter to "off" or "on"
 
 =back
 
-Set the ethernet transmit or receive buffer ring counts.  See ethtool --show-ring for the values.
+Set the ethernet transmit or receive buffer ring counts. See ethtool --show-ring for the values.
 
 =over
 
@@ -116,7 +116,7 @@ Set the ethernet transmit or receive buffer ring counts.  See ethtool --show-rin
 
 =back
 
-Set the wake-on-lan parameter.  See ethtool for more details of the choices.  "d" disables the
+Set the wake-on-lan parameter. See ethtool for more details of the choices. "d" disables the
 wake-on LAN.
 
 =head1 NOZEROCONF


### PR DESCRIPTION
fixed some double spacing.