### PR TITLE
ncm-metaconfig: don't allow specific turning on of SEED and CAMELLIA

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_profiles.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_profiles.pan
@@ -39,8 +39,11 @@ prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_profile
 'ip/0' = DB_IP[HOSTNAME];
 
 'nss/engine' = true;
-# SSL 3 ciphers. SSL 2 is disabled by default.
-'nss/ciphersuite' = list('+rsa_rc4_128_md5', '+rsa_rc4_128_sha', '+rsa_3des_sha', '-rsa_des_sha', '-rsa_rc4_40_md5', '-rsa_rc2_40_md5', '-rsa_null_md5', '-rsa_null_sha', '+fips_3des_sha','-fips_des_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-rsa_des_56_sha', '-rsa_rc4_56_sha', '+rsa_aes_128_sha', '+rsa_aes_256_sha');
+# SSL 3 ciphers minues rc4 and 3des. SSL 2 is disabled by default.
+'nss/ciphersuite' = list('-rsa_rc4_128_md5', '-rsa_rc4_128_sha', '-rsa_3des_sha', '-rsa_des_sha', '-rsa_rc4_40_md5',
+    '-rsa_rc2_40_md5', '-rsa_null_md5', '-rsa_null_sha', '-fips_3des_sha','-fips_des_sha', '-fortezza',
+    '-fortezza_rc4_128_sha', '-fortezza_null', '-rsa_des_56_sha', '-rsa_rc4_56_sha', '+rsa_aes_128_sha',
+    '+rsa_aes_256_sha');
 'nss/protocol' = list('TLSv1.0', 'TLSv1.1', 'TLSv1.2');
 'nss/nickname' = 'Server-Cert';
 'nss/certificatedatabase' = '/etc/httpd/alias';

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_sunstone.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/krb5_sunstone.pan
@@ -31,8 +31,8 @@ prefix "/software/components/metaconfig/services/{/etc/httpd/conf.d/krb5_sunston
 'ip/0' = DB_IP[HOSTNAME];
 
 'nss/engine' = true;
-# SSL 3 ciphers. SSL 2 is disabled by default.
-'nss/ciphersuite' = list('+rsa_rc4_128_md5', '+rsa_rc4_128_sha', '+rsa_3des_sha', '-rsa_des_sha', '-rsa_rc4_40_md5', '-rsa_rc2_40_md5', '-rsa_null_md5', '-rsa_null_sha', '+fips_3des_sha','-fips_des_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-rsa_des_56_sha', '-rsa_rc4_56_sha', '+rsa_aes_128_sha', '+rsa_aes_256_sha');
+# SSL 3 ciphers minus rc4 and 3des. SSL 2 is disabled by default.
+'nss/ciphersuite' = list('-rsa_rc4_128_md5', '-rsa_rc4_128_sha', '-rsa_3des_sha', '-rsa_des_sha', '-rsa_rc4_40_md5', '-rsa_rc2_40_md5', '-rsa_null_md5', '-rsa_null_sha', '-fips_3des_sha','-fips_des_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-rsa_des_56_sha', '-rsa_rc4_56_sha', '+rsa_aes_128_sha', '+rsa_aes_256_sha');
 'nss/protocol' = list('TLSv1.0', 'TLSv1.1', 'TLSv1.2');
 'nss/nickname' = 'Server-Cert';
 'nss/certificatedatabase' = '/etc/httpd/alias';

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/struct/nss_conf_el6.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/profiles/struct/nss_conf_el6.pan
@@ -42,9 +42,9 @@ structure template struct/nss_conf_el6;
 
 "vhosts/base/nss/nickname" ?= "server-cert";
 "vhosts/base/nss/engine" = true;
-# SSLv3,TLSv1.0,TLSv1.1
+# SSLv3,TLSv1.0,TLSv1.1 minus 3des and rc4
 "vhosts/base/nss/protocol" =  list("TLSv1.0");
-"vhosts/base/nss/ciphersuite" = list('+rsa_3des_sha', '-rsa_des_56_sha', '+rsa_des_sha', '-rsa_null_md5', '-rsa_null_sha', '-rsa_rc2_40_md5', '+rsa_rc4_128_md5', '-rsa_rc4_128_sha', '-rsa_rc4_40_md5', '-rsa_rc4_56_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-fips_des_sha', '+fips_3des_sha', '-rsa_aes_128_sha', '-rsa_aes_256_sha');
+"vhosts/base/nss/ciphersuite" = list('-rsa_3des_sha', '-rsa_des_56_sha', '-rsa_des_sha', '-rsa_null_md5', '-rsa_null_sha', '-rsa_rc2_40_md5', '-rsa_rc4_128_md5', '-rsa_rc4_128_sha', '-rsa_rc4_40_md5', '-rsa_rc4_56_sha', '-fortezza', '-fortezza_rc4_128_sha', '-fortezza_null', '-fips_des_sha', '-fips_3des_sha', '-rsa_aes_128_sha', '-rsa_aes_256_sha');
 "vhosts/base/nss/certificatedatabase" = "/etc/httpd/alias";
 
 

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_profiles/base
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_profiles/base
@@ -9,7 +9,7 @@ Base test for krb5_profiles.conf config
 ^\s{4}documentroot /var/www/https$
 ^\s{4}hostnamelookups on$
 ^\s{4}nsscertificatedatabase /etc/httpd/alias$
-^\s{4}nssciphersuite \+rsa_rc4_128_md5,\+rsa_rc4_128_sha,\+rsa_3des_sha,-rsa_des_sha,-rsa_rc4_40_md5,-rsa_rc2_40_md5,-rsa_null_md5,-rsa_null_sha,\+fips_3des_sha,-fips_des_sha,-fortezza,-fortezza_rc4_128_sha,-fortezza_null,-rsa_des_56_sha,-rsa_rc4_56_sha,\+rsa_aes_128_sha,\+rsa_aes_256_sha\s+
+^\s{4}nssciphersuite \-rsa_rc4_128_md5,\-rsa_rc4_128_sha,\-rsa_3des_sha,-rsa_des_sha,-rsa_rc4_40_md5,-rsa_rc2_40_md5,-rsa_null_md5,-rsa_null_sha,\-fips_3des_sha,-fips_des_sha,-fortezza,-fortezza_rc4_128_sha,-fortezza_null,-rsa_des_56_sha,-rsa_rc4_56_sha,\+rsa_aes_128_sha,\+rsa_aes_256_sha\s+
 ^\s{4}nssengine on$
 ^\s{4}nssnickname "Server-Cert"$
 ^\s{4}nssprotocol TLSv1.0,TLSv1.1,TLSv1.2$

--- a/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_sunstone/base
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/2.4/tests/regexps/krb5_sunstone/base
@@ -7,7 +7,7 @@ Base test for krb5_sunstone.conf config
 ^\s{4}documentroot /usr/lib/one/sunstone/public$
 ^\s{4}hostnamelookups on$
 ^\s{4}nsscertificatedatabase /etc/httpd/alias$
-^\s{4}nssciphersuite \+rsa_rc4_128_md5,\+rsa_rc4_128_sha,\+rsa_3des_sha,-rsa_des_sha,-rsa_rc4_40_md5,-rsa_rc2_40_md5,-rsa_null_md5,-rsa_null_sha,\+fips_3des_sha,-fips_des_sha,-fortezza,-fortezza_rc4_128_sha,-fortezza_null,-rsa_des_56_sha,-rsa_rc4_56_sha,\+rsa_aes_128_sha,\+rsa_aes_256_sha\s+
+^\s{4}nssciphersuite \-rsa_rc4_128_md5,\-rsa_rc4_128_sha,\-rsa_3des_sha,-rsa_des_sha,-rsa_rc4_40_md5,-rsa_rc2_40_md5,-rsa_null_md5,-rsa_null_sha,\-fips_3des_sha,-fips_des_sha,-fortezza,-fortezza_rc4_128_sha,-fortezza_null,-rsa_des_56_sha,-rsa_rc4_56_sha,\+rsa_aes_128_sha,\+rsa_aes_256_sha\s+
 ^\s{4}nssengine on$
 ^\s{4}nssnickname "Server-Cert"$
 ^\s{4}nssprotocol TLSv1.0,TLSv1.1,TLSv1.2$


### PR DESCRIPTION
* SEED and CAMELLIA are also insecure ciphersuites, you shouldn't be allowed to explicitly turn them on.
* This may break for people who have these turned on, they probably shouldn't.

Replaces #983.