### PR TITLE
ncm-opennebula: Documentation fixes

### DIFF
--- a/ncm-opennebula/src/main/perl/OpenNebula/Ceph.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Ceph.pm
@@ -8,7 +8,7 @@ Readonly our $CEPHSECRETFILE => "/var/lib/one/templates/secret/secret_ceph.xml";
 =head1 NAME
 
 C<NCM::Component::OpenNebula::Ceph> adds C<Ceph> backend support to
-L<NCM::Component::OpenNebula::Host>.
+C<NCM::Component::OpenNebula::Host>.
 
 =head2 Public methods
 

--- a/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
@@ -3,7 +3,7 @@
 =head1 NAME
 
 C<NCM::Component::OpenNebula::Host> adds C<KVM> hosts support to
-L<NCM::Component::OpenNebula>.
+C<NCM::Component::OpenNebula>.
 
 =head2 Public methods
 

--- a/ncm-opennebula/src/main/perl/OpenNebula/Image.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Image.pm
@@ -3,7 +3,7 @@
 =head1 NAME
 
 C<NCM::Component::OpenNebula::Image> adds C<OpenNebula> C<VM> images 
-support to L<NCM::Component::OpenNebula>.
+support to C<NCM::Component::OpenNebula>.
 
 =head2 Public methods
 

--- a/ncm-opennebula/src/main/perl/OpenNebula/Network.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Network.pm
@@ -3,7 +3,7 @@
 =head1 NAME
 
 C<NCM::Component::OpenNebula::Network> adds C<OpenNebula> C<VirtualNetwork> 
-configuration support to L<NCM::Component::opennebula>.
+configuration support to C<NCM::Component::opennebula>.
 
 =head2 Public methods
 

--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -24,7 +24,7 @@ Readonly::Array our @SERVERADMIN_AUTH_FILE => qw(sunstone_auth oneflow_auth
 =head1 NAME
 
 C<NCM::Component::OpenNebula::Server> adds C<OpenNebula> service configuration 
-support to L<NCM::Component::OpenNebula>.
+support to C<NCM::Component::OpenNebula>.
 
 =head2 Public methods
 

--- a/ncm-opennebula/src/main/perl/OpenNebula/VM.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/VM.pm
@@ -3,7 +3,7 @@
 =head1 NAME
 
 C<NCM::Component::OpenNebula::VM> adds C<OpenNebula> C<VMs> 
-manage support to L<NCM::Component::OpenNebula>.
+manage support to C<NCM::Component::OpenNebula>.
 
 =head2 Public methods
 


### PR DESCRIPTION
While building a new version of the documentation I found a small issue which will result in dead links. This fixes that.
