### PR TITLE
ncm-opennebula: Add aii component rpm

### DIFF
--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/rpms.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/rpms.pan
@@ -1,0 +1,10 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+# Template adding ncm-opennebula rpm to the configuration
+
+unique template quattor/aii/opennebula/rpms;
+
+"/software/packages" = pkg_repl("ncm-opennebula", "${no-snapshot-version}-${rpm.release}", "noarch");


### PR DESCRIPTION
This PR includes the missing rpm template for ONE AII
