### PR TITLE
ncm-directoryservices ncm-fmonagent ncm-mcx: Deprecate with warnings

### DIFF
--- a/ncm-directoryservices/src/main/pan/components/directoryservices/schema.pan
+++ b/ncm-directoryservices/src/main/pan/components/directoryservices/schema.pan
@@ -24,5 +24,7 @@ type component_directoryservices = {
         "ldapv3" ? directoryservices_ldap_entry{}
 };
 
-bind "/software/components/directoryservices" = component_directoryservices;
-
+bind "/software/components/directoryservices" = component_directoryservices with {
+    deprecated(1, 'The directoryservices component is deprecated and will be removed in a future release.');
+    true;
+};

--- a/ncm-fmonagent/src/main/pan/components/fmonagent/schema.pan
+++ b/ncm-fmonagent/src/main/pan/components/fmonagent/schema.pan
@@ -15,4 +15,7 @@ type component_fmonagent = {
     "no_contact_timeout" : long = 120
 };
 
-bind "/software/components/fmonagent" = component_fmonagent;
+bind "/software/components/fmonagent" = component_fmonagent with {
+    deprecated(1, 'The fmonagent component is deprecated and will be removed in a future release.');
+    true;
+};

--- a/ncm-mcx/src/main/pan/components/mcx/schema.pan
+++ b/ncm-mcx/src/main/pan/components/mcx/schema.pan
@@ -41,5 +41,7 @@ type component_mcx = {
         "computer" ? mcx_computer
 };
 
-bind "/software/components/mcx" = component_mcx;
-
+bind "/software/components/mcx" = component_mcx with {
+    deprecated(1, 'The mcx component is deprecated and will be removed in a future release.');
+    true;
+};


### PR DESCRIPTION
Throw deprecation if the following components are initialised:

* ncm-directoryservices
* ncm-fmonagent
* ncm-mcx

This is the first step towards #1027.