### PR TITLE
ncm-ccm: support purge_time config setting.

### DIFF
--- a/ncm-ccm/src/main/pan/components/ccm/schema.pan
+++ b/ncm-ccm/src/main/pan/components/ccm/schema.pan
@@ -78,6 +78,7 @@ type component_ccm = {
     'json_typed'       ? boolean
     'tabcompletion'    ? boolean
     'keep_old'         ? long(0..)
+    'purge_time'       ? long(0..)
     'trust'            ? kerberos_principal_string[]
     'principal'        ? kerberos_principal_string
     'keytab'           ? string


### PR DESCRIPTION
Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.

We would like to start using the purge_time config setting but it's missing from the schema.

* What backwards incompatibility it may introduce.

None.