### PR TITLE
ncm-download: fix proxy handling.

### DIFF
--- a/ncm-download/src/main/perl/download.pm
+++ b/ncm-download/src/main/perl/download.pm
@@ -179,10 +179,10 @@ sub download
                 %opts);
 
             if ($success) {
-                $proxyhosts = [$proxy, @$proxyhosts];
+                unshift @$proxyhosts, $proxy;
                 last;
             } else {
-                $proxyhosts = [@$proxyhosts, $proxy];
+		push @$proxyhosts, $proxy;
             }
         }
 

--- a/ncm-download/src/main/perl/download.pm
+++ b/ncm-download/src/main/perl/download.pm
@@ -179,10 +179,12 @@ sub download
                 %opts);
 
             if ($success) {
+                # add succesful proxy at begin
                 unshift @$proxyhosts, $proxy;
                 last;
             } else {
-		push @$proxyhosts, $proxy;
+                # add failed proxy at the back
+                push @$proxyhosts, $proxy;
             }
         }
 

--- a/ncm-download/src/test/resources/download.pan
+++ b/ncm-download/src/test/resources/download.pan
@@ -12,12 +12,20 @@ include 'components/download/config';
 prefix "/software/components/download";
 "server" = "default.server";
 "proto" = "https";
-"proxyhosts" = list('broken', 'working');
+"proxyhosts" = list('broken', 'working', 'working2');
 
 prefix "/software/components/download/files";
-"{/a/b/c}" = dict(
+"{/a/b/c1}" = dict(
     "proxy", true,
-    "href" ,"something",
+    "href" ,"something1",
+    );
+"{/a/b/c2}" = dict(
+    "proxy", true,
+    "href" ,"something2",
+    );
+"{/a/b/c3}" = dict(
+    "proxy", true,
+    "href" ,"something3",
     );
 "{/a/b/d}" = dict(
     "proxy", true,


### PR DESCRIPTION
* Why the change is necessary.

Bug in the proxy handling. The list of proxies is passed to a function
by reference, which is intended to rotate the list.

While the intention (and previous behaviour) was to put $proxy back
into the original list, either at the front or at the end, now it creates
a new list instead while the original one gets shorter...

* What backwards incompatibility it may introduce.

None.