### PR TITLE
ncm-freeipa: mock_rpc: handle JSON boolean string conversion with mixed JSON::PP and JSON::XS environment

### DIFF
--- a/ncm-freeipa/src/test/perl/mock_rpc.pm
+++ b/ncm-freeipa/src/test/perl/mock_rpc.pm
@@ -191,7 +191,21 @@ The space after the method name is significant, it is used to determine the used
 
 =cut
 
-sub _format { my $value = shift; return ref($value) eq 'ARRAY' ? join(',', @$value) : $value; }
+# Force booleans to 1/0; prevent mixed string prettification between
+# JSON::PP (0/1) and JSON::XS (true/false)
+sub _format
+{
+    my $value = shift;
+    my $txt;
+    if(ref($value) eq 'ARRAY') {
+        $txt = join(',', @$value);
+    } elsif(JSON::XS::is_bool($value)) {
+        $txt = $value ? 1 : 0;
+    } else {
+        $txt = $value;
+    }
+    return $txt;
+}
 
 $rc->mock('POST', sub {
     my ($self, $url, $data) = @_;


### PR DESCRIPTION
Unittests fail on new jenkins environment because there is a mixed JSON::XS and JSON::PP environment (due to loading of `Devel::Cover`).
