### PR TITLE
ncm-spma: support Solaris pkg exact-install and whitelists

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/ips/config.pan
+++ b/ncm-spma/src/main/pan/components/spma/ips/config.pan
@@ -22,9 +22,14 @@ prefix '/software/components/${project.artifactId}';
     '/software/uninstall',
 );
 
+'whitepaths' = list(
+    '/software/whitelist',
+);
+
 'register_change' = list(
     '/software/catalogues',
     '/software/requests',
+    '/software/whitelist',
     '/software/uninstall',
 );
 

--- a/ncm-spma/src/main/pan/components/spma/schema.pan
+++ b/ncm-spma/src/main/pan/components/spma/schema.pan
@@ -31,6 +31,7 @@ type component_spma_common = {
     "trailprefix" ? boolean # if no escape function, use underscore prefix
     "unescape" ? boolean # use escape function
     "uninstpaths" ? string[] # where to find uninstall definitions
+    "whitepaths" ? string[] # where to find whitelist definitions
     "userpkgs" ? legacy_binary_affirmation_string # Allow user packages
     "userprio" ? legacy_binary_affirmation_string # Priority to user packages
     "usespmlist" ? legacy_binary_affirmation_string # Have SPMA controlling any packages

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -37,6 +37,7 @@ use constant PKG_AVOID => [qw(/usr/bin/pkg avoid)];
 use constant SPMA_RUN_NOACTION => [qw(/usr/bin/spma-run --noaction)];
 use constant SPMA_RUN_EXECUTE => [qw(/usr/bin/spma-run --execute)];
 use constant PKG_INSTALL_NV => [qw(/usr/bin/pkg -R <rootdir> install -nv)];
+use constant PKG_HELP => [qw(/usr/bin/pkg --help)];
 use constant SPMA_IMAGEDIR => "/var/tmp/.ncm-spma-image";
 
 use constant PKG_NO_CHANGES => 4;      # if pkg returns 4 or spma-run returns 1
@@ -44,28 +45,29 @@ use constant SPMA_RUN_NO_CHANGES => 1; # then there was nothing to do
 
 #
 # Returns a hash with packages in the given nlist.
+# Can be given an existing hash to amend.
 #
 sub gethash_ips
 {
-    my ($self, $pkgs) = @_;
+    my ($self, $pkgs, $hash) = @_;
 
-    my %hash;
+    $hash ||= {};
 
     while (my ($pkg, $st) = each(%$pkgs)) {
         my $done = 0;
         if (exists $st->{version}) {
-            $hash{unescape($pkg)} = unescape($st->{version});
+            $hash->{unescape($pkg)} = unescape($st->{version});
             $done = 1;
         }
         while (my ($ver) = each(%$st)) {
             next if $ver eq 'version';
-            $hash{unescape($pkg)} = unescape($ver);
+            $hash->{unescape($pkg)} = unescape($ver);
             $done = 1;
         }
-        $hash{unescape($pkg)} = "" if ! $done;
+        $hash->{unescape($pkg)} = "" if ! $done;
     }
 
-    return \%hash;
+    return $hash;
 }
 
 #
@@ -95,7 +97,7 @@ sub reject_idrs
 
     my @pkgs = @$installed_set;
     for my $line (grep /^idr[0-9]/, @pkgs) {
-        $reject->{(split / /, $line)[0]} = 1;
+        $reject->{(split / /, $line)[0]} = "";
     }
     return $reject;
 }
@@ -116,6 +118,32 @@ sub frozen_ips
 
     die "cannot get verbose list of packages" if $?;
     for (grep / if.$/, @output) {
+        my ($pkg, $ver) = split /@/, (split / /)[0];
+        $hash{$pkg} = $ver;
+    }
+    return \%hash;
+}
+
+#
+# Take array of package names / versions, i.e. output of pkg_keys(),
+# and return a hash containing just those packages that are currently
+# installed on the system at the given version number
+#
+sub get_exact_pkgs
+{
+    my ($self, $pkglist) = @_;
+
+    my %hash;
+    my $cmd = PKG_LIST_V;
+    push @$cmd, @$pkglist;
+    my $proc = CAF::Process->new(PKG_LIST_V, log => $self, keeps_state => 1);
+    my $out = $proc->output();
+
+    my @output;
+    @output = split /\n/, $out if defined($out);
+
+    for (grep / i..$/, @output) {
+        s,^(pkg://[^/]*/|pkg:/|/),,;
         my ($pkg, $ver) = split /@/, (split / /)[0];
         $hash{$pkg} = $ver;
     }
@@ -415,18 +443,32 @@ sub run_pkg_command
 
 #
 # Get pkg@ver keys from hash where ver is actually the value.
+# Can be given an existing array to amend.
 #
 sub pkg_keys
 {
-    my ($self, $hash) = @_;
+    my ($self, $hash, $keylist) = @_;
 
-    my @keys;
+    $keylist ||= [];
+
     for my $pkg (keys %$hash) {
         my $ver = "";
         $ver = "\@$hash->{$pkg}" if $hash->{$pkg} ne "";
-        push @keys, "$pkg$ver";
+        push @$keylist, "$pkg$ver";
     }
-    return \@keys;
+    return $keylist;
+}
+
+#
+# Returns >0 if pkg command on this system has exact-install capability
+# introduced in Solaris 11.2
+#
+sub pkg_has_exact_install
+{
+    my $stderr;
+    my $proc = CAF::Process->new(PKG_HELP, stderr => \$stderr);
+    $proc->execute();
+    return scalar(grep /exact-install/, split('\n', $stderr));
 }
 
 #
@@ -434,8 +476,9 @@ sub pkg_keys
 #
 sub update_ips
 {
-    my ($self, $pkgs, $uninst, $run_now, $allow_user_pkgs, $cmdfile, $flagfile,
-            $bename, $include_idrs, $freeze, $imagedir) = @_;
+    my ($self, $pkgs, $reject, $uninst, $whitelist,
+            $run_now, $allow_user_pkgs, $cmdfile, $flagfile,
+            $bename, $rejectidr, $freeze, $imagedir) = @_;
 
     #
     # Delete flagfile now, so the result cannot be misinterpreted
@@ -455,24 +498,67 @@ sub update_ips
         return 0;
     }
 
+    my $exact_install;
+    unless ($allow_user_pkgs or scalar(%$uninst)) {
+        #
+        # Determine whether this version of Solaris is new enough to support
+        # the pkg exact-install command, which speeds this process up
+        #
+        $exact_install = $self->pkg_has_exact_install();
+    } else {
+        #
+        # If we are allowing user packages, we will not use pkg exact-install
+        #
+        # If there are packages on the uninstall list, then we cannot
+        # use pkg exact-install even if it is available, because it will
+        # do the wrong thing and remove orphan dependencies as well
+        #
+        $exact_install = 0;
+    }
+
     #
     # Get list of packages to process
     #
     my $wanted = $self->gethash_ips($pkgs);
     my $wanted_keys = $self->pkg_keys($wanted);
-    my $wanted_freshkeys = $wanted_keys;
     $self->info(scalar(@$wanted_keys) . " package(s) requested");
     $self->log("requested packages: " . join(" ", @$wanted_keys))
         if @$wanted_keys;
 
     my $installed_set = $self->load_installed_set()
-        if $include_idrs or !$allow_user_pkgs;
+        if $rejectidr or !$allow_user_pkgs;
 
-    my $reject = $self->gethash_ips($uninst);
+    $reject = $self->gethash_ips($reject);
+    $self->gethash_ips($uninst, $reject);
     my $reject_keys;
-    unless ($include_idrs) {
+    if (!$rejectidr or $exact_install) {
+        #
+        # If rejectidr is false, or if we are using pkg exact-install,
+        # we do not add IDR packages to the reject list
+        #
         $reject_keys = $self->pkg_keys($reject);
+
+        unless ($rejectidr) {
+            #
+            # If rejectidr is false, add all installed IDRs to the whitelist
+            # so that they will appear in the list of packages to install
+            #
+            my %idrhash;
+            $self->reject_idrs(\%idrhash, $installed_set);
+
+            my %wanted_merge = (%$wanted, %idrhash);
+            $wanted = \%wanted_merge;
+
+            #
+            # Recompute keys
+            #
+            $wanted_keys = undef;
+        }
     } else {
+        #
+        # If rejectidr is true and we are not using pkg exact-install,
+        # add all IDR packages to the reject list
+        #
         $self->reject_idrs($reject, $installed_set);
         $reject_keys = $self->pkg_keys($reject);
     }
@@ -480,106 +566,121 @@ sub update_ips
     $self->log("rejected packages: " . join(" ", @$reject_keys))
         if @$reject_keys;
 
+    $whitelist = $self->gethash_ips($whitelist);
+    my $whitelist_keys = $self->pkg_keys($whitelist);
+    $self->info(scalar(@$whitelist_keys) . " package(s) whitelisted");
+    $self->log("whitelisted packages: " . join(" ", @$whitelist_keys))
+        if @$whitelist_keys;
+
     my $frozen;
     if ($freeze and %{$frozen = $self->frozen_ips()}) {
         #
-        # We are ignoring frozen packages - this means two things:
-        #
-        #   1. Frozen packages must not appear on uninstall list.  This
-        #      is achieved by adding frozen packages to the @$wanted_freshkeys
-        #      array which is passed to ips_to_remove(), where they are
-        #      interpreted as packages that have been requested.
-        #
-        #   2. Frozen packages must not appear on install list.  This is
-        #      achieved by removing frozen packages from the $%wanted hash.
+        # We are ignoring frozen packages, this is achieved by adding
+        # frozen packages at their exact current version number to
+        # the list of wanted packages
         #
         my $frozen_keys = $self->pkg_keys($frozen);
         $self->info(scalar(@$frozen_keys) . " package(s) frozen");
         $self->log("frozen packages: " . join(" ", @$frozen_keys))
             if @$frozen_keys;
 
-        my %pkg_map;
-        for my $fmri (keys %$frozen) {
-            IPS::Package::pkg_add_lookup($fmri, 1, \%pkg_map);
-        }
-
-        for my $pkg ((my @keys = @$wanted_keys)) {
-            $pkg =~ s/@.*$//;
-            delete $wanted->{$pkg} if IPS::Package::pkg_lookup_installed(
-                                                            $pkg, \%pkg_map);
-        }
+        my %wanted_merge = (%$wanted, %$frozen);
+        $wanted = \%wanted_merge;
 
         #
         # Recompute keys
         #
-        $wanted_keys = $self->pkg_keys($wanted);
-        $wanted_freshkeys = [@$wanted_keys];
-        push @$wanted_freshkeys, @$frozen_keys;
+        $wanted_keys = undef;
     }
 
-    my ($to_rm, $fresh_set);
-    unless ($allow_user_pkgs) {
-        $self->info("finding user packages");
+    my $whitepkgs;
+    if (@$whitelist_keys and %{$whitepkgs =
+                                $self->get_exact_pkgs($whitelist_keys)}) {
+        #
+        # Packages installed on the system that appear on the whitelist must
+        # be added to the wanted list at their exact current version number
+        #
+        my %wanted_merge = (%$wanted, %$whitepkgs);
+        $wanted = \%wanted_merge;
 
         #
-        # Get set of packages that would be installed in a fresh image
+        # Recompute keys
         #
-        $fresh_set = $self->get_fresh_pkgs($wanted_freshkeys, $imagedir);
-
-        #
-        # Convert into an array of user packages to remove
-        #
-        $to_rm = $self->ips_to_remove($fresh_set, $installed_set);
+        $wanted_keys = undef;
     }
 
     #
-    # If there is an avoid list, and there are packages on the avoid
-    # list that are not on the uninstall list, then we need to consider
-    # whether to explicitly install them or not
+    # Recompute keys if needed
     #
-    $proc = CAF::Process->new(PKG_AVOID, log => $self);
-    my $out = $proc->output();
+    $wanted_keys = $self->pkg_keys($wanted) unless defined($wanted_keys);
 
-    my @output;
-    @output = split /\n/, $out if defined($out);
+    my $to_rm;
+    unless ($exact_install) {
+        my $fresh_set;
+        unless ($allow_user_pkgs) {
+            $self->info("finding user packages");
 
-    if (@output) {
-        my (%pkg_map, %avoid);
-        for (@output) {
-            s/^\s+//;
-            my $pkg = (split / /)[0];
-            IPS::Package::pkg_add_lookup($pkg, 1, \%pkg_map);
-            $avoid{$pkg} = 1;
+            #
+            # Get set of packages that would be installed in a fresh image
+            #
+            $fresh_set = $self->get_fresh_pkgs($wanted_keys, $imagedir);
+
+            #
+            # Convert into an array of user packages to remove
+            #
+            $to_rm = $self->ips_to_remove($fresh_set, $installed_set);
         }
-        for (keys %$reject) {
-            s,^(pkg://[^/]*/|pkg:/|/),,;
-            for my $pkg (IPS::Package::pkg_lookup_installed($_, \%pkg_map)) {
-                delete $avoid{$pkg};
+
+        #
+        # If there is an avoid list, and there are packages on the avoid
+        # list that are not on the uninstall or reject lists, then we need to
+        # consider whether to explicitly install them or not
+        #
+        $proc = CAF::Process->new(PKG_AVOID, log => $self);
+        my $out = $proc->output();
+
+        my @output;
+        @output = split /\n/, $out if defined($out);
+
+        if (@output) {
+            my (%pkg_map, %avoid);
+            for (@output) {
+                s/^\s+//;
+                my $pkg = (split / /)[0];
+                IPS::Package::pkg_add_lookup($pkg, 1, \%pkg_map);
+                $avoid{$pkg} = 1;
             }
-        }
-        if (%avoid) {
-            $self->info("processing avoid list");
-            $self->verbose("avoided package(s) to verify: " .
-                       join(" ", keys %avoid));
-            unless (defined $fresh_set) {
-                #
-                # Get set of packages that would be installed in a fresh image
-                # (but only if we haven't already got this information)
-                #
-                $fresh_set = $self->get_fresh_pkgs($wanted_freshkeys,
-                                                   $imagedir);
+            for (keys %$reject) {
+                s,^(pkg://[^/]*/|pkg:/|/),,;
+                for my $pkg (IPS::Package::pkg_lookup_installed($_,
+                                                                \%pkg_map)) {
+                    delete $avoid{$pkg};
+                }
             }
-            my @rm_avoid;
-            for my $pkg (keys %avoid) {
-                push @rm_avoid, $pkg if $fresh_set->has($pkg) and
-                                        !$wanted->{$pkg};
-            }
-            if (@rm_avoid) {
-                $self->info(scalar(@rm_avoid) .
-                            " package(s) no longer avoiding");
-                $self->log("package(s) to remove from avoid list " .
-                           "by explicit install: " . join(" ", @rm_avoid));
-                push @$wanted_keys, @rm_avoid;
+            if (%avoid) {
+                $self->info("processing avoid list");
+                $self->verbose("avoided package(s) to verify: " .
+                           join(" ", keys %avoid));
+                unless (defined $fresh_set) {
+                    #
+                    # Get set of packages that would be installed in a
+                    # fresh image (but only if we haven't already got
+                    # this information)
+                    #
+                    $fresh_set = $self->get_fresh_pkgs($wanted_keys, $imagedir);
+                }
+                my @rm_avoid;
+                for my $pkg (keys %avoid) {
+                    push @rm_avoid, $pkg if $fresh_set->has($pkg) and
+                                            !$wanted->{$pkg};
+                }
+                if (@rm_avoid) {
+                    $self->info(scalar(@rm_avoid) .
+                                " package(s) no longer avoiding");
+                    $self->log("package(s) to remove from avoid list " .
+                               "by explicit install: " . join(" ", @rm_avoid));
+                    push @$wanted_keys, @rm_avoid;
+                }
             }
         }
     }
@@ -589,6 +690,13 @@ sub update_ips
     #
     my $fh = CAF::FileWriter->new($cmdfile, log => $self,
                                   owner => $<, mode => 0644);
+
+    my $install_cmd;
+    if ($exact_install) {
+        $install_cmd = "exact-install";
+    } else {
+        $install_cmd = "install";
+    }
 
     my $be_opts;
     if (defined $bename) {
@@ -601,7 +709,7 @@ sub update_ips
     $be_opts .= " --reject " . join(" --reject ", @$to_rm)
         if $to_rm and @$to_rm;
 
-    my $line = "$be_opts " . join(' ', @$wanted_keys);
+    my $line = "$install_cmd $be_opts " . join(' ', @$wanted_keys);
     print $fh "$line\n";
     $fh->close();
 
@@ -612,8 +720,9 @@ sub update_ips
             # would be changed, so that the flagfile can be updated
             #
             $self->info("performing dry-run package install test");
-            if ($self->run_pkg_command(SPMA_RUN_NOACTION, 1,
-                                       SPMA_RUN_NO_CHANGES) == 0) {
+            my $cmd = SPMA_RUN_NOACTION;
+            push @$cmd, "--verbose" if $self->{LOGGER}{VERBOSE};
+            if ($self->run_pkg_command($cmd, 1, SPMA_RUN_NO_CHANGES) == 0) {
                 $fh = CAF::FileWriter->new($flagfile, log => $self,
                                            owner => $<, mode => 0644);
                 $fh->close();
@@ -624,8 +733,9 @@ sub update_ips
             }
         } else {
             $self->info("performing live package updates in new BE");
-            if ($self->run_pkg_command(SPMA_RUN_EXECUTE, 1,
-                                       SPMA_RUN_NO_CHANGES) == 0) {
+            my $cmd = SPMA_RUN_EXECUTE;
+            push @$cmd, "--verbose" if $self->{LOGGER}{VERBOSE};
+            if ($self->run_pkg_command($cmd, 1, SPMA_RUN_NO_CHANGES) == 0) {
                 $self->info("package changes made in new BE");
             } else {
                 $self->info("no package updates were required, " .
@@ -682,8 +792,11 @@ sub Configure
     # Merge software package requests from potentially multiple paths
     #
     my $merged_pkgs = $self->merge_pkg_paths($config, $t->{pkgpaths});
+    my $merged_reject = $self->merge_pkg_paths($config, $t->{rejectpaths});
     my $merged_uninst = $self->merge_pkg_paths($config, $t->{uninstpaths});
-    $self->update_ips($merged_pkgs, $merged_uninst, $t->{run},
+    my $merged_whitelist = $self->merge_pkg_paths($config, $t->{whitepaths});
+    $self->update_ips($merged_pkgs, $merged_reject, $merged_uninst,
+                      $merged_whitelist, $t->{run},
                       $t->{userpkgs}, $cmdfile, $flagfile,
                       $t->{ips}->{bename}, $t->{ips}->{rejectidr},
                       $t->{ips}->{freeze}, $imagedir) or return 0;

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -126,8 +126,8 @@ sub frozen_ips
 
 #
 # Take array of package names / versions, i.e. output of pkg_keys(),
-# and return a hash containing just those packages that are currently
-# installed on the system at the given version number
+# by reference and return a hash containing just those packages that are
+# currently installed on the system at the given version number
 #
 sub get_exact_pkgs
 {
@@ -443,7 +443,7 @@ sub run_pkg_command
 
 #
 # Get pkg@ver keys from hash where ver is actually the value.
-# Can be given an existing array to amend.
+# Can be given an existing array, by reference, to amend.
 #
 sub pkg_keys
 {

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -76,7 +76,7 @@ sub load_installed_set
     my ($self) = @_;
     my $set = Set::Scalar->new();
 
-    my $proc = CAF::Process->new(PKG_LIST, log => $self);
+    my $proc = CAF::Process->new(PKG_LIST, log => $self, keeps_state => 1);
     my @output = split /\n/, $proc->output();
     die "cannot get list of packages" if $?;
     for my $line (@output) {
@@ -108,7 +108,7 @@ sub frozen_ips
     my ($self) = @_;
 
     my %hash;
-    my $proc = CAF::Process->new(PKG_LIST_V, log => $self);
+    my $proc = CAF::Process->new(PKG_LIST_V, log => $self, keeps_state => 1);
     my $out = $proc->output();
 
     my @output;
@@ -151,7 +151,7 @@ sub image_create
     # N.B. this is incomplete as it only copies the publisher URI
     # and does not currently take account of other publisher properties
     #
-    my $proc = CAF::Process->new(PKG_PUBLISHER, log => $self);
+    my $proc = CAF::Process->new(PKG_PUBLISHER, log => $self, keeps_state => 1);
     my $out = $proc->output();
     die "cannot get publishers" if $?;
 
@@ -203,7 +203,7 @@ sub image_create
         # that can be used for package operations
         #
         my $cmd = PKG_IMAGE_CREATE;
-        my $proc = CAF::Process->new($cmd, log => $self);
+        my $proc = CAF::Process->new($cmd, log => $self, keeps_state => 1);
         $proc->pushargs($newdir);
         $proc->run();
         die "failed to create image" if $?;
@@ -213,7 +213,7 @@ sub image_create
         # file earlier
         #
         for $cmd (@pubcmds) {
-            $proc = CAF::Process->new($cmd, log => $self);
+            $proc = CAF::Process->new($cmd, log => $self, keeps_state => 1);
             $proc->run();
             die "failed to set publisher in image directory: '" .
                 join(" ", @$cmd) . "' failed" if $?;
@@ -364,7 +364,7 @@ sub run_pkg_command
     #   (4 for /usr/bin/pkg, 1 for /usr/bin/spma-run)
     #
     my ($self, $cmd, $log, $exit_void) = @_;
-    my $proc = CAF::Process->new($cmd, log => $self);
+    my $proc = CAF::Process->new($cmd, log => $self, keeps_state => 1);
     my $output = $proc->output();
     $output = "" unless defined($output);
 

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -467,7 +467,8 @@ sub pkg_keys
 sub pkg_has_exact_install
 {
     my $stderr;
-    my $proc = CAF::Process->new(PKG_HELP, stderr => \$stderr);
+    my $proc = CAF::Process->new(PKG_HELP, stderr => \$stderr,
+                                 keeps_state => 1);
     $proc->execute();
     return scalar(grep /exact-install/, split('\n', $stderr));
 }

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -393,7 +393,11 @@ sub run_pkg_command
     if ($do_err) {
         $self->error($output);
         die "$$cmd[0] $sdesc";
-    } elsif ($log) {
+    }
+
+    $self->verbose($output);
+
+    if ($log) {
         $self->log($output);
     }
     $self->log("$$cmd[0] $sdesc") if ! $do_err;

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -379,6 +379,7 @@ sub merge_pkg_paths
 
 #
 # Runs pkg or spma-run command and interprets exit status.
+# Note that this is only suitable for commands that do not change state.
 #
 sub run_pkg_command
 {

--- a/ncm-spma/src/main/perl/spma/ips.pm
+++ b/ncm-spma/src/main/perl/spma/ips.pm
@@ -167,7 +167,7 @@ sub image_create
         my ($publisher, $sticky, $syspub, $enabled, $type,
             $status, $uri, $proxy) = split;
 
-        next unless $enabled eq 'true' and defined($uri);
+        next unless $enabled eq 'true' and $type eq 'origin' and defined($uri);
 
         my $cmd = PKG_SET_PUBLISHER;
         my @cmd = @$cmd;

--- a/ncm-spma/src/main/perl/spma/ips.pod
+++ b/ncm-spma/src/main/perl/spma/ips.pod
@@ -60,24 +60,31 @@ are defined by a catalogue (e.g. constrained by an incorporate dependency).
 =item * C<< /software/uninstall >> ? nlist ()
 
 A list of packages to uninstall. Packages in this list will not be installed,
-and will be passed to the C<< pkg install >> command via the C<< --reject >> option.
-The format is the same as with C<< /software/requests >>.
+and if found on the system will be removed. The format is the same as with
+C<< /software/requests >>.
+
+=item * C<< /software/whitelist >> ? nlist ()
+
+A list of packages to whitelist. Packages in this list are permitted on the
+system even if they have not been explicitly requested and even if
+C<< userpkgs >> is set to C<< no >>. The format is the same as with
+C<< /software/requests >>.
 
 =item * C<< /software/components/spma/packager >> ? string
 
-Must contain 'B<ips>' to use this module.
+Must contain C<< ips >> to use this module.
 
 =item * C<< /software/components/spma/run >> ? string
 
-Set to B<yes> to allow this module to launch C<< spma-run --execute >> to make
-immediate changes to the new boot environment. If set to B<no> or omitted,
+Set to C<< yes >> to allow this module to launch C<< spma-run --execute >> to make
+immediate changes to the new boot environment. If set to C<< no >> or omitted,
 this module prepares and validates the changes only, but does not perform
 any updates, it will be the responsibility of an external process to launch
 C<< spma-run --execute >> in this case.
 
 =item * C<< /software/components/spma/userpkgs >> ? string
 
-Set to B<yes> to allow user-installed packages. If set to B<no> or omitted,
+Set to C<< yes >> to allow user-installed packages. If set to C<< no >> or omitted,
 then SPMA will find all leaf packages that have not been requested and
 uninstall them via C<< --reject >> arguments to C<< pkg install >>.
 
@@ -95,6 +102,13 @@ Should be set to:
 
   list("/software/uninstall");
 
+=item * C<< /software/components/spma/whitepaths >> : string []
+
+Contains a list of resource paths where packages to whitelist are located.
+Should be set to:
+
+  list("/software/whitelist");
+
 =item * C<< /software/components/spma/cmdfile >> : string
 
 Where to save commands for the C<< spma-run >> script. Default location
@@ -102,7 +116,7 @@ is C<< /var/tmp/spma-commands >>.
 
 =item * C<< /software/components/spma/flagfile >> ? string
 
-File to touch if C<< /software/components/spma/run >> is set to B<no> and this
+File to touch if C<< /software/components/spma/run >> is set to C<< no >> and this
 module has determined that there is work to do, i.e. packages to install or
 to uninstall. If the file exists after this module has completed, then
 C<< spma-run --execute >> can be run to create a new BE and make package changes
@@ -123,14 +137,14 @@ instead, leaving Solaris to decide on the name of the new BE.
 Add a C<< --reject >> option to the C<< pkg install >> command for every Solaris IDR
 installed that has not been explicitly requested.
 
-Default is B<true>.
+Default is C<< true >>.
 
 =item * C<< /software/components/spma/ips/freeze >> : boolean
 
 Ignore frozen packages. This will prevent SPMA from updating or uninstalling
 frozen packages.
 
-Default is B<true>.
+Default is C<< true >>.
 
 =back
 
@@ -156,6 +170,7 @@ Solaris:
   "packager" = "ips";
   "pkgpaths" = list("/software/catalogues", "/software/requests");
   "uninstpaths" = list("/software/uninstall");
+  "whitepaths" = list("/software/whitelist");
   "register_change" = list("/software/catalogues",
                            "/software/requests",
                            "/software/uninstall");


### PR DESCRIPTION
Where it is possible to use the `pkg exact-install` command to create a new Solaris boot environment with an exact list of packages, then use it as it is faster.  Where it is not possible to do this, revert to the previous logic where the package list is determined by comparing with a temporary package image directory.

This patch also adds support for whitelists which is a list of packages that are permitted on the system even if they have not been explicitly requested and even if `userpkgs` is set to `no`.
