### PR TITLE
ncm-network, ncm-authconfig, ncm-metaconfig: Use new valid_interface type

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/ipa.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/ipa.pan
@@ -19,16 +19,13 @@ type authconfig_sssd_ipa_krb5 = {
     'confd_path' ? absolute_file_path
 };
 
-# TODO: use valid_interface type from core templates once https://github.com/quattor/template-library-core/issues/130 is fixed
-type ipa_valid_interface = string with exists ("/system/network/interfaces/" + SELF);
-
 @{
     dyndns settings for the IPA access provider
 }
 type authconfig_sssd_ipa_dyndns = {
     'update' ? boolean
     'ttl' ? long(0..)
-    'iface' ? ipa_valid_interface[]
+    'iface' ? valid_interface[]
     'refresh_interval' ? long(0..)
     'update_ptr' ? boolean
     'force_tcp' ? boolean

--- a/ncm-metaconfig/src/main/metaconfig/ctdb/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ctdb/pan/schema.pan
@@ -2,24 +2,10 @@ declaration template metaconfig/ctdb/schema;
 
 include 'pan/types';
 
-
-@{ Checks for a valid network device @}
-function is_interface_device = {
-    if (exists(format("/system/network/interfaces/", ARGV[0]))) {
-        return(true);
-    };
-    foreach(ifc;attr;value('/system/network/interfaces')) {
-        if (attr['device'] == ARGV[0]){
-            return(true);
-        };
-    };
-    return(false);
-};
-
 @{ type for a ctdb public address @}
 type ctdb_public_address = {
     'network_name'          : type_network_name
-    'network_interface'    : string with is_interface_device(SELF)
+    'network_interface'    : valid_interface
 };
 
 type ctdb_public_addresses = ctdb_public_address[];
@@ -41,4 +27,3 @@ type ctdb_service = {
     'nfs_server_mode'           ? string
     'prologue'                  ? string    
 };
-

--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -29,7 +29,7 @@ type structure_bonding_options = {
     "miimon" : long
     "updelay" ? long
     "downdelay" ? long
-    "primary" ? string with exists("/system/network/interfaces/" + SELF)
+    "primary" ? valid_interface
     "lacp_rate" ? long(0..1)
     "xmit_hash_policy" ? string with match (SELF, '^(0|1|2|layer(2|2\+3|3\+4))$')
 } with {
@@ -124,14 +124,14 @@ type structure_interface = {
     "route"   ? structure_route[]
     "aliases" ? structure_interface_alias{}
     "set_hwaddr" ? boolean
-    "bridge"    ? string with exists ("/system/network/interfaces/" + SELF)
+    "bridge"    ? valid_interface
     "bonding_opts" ? structure_bonding_options
     "offload"   ? structure_ethtool_offload
     "ring"      ? structure_ethtool_ring
     "ethtool"   ? structure_ethtool
 
     "vlan" ? boolean
-    "physdev"    ? string with exists ("/system/network/interfaces/" + SELF)
+    "physdev"    ? valid_interface
 
     "fqdn" ? string
     "network_environment" ? string
@@ -144,7 +144,7 @@ type structure_interface = {
     "bridging_opts" ? structure_bridging_options
 
     "bond_ifaces" ? string[]
-    "ovs_bridge" ? string with exists ("/system/network/interfaces/" + SELF)
+    "ovs_bridge" ? valid_interface
     "ovs_extra" ? string
     "ovs_opts" ? string # See ovs-vswitchd.conf.db(5) for documentation
     "ovs_patch_peer" ? string
@@ -199,7 +199,7 @@ type structure_router = string[];
 type structure_ipv6 = {
     "enabled" ?  boolean
     "default_gateway"  ? type_ip
-    "gatewaydev"       ? string with exists ("/system/network/interfaces/" + SELF) # sets IPV6_DEFAULTDEV
+    "gatewaydev"       ? valid_interface # sets IPV6_DEFAULTDEV
 };
 
 @documentation{
@@ -210,7 +210,7 @@ type structure_network = {
     "hostname"         : type_shorthostname
     "realhostname"     ? type_fqdn
     "default_gateway"  ? type_ip
-    "gatewaydev"       ? string with exists ("/system/network/interfaces/" + SELF)
+    "gatewaydev"       ? valid_interface
     "interfaces"       : structure_interface{}
     "nameserver"       ? type_ip[]
     "nisdomain"        ? string(1..64) with match(SELF, '^\S+$')


### PR DESCRIPTION
Make use of `valid_interface` type introduced in quattor/template-library-core#135,
hence requires quattor/template-library-core#135.