### PR TITLE
ncm-gpfs: add new hdfs-protocol package to GPFSRPMS

### DIFF
--- a/ncm-gpfs/src/main/perl/gpfs.pm
+++ b/ncm-gpfs/src/main/perl/gpfs.pm
@@ -47,6 +47,7 @@ use constant GPFSRPMS => qw(
                             ^gpfs.msg.en_US$
                             ^gpfs.ext$
                             ^gpfs.gskit$
+                            ^gpfs.hdfs-protocol$
                             ^gpfs.hadoop-connector$
                            );
 


### PR DESCRIPTION
ncm-gpfs does not need to fail because of unrecognized package gpfs.hdfs-protocol