### PR TITLE
ncm-metaconfig: opennebula Include CA option

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/opennebula/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/opennebula/pan/schema.pan
@@ -18,6 +18,8 @@ type aii_section = {
     "user" ? string
     "pattern" ? string
     "url" ? type_absoluteURI with match (SELF, "^http.+/RPC2$")
+    @{set CA certificate location for SSL connections}
+    "ca" ? string
 } = dict();
 
 @documentation{

--- a/ncm-metaconfig/src/main/metaconfig/opennebula/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/opennebula/tests/profiles/config.pan
@@ -9,3 +9,4 @@ prefix "/software/components/metaconfig/services/{/etc/aii/opennebula.conf}/cont
 "cluster.com/password" = "a_good_pass_here";
 "cluster.com/user" = "serveradmin2";
 "cluster.com/pattern" = 'node0\d+.cluster.com';
+"cluster.com/ca" = "/etc/pki/CA/certs/cabundle-test.pem";

--- a/ncm-metaconfig/src/main/metaconfig/opennebula/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/opennebula/tests/regexps/config/base
@@ -4,6 +4,7 @@ multiline
 /etc/aii/opennebula.conf
 ---
 ^\[.+\]$
+^ca\=.+$
 ^password\=.+$
 ^pattern\=.+$
 ^url\=.+$

--- a/ncm-metaconfig/src/main/metaconfig/opennebula/tests/regexps/config/rpc
+++ b/ncm-metaconfig/src/main/metaconfig/opennebula/tests/regexps/config/rpc
@@ -4,6 +4,7 @@ multiline
 /etc/aii/opennebula.conf
 ---
 ^\[cluster\.com\]$
+^ca=/etc/pki/CA/certs/cabundle-test\.pem
 ^password=a\_good\_pass\_here$
 ^pattern=node0\\d\+\.cluster\.com$
 ^url=https://my\.example\.com/RPC2$


### PR DESCRIPTION
Include a CA option to enable secure RPC connections.

Resolves: #1015
