### PR TITLE
metaconfig: service ncm-ncd: add new config options

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/ncm-ncd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ncm-ncd/pan/schema.pan
@@ -1,6 +1,7 @@
 declaration template metaconfig/ncm-ncd/schema;
 
 include 'pan/types';
+include if_exists('components/accounts/functions');
 
 type ncm_ncd = {
     'all' ? boolean
@@ -11,11 +12,14 @@ type ncm_ncd = {
     'chroot' ? string
     'configure' ? string
     'facility' ? string
-    'forcelock' ? boolean 
+    'forcelock' ? boolean
     'ignore-errors-from-dependencies' ? boolean
     'ignorelock' ? boolean
     'include' ? string[]
+    'log_group_readable' ? string with if (path_exists('/software/components/accounts')) {is_user_or_group('group', SELF)} else {true}
+    'log_world_readable' ? boolean
     'logdir' ? string
+    'logpid' ? boolean
     'multilog' ? boolean
     'noaction' ? boolean
     'nodeps' ? boolean
@@ -29,4 +33,5 @@ type ncm_ncd = {
     'timeout' ? long(0..)
     'unconfigure' ? string
     'useprofile' ? long # TODO support negative CID (e.g. -1)?
+    'verbose_logfile' ? boolean
 };


### PR DESCRIPTION
Allow to configure new options introduced by https://github.com/quattor/ncm-ncd/pull/88