### PR TITLE
ncm-cdp : Update ncm-cdp schema to support hostname

### DIFF
--- a/ncm-cdp/src/main/pan/components/cdp/schema.pan
+++ b/ncm-cdp/src/main/pan/components/cdp/schema.pan
@@ -16,6 +16,7 @@ type component_cdp = {
     'fetch'        ? string
     'fetch_offset' ? long(0..)
     'fetch_smear'  ? long(0..)
+    'hostname'     ? type_hostname
 };
 
 bind '/software/components/cdp' = component_cdp;


### PR DESCRIPTION
A new "hostname" option has been introduced by https://github.com/quattor/cdp-listend/pull/16 to specify the interface to bind. Fixes #944 (requires quattor/cdp-listend#16 for the underlying support).
This is a backward compatible change.
