### PR TITLE
ncm-network: Remove useless log message

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -907,7 +907,6 @@ sub Configure
         } else {
             $self->error("Restoring old config failed.");
         }
-        $self->info("Some more debug info");
         $self->info("Result of test_network_ping: ".test_network_ping());
         $self->info("Initial setup\n$init_config");
         $self->info("Setup after failure\n$failure_config");


### PR DESCRIPTION
Removes the utterly useless "Some more debug info" message that irritates me so much.

We should probably do something about the multi line message after it as well, but this will do for now.