### PR TITLE
ncm-fstab: enable NoAction support.

### DIFF
--- a/ncm-fstab/src/main/perl/fstab.pm
+++ b/ncm-fstab/src/main/perl/fstab.pm
@@ -22,6 +22,7 @@ use constant MOUNT => qw(/bin/mount);
 
 our @ISA = qw(NCM::Component);
 our $EC = LC::Exception::Context->new()->will_store_all();
+our $NoActionSupported = 1;
 
 # Updates entries in /etc/fstab. Returns a hash with the mountpoints
 # that exist in the profile.


### PR DESCRIPTION
Describe the change you are making here, in particular we would like to know:

Since the last time I looked at this component, the call to LC::File::makedir has been replaced with LC::Check::directory, so it should be possible to enable NoAction support.

* Why the change is necessary.

Component supports NoAction but needs flag set.

* What backwards incompatibility it may introduce.

None.