### PR TITLE
ncm-fstab: pass tree instead of config

### DIFF
--- a/ncm-fstab/src/main/perl/fstab.pm
+++ b/ncm-fstab/src/main/perl/fstab.pm
@@ -51,9 +51,8 @@ sub update_entries
 # build the protected hashes from the template
 sub protected_hash 
 {
-    my ($self, $config) = @_;
+    my ($self, $tree) = @_;
 
-    my $tree = $config->getTree($self->prefix());
     my $mounts_depr = $tree->{protected_mounts}; 
     
     my $protected = {};
@@ -158,9 +157,10 @@ sub Configure
 {
     my ($self, $config) = @_;
 
+    my $tree = $config->getTree($self->prefix());
     my $fstab = CAF::FileEditor->new (NCM::Filesystem::FSTAB, log => $self,
 				      backup => '.old');
-    my $protected = $self->protected_hash($config);
+    my $protected = $self->protected_hash($tree);
     my %mounts;
     %mounts = $self->update_entries ($config, $fstab, $protected->{static});
     %mounts = $self->valid_mounts($protected->{keep}, $fstab, %mounts);

--- a/ncm-fstab/src/test/perl/protected.t
+++ b/ncm-fstab/src/test/perl/protected.t
@@ -38,8 +38,8 @@ use data;
 $CAF::Object::NoAction = 1;
 my $cfg = get_config_for_profile('fstab');
 my $cmp = NCM::Component::fstab->new('fstab');
-
-my $protected = $cmp->protected_hash($cfg);
+my $tree = $cfg->getTree($cmp->prefix());
+my $protected = $cmp->protected_hash($tree);
 cmp_deeply($protected, \%data::PROTECTED, 'protected hash ok');
 
 my $fstab = CAF::FileEditor->new ($FSTAB);
@@ -50,9 +50,9 @@ my %mounts = ();
 cmp_deeply(\%mounts, \%data::MOUNTS, 'valid mounts ok');
 
 $cfg = get_config_for_profile('fstab_depr');
-
+$tree = $cfg->getTree($cmp->prefix());
 %mounts = ();
-$protected = $cmp->protected_hash($cfg);
+$protected = $cmp->protected_hash($tree);
 %mounts = $cmp->valid_mounts($protected->{keep}, $fstab, %mounts);
 cmp_deeply(\%mounts, \%data::MOUNTS, 'valid mounts (deprecated) ok');
 


### PR DESCRIPTION
Some changes needed to subclass ncm-filesystems from ncm-fstab. So also needed for the tests to run for #985