### PR TITLE
ncm-accounts, ncm-amandaserver, ncm-cups, ncm-iptables, ncm-nscd: Use legacy type for simple yes/no strings

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/schema.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/schema.pan
@@ -54,7 +54,7 @@ type structure_login_defs = {
     'pass_min_days' ? long(1..)
     'pass_min_len' ? long(1..)
     'pass_warn_age' ? long(1..)
-    'create_home' ? string with match (SELF,'yes|no')
+    'create_home' ? legacy_binary_affirmation_string
     'mail_dir' ? string
     'umask' ? string
     'userdel_cmd' ? string

--- a/ncm-amandaserver/src/main/pan/components/amandaserver/schema.pan
+++ b/ncm-amandaserver/src/main/pan/components/amandaserver/schema.pan
@@ -16,28 +16,37 @@ type columnspec = {
 	"width" : long
 };
 
-type backupstring = string with exists ("/software/components/amandaserver/backups/"
-					+ SELF) ||
-                               error ("No backups with name " + SELF);
- 
-type tapetypestring = string with exists ("/software/components/amandaserver/backups/config/tapetypes/"
-					+ SELF) ||
-                               error ("No tapetype with name " + SELF);
-                               
-type dumptypestring = string with exists ("/software/components/amandaserver/backups/config/dumptypes/"
-					+ SELF) ||
-                               error ("No dumptype with name " + SELF);
-                             
-type interfacestring = string with exists ("/software/components/amandaserver/backups/config/interfaces/"
-					+ SELF) ||
-                               error ("No interfaces with name " + SELF);
-                               
-type booleanstring = string with match (SELF, '^(yes|y|true|t|on|no|n|false|f|off)$');
+type backupstring = string with exists(
+    "/software/components/amandaserver/backups/" + SELF
+) || error ("No backups with name " + SELF);
 
-type sizestring = string with match (SELF, '^(\-*\d+\s+(?i)(b|byte|bytes|k|kb|kbyte|kbytes|kilobyte|kilobytes|m|mb|meg|mbyte|mbytes|megabyte|megabytes|g|gb|gbyte|gbytes|gigabyte|gigabytes))$');
-             
-type speedstring = string with match (SELF, '^(\-*\d+\s+(?i)(bps|kps|kbps|mps mbps))$');
-                  
+type tapetypestring = string with exists(
+    "/software/components/amandaserver/backups/config/tapetypes/" + SELF
+) || error ("No tapetype with name " + SELF);
+
+type dumptypestring = string with exists(
+    "/software/components/amandaserver/backups/config/dumptypes/" + SELF
+) || error ("No dumptype with name " + SELF);
+
+type interfacestring = string with exists(
+    "/software/components/amandaserver/backups/config/interfaces/" + SELF
+) || error ("No interfaces with name " + SELF);
+
+type booleanstring = string with match(
+    SELF,
+    '^(yes|y|true|t|on|no|n|false|f|off)$'
+);
+
+type sizestring = string with match(
+    SELF,
+    '^(\-*\d+\s+(?i)(b|byte|bytes|k|kb|kbyte|kbytes|kilobyte|kilobytes|m|mb|meg|mbyte|mbytes|megabyte|megabytes|g|gb|gbyte|gbytes|gigabyte|gigabytes))$'
+);
+
+type speedstring = string with match(
+    SELF,
+    '^(\-*\d+\s+(?i)(bps|kps|kbps|mps mbps))$'
+);
+
 # General options
 type structure_amandaserver_general = {
 	"org" ? string
@@ -67,7 +76,7 @@ type structure_amandaserver_general = {
 	"bumpsize" ? sizestring
 	"bumpmult" ? double
 	"bumpdays" ? long
-	"disklist" ? string 
+	"disklist" ? string
 	"infofile" ? string
 	"logdir" ? string
 	"indexdir" ? string
@@ -78,7 +87,7 @@ type structure_amandaserver_general = {
 	"amrecover_do_fsf" ? booleanstring
 	"amrecover_check_label" ? booleanstring
 	"amrecover_changer" ? string
-	"columnspec" ? columnspec[] 
+	"columnspec" ? columnspec[]
 	"includefile" ? string
 };
 
@@ -158,7 +167,7 @@ type structure_amandaserver_config = {
 	"tapetypes" : structure_amandaserver_tapetype[]
 	"dumptypes" : structure_amandaserver_dumptype[]
 	"interfaces" : structure_amandaserver_interface[]
-};	
+};
 
 # Definition for a disk
 type structure_amandaserver_disk = {

--- a/ncm-amandaserver/src/main/pan/components/amandaserver/schema.pan
+++ b/ncm-amandaserver/src/main/pan/components/amandaserver/schema.pan
@@ -4,7 +4,7 @@
 
 declaration template components/amandaserver/schema;
 
-include {'quattor/schema'};
+include 'quattor/schema';
 
 # Convenience type definitions
 

--- a/ncm-amandaserver/src/main/pan/components/amandaserver/schema.pan
+++ b/ncm-amandaserver/src/main/pan/components/amandaserver/schema.pan
@@ -11,9 +11,9 @@ include {'quattor/schema'};
 # Type columnspec (comma separated  list  of triples.
 # Each triple consists of three parts which are separated by a equal sign (’=’) and a colon (’:’)
 type columnspec = {
-	"name" : string with match (SELF, "Compress|Disk|DumpRate|DumpTime|HostName|LevelOrigKB|OutKB|TapeRate|TapeTime")
-	"space" : long
-	"width" : long
+    "name" : string with match (SELF, "Compress|Disk|DumpRate|DumpTime|HostName|LevelOrigKB|OutKB|TapeRate|TapeTime")
+    "space" : long
+    "width" : long
 };
 
 type backupstring = string with exists(
@@ -49,150 +49,150 @@ type speedstring = string with match(
 
 # General options
 type structure_amandaserver_general = {
-	"org" ? string
-	"mailto" ? string
-	"dumpcycle" ? long # In days
-	"runspercycle" ? long
-	"tapecycle" ? long # Number of tapes
-	"dumpuser" ? string
-	"printer" ? string
-	"tapedev" ?  string
-	"rawtapedev" ?  string
-	"tpchanger" ? string
-	"changerdev" ? string
-	"changerfile" ? string
-	"runtapes" ? long
-	"maxdumpsize" ? sizestring
-	"taperalgo" ? string with match (SELF, "first|firstfit|largest|largestfit|smallest|last")
-	"labelstr" ? string
-	"tapetype" ? string # deberia ser tapestring pero no se como
-	"ctimeout" ? long # In seconds
-	"dtimeout" ? long # In seconds
-	"etimeout" ? long  # In seconds
-	"inparallel" ? long
-	"netusage" ? speedstring
-	"dumporder" ? string with match (SELF, "^[s|S|t|T|b|B]+$")
-	"maxdumps" ? long
-	"bumpsize" ? sizestring
-	"bumpmult" ? double
-	"bumpdays" ? long
-	"disklist" ? string
-	"infofile" ? string
-	"logdir" ? string
-	"indexdir" ? string
-	"tapelist" ? string
-	"tapebufs" ? long
-	"reserve" ? number
-	"autoflush" ? booleanstring
-	"amrecover_do_fsf" ? booleanstring
-	"amrecover_check_label" ? booleanstring
-	"amrecover_changer" ? string
-	"columnspec" ? columnspec[]
-	"includefile" ? string
+    "org" ? string
+    "mailto" ? string
+    "dumpcycle" ? long # In days
+    "runspercycle" ? long
+    "tapecycle" ? long # Number of tapes
+    "dumpuser" ? string
+    "printer" ? string
+    "tapedev" ?  string
+    "rawtapedev" ?  string
+    "tpchanger" ? string
+    "changerdev" ? string
+    "changerfile" ? string
+    "runtapes" ? long
+    "maxdumpsize" ? sizestring
+    "taperalgo" ? string with match (SELF, "first|firstfit|largest|largestfit|smallest|last")
+    "labelstr" ? string
+    "tapetype" ? string # deberia ser tapestring pero no se como
+    "ctimeout" ? long # In seconds
+    "dtimeout" ? long # In seconds
+    "etimeout" ? long  # In seconds
+    "inparallel" ? long
+    "netusage" ? speedstring
+    "dumporder" ? string with match (SELF, "^[s|S|t|T|b|B]+$")
+    "maxdumps" ? long
+    "bumpsize" ? sizestring
+    "bumpmult" ? double
+    "bumpdays" ? long
+    "disklist" ? string
+    "infofile" ? string
+    "logdir" ? string
+    "indexdir" ? string
+    "tapelist" ? string
+    "tapebufs" ? long
+    "reserve" ? number
+    "autoflush" ? booleanstring
+    "amrecover_do_fsf" ? booleanstring
+    "amrecover_check_label" ? booleanstring
+    "amrecover_changer" ? string
+    "columnspec" ? columnspec[]
+    "includefile" ? string
 };
 
 # Options for holdingdisks
 type structure_amandaserver_holdingdisk = {
-	"comment" ? string
-	"directory" ? string
-	"use" ? sizestring
-	"chunksize" ? sizestring
+    "comment" ? string
+    "directory" ? string
+    "use" ? sizestring
+    "chunksize" ? sizestring
 };
 
 # Options for dumptype configuration
 type structure_amandaserver_dumptype_conf = {
-	"auth" ? string
-	"comment" ? string
-	"comprate" ? double[]
-	"compress" ? string with match (SELF,'^((client|server|none)( \w+)?)$')
-	"dumpcycle" ? long # In days
-	"exclude" ? string with match (SELF, '^((list|file)( .+)?)$')
-	"holdingdisk" ? booleanstring
-	"ignore" ? booleanstring
-	"include" ? string with match (SELF, '^((list|file)( .+)?)$')
-	"index" ? string with match (SELF, '^(yes|y|true|t|on|no|n|false|f|off)$')
-	"kencrypt" ? booleanstring
-	"maxdumps" ? long
-	"maxpromoteday" ? long
-	"priority" ? string
-	"program" ? string
-	"record" ? booleanstring
-	"skip-full" ? booleanstring
-	"skip-incr" ? booleanstring
-	"starttime" ? long # Entered as hh*100+mm
-	"strategy" ? string with match (SELF, "standard|nofull|noinc|skip")
-	"inc_dumptypes" ? string[] # deberia de ser dumptypestring[]
+    "auth" ? string
+    "comment" ? string
+    "comprate" ? double[]
+    "compress" ? string with match (SELF,'^((client|server|none)( \w+)?)$')
+    "dumpcycle" ? long # In days
+    "exclude" ? string with match (SELF, '^((list|file)( .+)?)$')
+    "holdingdisk" ? booleanstring
+    "ignore" ? booleanstring
+    "include" ? string with match (SELF, '^((list|file)( .+)?)$')
+    "index" ? string with match (SELF, '^(yes|y|true|t|on|no|n|false|f|off)$')
+    "kencrypt" ? booleanstring
+    "maxdumps" ? long
+    "maxpromoteday" ? long
+    "priority" ? string
+    "program" ? string
+    "record" ? booleanstring
+    "skip-full" ? booleanstring
+    "skip-incr" ? booleanstring
+    "starttime" ? long # Entered as hh*100+mm
+    "strategy" ? string with match (SELF, "standard|nofull|noinc|skip")
+    "inc_dumptypes" ? string[] # deberia de ser dumptypestring[]
 };
 
 # Options for dumptype
 type structure_amandaserver_dumptype = {
-	"dumptype_name" : string
-	"dumptype_conf" : structure_amandaserver_dumptype_conf
+    "dumptype_name" : string
+    "dumptype_conf" : structure_amandaserver_dumptype_conf
 };
 
 # Options for tapetype configuration
 type structure_amandaserver_tapetype_conf = {
-	"comment" ? string
-	"filemark" ? sizestring
-	"length" ? sizestring
-	"block-size" ? sizestring
-	"file-pad" ? booleanstring
-	"speed" ? speedstring
-	"lbl-templ" ? string
-	"inc_tapetypes" ? string[] # deberia ser tapetypestring[]
+    "comment" ? string
+    "filemark" ? sizestring
+    "length" ? sizestring
+    "block-size" ? sizestring
+    "file-pad" ? booleanstring
+    "speed" ? speedstring
+    "lbl-templ" ? string
+    "inc_tapetypes" ? string[] # deberia ser tapetypestring[]
 };
 
 # Options for tapetype
 type structure_amandaserver_tapetype = {
-	"tapetype_name" : string
-	"tapetype_conf" : structure_amandaserver_tapetype_conf
+    "tapetype_name" : string
+    "tapetype_conf" : structure_amandaserver_tapetype_conf
 };
 
 # Options for interface configuration
 type structure_amandaserver_interface_conf = {
-	"comment" ? string
-	"use" ? speedstring
-	"inc_interfaces" ? string[] # deberia ser interfacestring[]
+    "comment" ? string
+    "use" ? speedstring
+    "inc_interfaces" ? string[] # deberia ser interfacestring[]
 };
 
 # Options for interface
 type structure_amandaserver_interface = {
-	"interface_name" : string
-	"interface_conf" : structure_amandaserver_interface_conf
+    "interface_name" : string
+    "interface_conf" : structure_amandaserver_interface_conf
 };
 # The full definition for the config file
 type structure_amandaserver_config = {
-	"general_options" : structure_amandaserver_general
-	"holdingdisks" : structure_amandaserver_holdingdisk{}
-	"tapetypes" : structure_amandaserver_tapetype[]
-	"dumptypes" : structure_amandaserver_dumptype[]
-	"interfaces" : structure_amandaserver_interface[]
+    "general_options" : structure_amandaserver_general
+    "holdingdisks" : structure_amandaserver_holdingdisk{}
+    "tapetypes" : structure_amandaserver_tapetype[]
+    "dumptypes" : structure_amandaserver_dumptype[]
+    "interfaces" : structure_amandaserver_interface[]
 };
 
 # Definition for a disk
 type structure_amandaserver_disk = {
-	"hostname" : string
-	"diskname" : string
-	"dumptype" : string # deberia ser dumptypestring
+    "hostname" : string
+    "diskname" : string
+    "dumptype" : string # deberia ser dumptypestring
 };
 
 # The full definition for the component backup
 type structure_amandaserver_backup = {
-	"config" : structure_amandaserver_config
-	"disklist" : structure_amandaserver_disk[]
+    "config" : structure_amandaserver_config
+    "disklist" : structure_amandaserver_disk[]
 };
 
 # Definition for the component amandahosts entries
 type structure_amandaserver_amandahost = {
-	"domain" : string
-	"user" : string
+    "domain" : string
+    "user" : string
 };
 
 # The full definition for the component
 type structure_component_amandaserver = {
-	include structure_component
-	"backups" : structure_amandaserver_backup{}
-	"amandahosts" : structure_amandaserver_amandahost[]
+    include structure_component
+    "backups" : structure_amandaserver_backup{}
+    "amandahosts" : structure_amandaserver_amandahost[]
 };
 
 bind "/software/components/amandaserver" = structure_component_amandaserver;

--- a/ncm-cups/src/main/pan/components/cups/schema.pan
+++ b/ncm-cups/src/main/pan/components/cups/schema.pan
@@ -22,7 +22,7 @@ type component_cups_printer = {
 
 
 type component_cups_options = {
-    "AutoPurgeJobs"         ? string with match (SELF, "yes|no")
+    "AutoPurgeJobs"         ? legacy_binary_affirmation_string
     "Classification"        ? string
     "ClassifyOverride"      ? string with match (SELF, "on|off")
     "DataDir"               ? string
@@ -32,8 +32,8 @@ type component_cups_options = {
     "LogLevel"              ? string with match (SELF,"debug2|debug|info|warn|error|none")
     "MaxCopies"             ? long
     "MaxLogSize"            ? long
-    "PreserveJobHistory"    ? string with match (SELF, "yes|no")
-    "PreserveJobFiles"      ? string with match (SELF, "yes|no")
+    "PreserveJobHistory"    ? legacy_binary_affirmation_string
+    "PreserveJobFiles"      ? legacy_binary_affirmation_string
     "Printcap"              ? string
     "ServerAdmin"           ? string
     "ServerName"            ? string

--- a/ncm-iptables/src/main/pan/components/iptables/schema.pan
+++ b/ncm-iptables/src/main/pan/components/iptables/schema.pan
@@ -87,7 +87,7 @@ type component_iptables_acls = {
     "preamble"          ? component_iptables_preamble
     "rules"             ? component_iptables_rule[]
     "epilogue"          ? string
-    "ordered_rules"     ? string with match (SELF, 'yes|no')
+    "ordered_rules"     ? legacy_binary_affirmation_string
 };
 
 type component_iptables = {

--- a/ncm-nscd/src/main/pan/components/nscd/schema.pan
+++ b/ncm-nscd/src/main/pan/components/nscd/schema.pan
@@ -8,15 +8,15 @@ declaration template components/nscd/schema;
 include {'quattor/schema'};
 
 type componend_nscd_service_type = {
-     "enable-cache"           ? string with match (SELF, '(yes|no)')
+     "enable-cache"           ? legacy_binary_affirmation_string
      "positive-time-to-live"  ? long
      "negative-time-to-live"  ? long
      "suggested-size"         ? long
-     "check-files"            ? string with match (SELF, '(yes|no)')
-     "persistent"             ? string with match (SELF, '(yes|no)')
-     "shared"                 ? string with match (SELF, '(yes|no)')
+     "check-files"            ? legacy_binary_affirmation_string
+     "persistent"             ? legacy_binary_affirmation_string
+     "shared"                 ? legacy_binary_affirmation_string
      "max-db-size"            ? long
-     "auto-propagate"         ? string with match (SELF, '(yes|no)')
+     "auto-propagate"         ? legacy_binary_affirmation_string
 };
 
 type component_nscd_type = {
@@ -29,7 +29,7 @@ type component_nscd_type = {
     "server-user"      ? string
     "stat-user"        ? string
     "reload-count"     ? string
-    "paranoia"         ? string with match (SELF, '(yes|no)')
+    "paranoia"         ? legacy_binary_affirmation_string
     "restart-interval" ? long
 
     "passwd" ? componend_nscd_service_type
@@ -38,4 +38,3 @@ type component_nscd_type = {
 };
 
 bind "/software/components/nscd" = component_nscd_type;
-


### PR DESCRIPTION
Fixes #752 as described therein.