### PR TITLE
ncm-filesystems: rewrite to reuse ncm-fstab code

### DIFF
--- a/ncm-filesystems/src/main/pan/components/filesystems/schema.pan
+++ b/ncm-filesystems/src/main/pan/components/filesystems/schema.pan
@@ -8,10 +8,14 @@ include 'quattor/schema';
 include 'quattor/blockdevices';
 include 'quattor/filesystems';
 
+@documentation{
+when manage_blockdevs is false, filesystems does same as fstab
+No other resources here: this component takes its configuration
+from fstab component, "/system/filesystems" and "/system/blockdevices"
+}
 type structure_component_filesystems = {
     include structure_component
-    # No resources here: this component takes its configuration
-    # from "/system/filesystems" and "/system/blockdevices"
+    'manage_blockdevs' : boolean = true
 };
 
 bind "/software/components/filesystems" = structure_component_filesystems;

--- a/ncm-filesystems/src/main/perl/filesystems.pm
+++ b/ncm-filesystems/src/main/perl/filesystems.pm
@@ -1,116 +1,130 @@
 #${PMpre} NCM::Component::filesystems${PMpost}
 
-use LC::Exception qw (throw_error);
-use LC::Process qw (output);
-use Cwd qw(abs_path);
+use CAF::Process;
+use CAF::FileEditor;
+use CAF::FileReader;
 use NCM::Filesystem;
 use NCM::Partition 16.12.1 qw (partition_sort);
 use CAF::Object;
+use Fcntl qw(:seek);
+use Readonly;
+use Cwd qw(abs_path);
 
-use constant PROTECTED_PATH => "/software/components/fstab/protected_mounts";
+Readonly my $UMOUNT => "/bin/umount";
+Readonly my $FSTAB_CMP_PATH => '/software/components/fstab';
+Readonly my $FS_TREE => '/system/filesystems';
+Readonly my $PARTITIONS_TREE => '/system/blockdevices/partitions';
+use parent qw(NCM::Component::fstab);
 
-use parent qw(NCM::Component);
-our $EC = LC::Exception::Context->new->will_store_all;
+our $EC = LC::Exception::Context->new()->will_store_all();
+our $NoActionSupported = 0; # First needs check/fixing in ncm-lib-blockdevices issue #74
 
-# Returns a hash with the canonical paths to the protected mountpoints
-# as its keys. I This small overhead may simplify the code later.
-sub protected_hash
+#  Removes filesystem and deletes stuff that is not present in the %mounts 
+#  argument from fstab.
+sub delete_outdated
 {
-	my $config = shift;
-	my %ph;
+    my ($self, $fstab, $mountsr, $config, $remove) = @_;
 
-	my $pl = $config->getElement (PROTECTED_PATH)->getTree;
+    my @rm;
+    my %mounts = %$mountsr;
+    $fstab->seek_begin();
 
-	foreach my $i (@$pl) {
-		$ph{$i} = 0;
-		my $path = abs_path("$i/");
-		$ph{$path} = 0 if $path;
-	}
-	return %ph;
+    while (my $f = <$fstab>) {
+        my $mount = $self->mount_from_entry($f) or next;
+        if (!exists ($mounts{$mount}) && !exists($mounts{abs_path($mount)})) {
+            CAF::Process->new ([$UMOUNT, $mount],
+                log => $self)->run();
+            push (@rm, $f);
+            $self->verbose ("Scheduling for removal from fstab: $mount");
+            $self->verbose ("Scheduling for removal filesystem $mount") if $remove;
+        }
+    }
+
+    foreach my $outdated (@rm) {
+        if ($remove) {
+            my $fsrm = NCM::Filesystem->new_from_fstab ($outdated, $config, log => $self);
+            $self->info("Removing filesystem for $fsrm->{mountpoint}");
+            if ($fsrm->remove_if_needed) {
+                $self->error("error $fsrm->{mountpoint}");
+                return;
+            } else {
+                $self->info("removed $fsrm->{mountpoint}")
+            }
+        }
+        $self->info("Removing line $outdated");
+        $fstab->replace_lines (qr{$outdated}, qr{^$}, "");
+    }
+    return 1;
 }
 
-# Returns a hash with the mountpoints of the filesystems defined on
-# the profile as its keys, and the filesystem objects as its values.
-sub fshash
+
+sub create_blockdevices
 {
-	my $fsl = shift;
-	my %fsh;
+    my ($self, $config, $fs) = @_;
+    # Partitions must be created first
+    my $parttree = $config->getElement ($PARTITIONS_TREE);
+    my @part = ();
+    $self->info ("Checking whether partitions need to be created");
 
-	$fsh{$_->{mountpoint}} = $_ foreach @$fsl;
-	return %fsh;
-}
+    while ($parttree && $parttree->hasNextElement) {
+        my $partel = $parttree->getNextElement;
+        push (@part, NCM::Partition->new ($partel->getPath->toString, $config, log => $self));
+    }
+    foreach my $partition (partition_sort(@part)) {
+        if ($partition->create != 0) {
+            $self->error("Couldn't create partition: " . $partition->devpath);
+            return 0;
+        }
+    }
+    foreach my $filesystem (@$fs) {
+        if ($filesystem->create_if_needed != 0) {
+            $self->error("Failed to create filesystem:  $filesystem->{mountpoint}");
+            return 0;
+        }
+    }
+    return 1;
+};
 
-# Frees space on the system. It removes filesystems that are not
-# present in the profile anymore, and are *not* present in the
-# protected hash either. Returns 0 on success, -1 on error.
-sub free_space
-{
-	my ($self, $cfg, $protected, @fs) = @_;
-
-	my %ph = %$protected;
-	my %fsh = fshash (\@fs);
-
-	my $fl = output ("grep", "^[[:space:]]*#", "/etc/fstab", "-v");
-
-	$self->info ("Checking filesystems not defined in the profile");
-	my @fstab = split ("\n+", $fl);
-	foreach my $l (@fstab) {
-		$self->debug (5,"Fstab line: $l");
-		$l =~ m{^\S+\s+(\S+)\s} or next;
-		my $mount = $1;
-		next if(exists $fsh{$mount} || exists $ph{$mount}
-			    || exists($ph{abs_path($mount)}));
-		$self->verbose("Removing filesystem $mount");
-		my $f = NCM::Filesystem->new_from_fstab ($l, log => $self);
-		$f->remove_if_needed==0 or return -1;
-
-	}
-	return 0;
-}
 
 sub Configure
 {
-	my ($self, $config) = @_;
+    my ($self, $config) = @_;
 
-	my @fs = ();
+    my $tree = $config->getTree($self->prefix());
+    my $fstab_tree = $config->getTree($FSTAB_CMP_PATH);
 
-	if ($CAF::Object::NoAction) {
-		$self->warn ("--noaction not supported. Leaving.");
-		return 1;
-	}
+    my $manage = $tree->{manage_blockdevs};
+    $self->info('Managing blockdevices: ', ($manage) ? 'yes' : 'no');
+    my $fstab = CAF::FileEditor->new (NCM::Filesystem::FSTAB, log => $self,
+				      backup => '.old');
 
-	my $el = $config->getElement ("/system/filesystems");
-	while ($el->hasNextElement) {
-		my $el2 = $el->getNextElement;
-		push (@fs, NCM::Filesystem->new ($el2->getPath->toString, $config, log => $self));
-	}
-	my %protected = protected_hash ($config);
-	$self->free_space ($config, \%protected, @fs)==0 or return 0;
-	# Partitions must be created first, see bug #26137
-	$el = $config->getElement ("/system/blockdevices/partitions");
-	my @part = ();
-	$self->info ("Checking whether partitions need to be created");
+    my $fs = [];
+    my $fstree = $config->getElement ($FS_TREE);
+    while ($fstree->hasNextElement) {
+        my $fsel = $fstree->getNextElement;
+        push (@$fs, NCM::Filesystem->new ($fsel->getPath->toString, $config, log => $self));
+    }
 
-	while ($el && $el->hasNextElement) {
-		my $el2 = $el->getNextElement;
-		push (@part, NCM::Partition->new ($el2->getPath->toString, $config, log => $self));
-	}
-	foreach (partition_sort(@part)) {
-		if ($_->create != 0) {
-			throw_error ("Couldn't create partition: " . $_->devpath);
-			return 0;
-		}
-	}
-	foreach (@fs) {
-		if ($_->create_if_needed != 0) {
-			throw_error ("Failed to create filesystem:  $_->{mountpoint}");
-			return 0;
-		}
+    my $protected = $self->protected_hash($fstab_tree);
+    my %mounts = map {$_->{mountpoint} => $_} @$fs;
+    %mounts = $self->valid_mounts($protected->{keep}, $fstab, %mounts);
 
-		if ($_->format_if_needed (%protected) != 0) {
-			$self->warn ("Failed to format filesystem: ".
-				      $_->{mountpoint});
-		}
-	}
-	return 1;
+    $self->delete_outdated ($fstab, \%mounts, $config, $manage) or return 0;
+    if($manage) {
+        $self->create_blockdevices ($config, $fs) or return 0;
+    }
+    $self->update_entries ($config, $fstab, $protected->{static});
+
+    if ($fstab->close()) {
+    	$fstab = CAF::FileReader->new (NCM::Filesystem::FSTAB, log => $self);
+    	my $err = $self->remount_everything ($fstab);
+    	if ($err) {
+    	    $self->error ("Failed to mount some filesystems");
+    	    return 0;
+    	}
+    }
+
+    return 1;
 }
+
+1;

--- a/ncm-filesystems/src/main/perl/filesystems.pod
+++ b/ncm-filesystems/src/main/perl/filesystems.pod
@@ -16,6 +16,8 @@ from C<< /etc/fstab >>, using ncm-fstab.
 The component doesn't provide any special resources at the moment. It
 just watches for changes on C<< /system/filesystems >> and C<< /system/blockdevices >>
 and creates new filesystems, if needed.
+You can also use ncm-filesystems to replace ncm-fstab :
+If C<< manage_blockdevs >> is set to false, only the ncm-fstab code will run.
 
 A blockdevice is useful only for its ability to hold a
 filesystem. Blockdevices with no filesystems associated will not be

--- a/ncm-filesystems/src/test/perl/00-load.t
+++ b/ncm-filesystems/src/test/perl/00-load.t
@@ -12,6 +12,11 @@ Basic test that ensures that our module will load correctly.
 
 use strict;
 use warnings;
+
+BEGIN {
+    unshift(@INC, '../ncm-fstab/target/lib/perl');
+}
+
 use Test::More tests => 1;
 use Test::Quattor;
 

--- a/ncm-filesystems/src/test/perl/configure.t
+++ b/ncm-filesystems/src/test/perl/configure.t
@@ -16,6 +16,8 @@ use Readonly;
 Readonly my $FSTAB => 'target/test/etc/fstab';
 
 BEGIN{
+    unshift(@INC, '../ncm-fstab/target/lib/perl');
+
     # This only works because the constant of NCM::Filesystem is used in a ncm-fstab sub
     use Test::Quattor;
     use NCM::Filesystem;

--- a/ncm-filesystems/src/test/perl/configure.t
+++ b/ncm-filesystems/src/test/perl/configure.t
@@ -1,0 +1,97 @@
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+=pod
+
+=head1 test for ncm-filesystems Configure method
+
+Tests for adding, changing and deleting entries in /etc/fstab and mounting
+
+=cut
+
+use strict;
+use warnings;
+use Readonly;
+Readonly my $FSTAB => 'target/test/etc/fstab';
+
+BEGIN{
+    # This only works because the constant of NCM::Filesystem is used in a ncm-fstab sub
+    use Test::Quattor;
+    use NCM::Filesystem;
+    undef &{NCM::Filesystem::FSTAB};
+    *{NCM::Filesystem::FSTAB} =  sub () {$FSTAB} ;
+}
+
+use CAF::FileEditor;
+use CAF::Object;
+use File::Basename;
+use File::Path qw(mkpath);
+use LC::Check;
+use NCM::Component::filesystems;
+use Test::Deep;
+use Test::MockModule;
+use Test::More;
+use Test::Quattor qw(configure);
+use Test::Quattor::RegexpTest;
+use data;
+
+is(NCM::Filesystem::FSTAB, $FSTAB);
+mkpath dirname $FSTAB;
+
+$CAF::Object::NoAction = 1;
+$LC::Check::NoAction = 1;
+set_caf_file_close_diff(1);
+my $cfg = get_config_for_profile('configure');
+my $cmp = NCM::Component::filesystems->new('filesystems');
+$NCM::Blockdevices::this_app = $cmp;
+use NCM::Blockdevices;
+
+my $mock = Test::MockModule->new('NCM::Filesystem');
+my $mockp = Test::MockModule->new('NCM::Partition');
+
+my $managed = 0;
+$mock->mock('create_if_needed', sub {
+    my ($self) = @_;
+    diag "create_if_needed ran on $self->{mountpoint}";
+    $managed = 1;
+    return;
+    }
+);
+
+$mock->mock('remove_if_needed', sub {
+    my ($self) = @_;
+    diag "remove_if_needed ran on $self->{mountpoint}";
+    $managed = 1;
+    return;
+    }
+);
+
+$mockp->mock('create', sub {
+    my ($self) = @_;
+    diag "create ran on $self->{devname}";
+    $managed = 1;
+    return;
+    }
+);
+
+set_file_contents($FSTAB, $data::FSTAB_CONTENT);
+
+# Test all values
+$cmp->Configure($cfg);
+my $fh = get_file($FSTAB);
+
+my $rt = Test::Quattor::RegexpTest->new(
+    regexp => 'src/test/resources/fstab_regextest',
+    text => "$fh",
+    );  
+$rt->test();
+
+my $cmd = get_command("/bin/mount -o remount /");
+ok(defined($cmd), "remount / was invoked");
+$cmd=get_command("/bin/mount -o remount /boot");
+ok(!defined($cmd), "remount /boot was not invoked");
+is($managed, 0, "Nothing is created or removed on fs or partition level");
+
+done_testing();
+

--- a/ncm-filesystems/src/test/perl/configure_create.t
+++ b/ncm-filesystems/src/test/perl/configure_create.t
@@ -12,6 +12,11 @@ Tests for adding, changing and deleting entries in /etc/fstab and mounting
 =cut
 
 use strict;
+
+BEGIN {
+    unshift(@INC, '../ncm-fstab/target/lib/perl');
+}
+
 use warnings;
 use Readonly;
 Readonly my $FSTAB => 'target/test/etc/fstab';

--- a/ncm-filesystems/src/test/perl/configure_create.t
+++ b/ncm-filesystems/src/test/perl/configure_create.t
@@ -1,0 +1,103 @@
+# -*- mode: cperl -*-
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+=pod
+
+=head1 test for ncm-filesystems Configure method
+
+Tests for adding, changing and deleting entries in /etc/fstab and mounting
+
+=cut
+
+use strict;
+use warnings;
+use Readonly;
+Readonly my $FSTAB => 'target/test/etc/fstab';
+
+BEGIN{
+    # This only works because the constant of NCM::Filesystem is used in a ncm-fstab sub
+    use NCM::Filesystem;
+    undef &{NCM::Filesystem::FSTAB};
+    *{NCM::Filesystem::FSTAB} =  sub () {$FSTAB} ;
+}
+use CAF::FileEditor;
+use CAF::Object;
+use File::Basename;
+use File::Path qw(mkpath);
+use LC::Check;
+use NCM::Component::filesystems;
+use Test::Deep;
+use Test::More;
+use Test::MockModule;
+use Test::Quattor qw(configure_create);
+use Test::Quattor::RegexpTest;
+use data;
+
+is(NCM::Filesystem::FSTAB, $FSTAB);
+mkpath dirname $FSTAB;
+
+$CAF::Object::NoAction = 1;
+$LC::Check::NoAction = 1;
+set_caf_file_close_diff(1);
+my $cfg = get_config_for_profile('configure_create');
+my $cmp = NCM::Component::filesystems->new('filesystems');
+$NCM::Blockdevices::this_app = $cmp;
+use NCM::Blockdevices;
+
+my $mock = Test::MockModule->new('NCM::Filesystem');
+my $mockp = Test::MockModule->new('NCM::Partition');
+
+my $created_fs = [];
+my $created_part = [];
+my $removed_fs = [];
+$mock->mock('create_if_needed', sub {
+    my ($self) = @_;
+    diag "create_if_needed ran on $self->{mountpoint}";
+    push (@$created_fs, $self->{mountpoint});
+    return 0;
+    }
+);
+
+$mock->mock('remove_if_needed', sub {
+    my ($self) = @_;
+    diag "remove_if_needed ran on $self->{mountpoint}";
+    push (@$removed_fs, $self->{mountpoint});
+
+    return 0;
+    }
+);
+
+$mockp->mock('create', sub {
+    my ($self) = @_;
+    diag "create is ran on $self->{devname}";
+    push (@$created_part, $self->{devname});
+    return 0;
+    }
+);
+
+set_file_contents($FSTAB, $data::FSTAB_CONTENT);
+
+# Test all values
+$cmp->Configure($cfg);
+my $fh = get_file($FSTAB);
+
+cmp_deeply($created_part, \@data::PARTS_CREATE, "Partition create called");
+cmp_deeply($created_fs, \@data::FS_CREATE, "fs create_if_needed called");
+cmp_deeply($removed_fs, \@data::FS_REMOVE, "fs remove_if_needed called");
+
+my $rt = Test::Quattor::RegexpTest->new(
+    regexp => 'src/test/resources/fstab_regextest',
+    text => "$fh",
+    );  
+$rt->test();
+
+my $cmd = get_command("/bin/mount -o remount /");
+ok(defined($cmd), "remount / was invoked");
+$cmd=get_command("/bin/mount -o remount /boot");
+ok(!defined($cmd), "remount /boot was not invoked");
+
+
+done_testing();
+

--- a/ncm-filesystems/src/test/perl/data.pm
+++ b/ncm-filesystems/src/test/perl/data.pm
@@ -1,0 +1,93 @@
+# -*- mode: cperl -*-
+# ${license-info}
+# ${author-info}
+# ${build-info}
+
+=pod
+=head1 fstab data entries
+# For testing ncm-filesystems functions
+
+=cut
+
+package data;
+
+use strict;
+use warnings;
+
+use Readonly;
+
+
+Readonly::Hash our %PROTECTED => (
+    'keep' => {
+      'fs_types' => {
+        'ceph' => 1,
+        'gpfs' => 1
+      },
+      'mounts' => {
+        '/' => 1,
+        '/boot' => 1,
+        '/home' => 1
+      }
+    },
+    'static' => {
+      'fs_types' => {},
+      'mounts' => {
+        '/' => 1,
+        '/boot' => 1,
+        '/usr' => 1
+      }
+    }
+);
+
+Readonly our $FSTAB_CONTENT => <<'EOF';
+
+# /etc/fstab
+# Created by anaconda on Wed Feb 26 09:20:11 2014
+#
+# Accessible filesystems, by reference, are maintained under '/dev/disk'
+# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
+#
+/dev/mapper/vg_sl65-lv_root /                       ext4    defaults        1 1
+UUID=f6452f58-99b1-41fe-9840-f688157171f8 /boot                   ext4    noauto        1 2
+/dev/mapper/vg_sl65-lv_swap swap                    swap    defaults        0 0
+tmpfs                   /dev/shm                tmpfs   defaults        0 0
+devpts                  /dev/pts                devpts  gid=5,mode=620  0 0
+sysfs                   /sys                    sysfs   defaults        0 0
+proc                    /proc                   proc    defaults        0 0
+/dev/gpfsfs             /gpfs/fs1               gpfs    defaults        0   0
+10.10.10.10:6789:/      /cephfs                 ceph    name=admin      0   0
+/dev/sda5               /home                   ext4    defaults        1   2
+/dev/sda6               /special                xfs     defaults        0   0   
+EOF
+
+
+Readonly::Hash our  %MOUNTS => (
+   '/' => 1,
+   '/boot' => 1,
+   '/cephfs' => 1,
+   '/gpfs/fs1' => 1,
+   '/home' => 1,
+);
+
+Readonly::Array our @PARTS_CREATE => (
+    'sda1',
+    'sda2',
+    'sda3',
+    'sda4',
+    'sda5',
+    'sda6'
+);
+
+Readonly::Array our @FS_CREATE => (
+    '/boot',
+    '/',
+    '/new',
+    '/food',
+    '/home',
+    '/special'
+);
+Readonly::Array our @FS_REMOVE => (
+    '/dev/shm',
+    '/dev/pts',
+    '/proc'
+);

--- a/ncm-filesystems/src/test/resources/configure.pan
+++ b/ncm-filesystems/src/test/resources/configure.pan
@@ -1,0 +1,13 @@
+object template configure;
+
+include 'devices';
+prefix '/software/components/fstab';
+
+'static/fs_types' = list('xfs');
+'static/mounts' = list('/', '/boot', '/proc');
+'keep/mounts' =  list('/', '/boot', '/home', '/sys');
+'keep/fs_types' = list('gpfs', 'ceph', 'swap');
+
+prefix '/software/components/filesystems';
+'manage_blockdevs' = false;
+

--- a/ncm-filesystems/src/test/resources/configure_create.pan
+++ b/ncm-filesystems/src/test/resources/configure_create.pan
@@ -1,0 +1,12 @@
+object template configure_create;
+
+include 'devices';
+
+prefix '/software/components/fstab';
+'static/fs_types' = list('xfs');
+'static/mounts' = list('/', '/boot', '/proc');
+'keep/mounts' =  list('/', '/boot', '/home', '/sys');
+'keep/fs_types' = list('gpfs', 'ceph', 'swap');
+
+prefix '/software/components/filesystems';
+'manage_blockdevs' = true;

--- a/ncm-filesystems/src/test/resources/devices.pan
+++ b/ncm-filesystems/src/test/resources/devices.pan
@@ -1,0 +1,96 @@
+unique template devices;
+
+# keep BlockDevices happy
+"/system/network/hostname" = 'x';
+"/system/network/domainname" = 'y';
+
+"/hardware/harddisks/sda" = nlist(
+    "capacity", 4000, 
+);
+
+"/system/blockdevices" = nlist (
+    "physical_devs", nlist (
+        "sda", nlist ("label", "gpt")
+        ),
+    "partitions", nlist (
+        "sda1", nlist (
+            "holding_dev", "sda",
+            "size", 100,
+            "type", "primary", # no defaults !
+            ),
+        "sda2", nlist (
+            "holding_dev", "sda",
+            "size", 100,
+            "type", "primary", # no defaults !
+            ),
+        "sda3", nlist (
+            "holding_dev", "sda",
+            "size", 100,
+            "type", "primary", # no defaults !
+            ),
+        "sda4", nlist (
+            "holding_dev", "sda",
+            "size", 100,
+            "type", "primary", # no defaults !
+            ),
+        "sda5", nlist (
+            "holding_dev", "sda",
+            "size", 100,
+            "type", "primary", # no defaults !
+            ),
+        "sda6", nlist (
+            "holding_dev", "sda",
+            "size", 100,
+            "type", "primary", # no defaults !
+            ),
+    ),
+);
+
+"/system/filesystems" = list (
+    nlist (
+        "mount", true,
+        "mountpoint", "/boot",
+        "preserve", true,
+        "format", false,
+        "mountopts", "auto",
+        "block_device", "partitions/sda1",
+        "type", "ext4",
+        "freq", 0,
+        "pass", 0
+        )
+);
+
+"/system/filesystems" = { 
+    # always make a copy
+
+    fs=value("/system/filesystems/0");
+    fs["block_device"] = "partitions/sda2";
+    fs["mountpoint"] = "/";
+    append(fs);
+
+    fs=value("/system/filesystems/0");
+    fs["block_device"] = "partitions/sda3";
+    fs["mountpoint"] = "/new";
+    append(fs);
+
+    fs=value("/system/filesystems/0");
+    fs["block_device"] = "partitions/sda4";
+    fs["mountpoint"] = "/food";
+    fs["label"] = "FRIETJES";
+    fs["type"] = "chokotoFS";
+    append(fs);
+
+    fs=value("/system/filesystems/0");
+    fs["block_device"] = "partitions/sda5";
+    fs["mountpoint"] = "/home";
+    fs["type"] = "ext4";
+    fs["label"] = "HOME";
+    append(fs);
+
+    fs=value("/system/filesystems/0");
+    fs["block_device"] = "partitions/sda6";
+    fs["mountpoint"] = "/special";
+    fs["label"] = "BLT";
+    fs["type"] = "xfs";
+    append(fs);
+};

--- a/ncm-filesystems/src/test/resources/devices.pan
+++ b/ncm-filesystems/src/test/resources/devices.pan
@@ -4,41 +4,41 @@ unique template devices;
 "/system/network/hostname" = 'x';
 "/system/network/domainname" = 'y';
 
-"/hardware/harddisks/sda" = nlist(
+"/hardware/harddisks/sda" = dict(
     "capacity", 4000, 
 );
 
-"/system/blockdevices" = nlist (
-    "physical_devs", nlist (
-        "sda", nlist ("label", "gpt")
+"/system/blockdevices" = dict (
+    "physical_devs", dict (
+        "sda", dict ("label", "gpt")
         ),
-    "partitions", nlist (
-        "sda1", nlist (
+    "partitions", dict (
+        "sda1", dict (
             "holding_dev", "sda",
             "size", 100,
             "type", "primary", # no defaults !
             ),
-        "sda2", nlist (
+        "sda2", dict (
             "holding_dev", "sda",
             "size", 100,
             "type", "primary", # no defaults !
             ),
-        "sda3", nlist (
+        "sda3", dict (
             "holding_dev", "sda",
             "size", 100,
             "type", "primary", # no defaults !
             ),
-        "sda4", nlist (
+        "sda4", dict (
             "holding_dev", "sda",
             "size", 100,
             "type", "primary", # no defaults !
             ),
-        "sda5", nlist (
+        "sda5", dict (
             "holding_dev", "sda",
             "size", 100,
             "type", "primary", # no defaults !
             ),
-        "sda6", nlist (
+        "sda6", dict (
             "holding_dev", "sda",
             "size", 100,
             "type", "primary", # no defaults !
@@ -47,7 +47,7 @@ unique template devices;
 );
 
 "/system/filesystems" = list (
-    nlist (
+    dict (
         "mount", true,
         "mountpoint", "/boot",
         "preserve", true,
@@ -63,31 +63,31 @@ unique template devices;
 "/system/filesystems" = { 
     # always make a copy
 
-    fs=value("/system/filesystems/0");
+    fs = value("/system/filesystems/0");
     fs["block_device"] = "partitions/sda2";
     fs["mountpoint"] = "/";
     append(fs);
 
-    fs=value("/system/filesystems/0");
+    fs = value("/system/filesystems/0");
     fs["block_device"] = "partitions/sda3";
     fs["mountpoint"] = "/new";
     append(fs);
 
-    fs=value("/system/filesystems/0");
+    fs = value("/system/filesystems/0");
     fs["block_device"] = "partitions/sda4";
     fs["mountpoint"] = "/food";
     fs["label"] = "FRIETJES";
     fs["type"] = "chokotoFS";
     append(fs);
 
-    fs=value("/system/filesystems/0");
+    fs = value("/system/filesystems/0");
     fs["block_device"] = "partitions/sda5";
     fs["mountpoint"] = "/home";
     fs["type"] = "ext4";
     fs["label"] = "HOME";
     append(fs);
 
-    fs=value("/system/filesystems/0");
+    fs = value("/system/filesystems/0");
     fs["block_device"] = "partitions/sda6";
     fs["mountpoint"] = "/special";
     fs["label"] = "BLT";

--- a/ncm-filesystems/src/test/resources/fstab_regextest
+++ b/ncm-filesystems/src/test/resources/fstab_regextest
@@ -1,0 +1,16 @@
+fstab regextest
+---
+---
+^/dev/mapper/vg_sl65-lv_root\s+/\s+ext4\s+defaults\s+1\s+1\s*[^/]*$
+^UUID=f6452f58-99b1-41fe-9840-f688157171f8\s+/boot\s+ext4\s+noauto\s+1\s+2\s*[^/]*$
+^/dev/mapper/vg_sl65-lv_swap\s+swap\s+swap\s+defaults\s+0\s+0\s*[^/]*$
+^sysfs\s+/sys\s+sysfs\s+defaults\s+0\s+0\s*[^/]*$
+^/dev/gpfsfs\s+/gpfs/fs1\s+gpfs\s+defaults\s+0\s+0\s*[^/]*$
+^10.10.10.10:6789:/\s+/cephfs\s+ceph\s+name=admin\s+0\s+0\s*[^/]*$
+^LABEL=HOME\s+/home\s+ext4\s+auto\s+0\s+0\s*[^/]*$
+^/dev/sda6\s+/special\s+xfs\s+defaults\s+0\s+0\s*[^/]*$
+^/dev/sda3\s+/new\s+ext4\s+auto\s+0\s+0\s*[^/]*$
+^LABEL=FRIETJES\s+/food\s+chokotoFS\s+auto\s+0\s+0\s*[^/]*$
+^proc\s+ ### COUNT 0
+^devpts\s+ ### COUNT 0
+^tmpfs\s+ ### COUNT 0

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
     <module>ncm-directoryservices</module>
     <module>ncm-etcservices</module>
     <module>ncm-nagios</module>
-    <module>ncm-filesystems</module>
     <module>ncm-hostsfile</module>
     <module>ncm-ssh</module>
     <module>ncm-download</module>
@@ -68,6 +67,7 @@
     <module>ncm-mysql</module>
     <module>ncm-ldconf</module>
     <module>ncm-fstab</module>
+    <module>ncm-filesystems</module>
     <module>ncm-syslogng</module>
     <module>ncm-syslog</module>
     <module>ncm-shorewall</module>


### PR DESCRIPTION
Use fstab methods for filesystems
Filesystems is written to also include ncm-fstab functionality (So if you want to use filesystems somewhere, you don't need fstab) .
 If you would set manage_blockdevs to false, it would do the same as ncm-fstab