### PR TITLE
ncm-network: device name regex: allow function and device in PCI name

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -265,7 +265,7 @@ sub Configure
     opendir(DIR, $dir_pref);
     # here's the reason why it only verifies eth, bond, bridge, usb and vlan
     # devices. add regexp at will
-    my $dev_regexp='-((eth|seth|em|bond|br|ovirtmgmt|vlan|usb|ib|p\d+p|en(o|(p\d+)?s))\d+|enx[[:xdigit:]]{12})(\.\d+)?';
+    my $dev_regexp='-((eth|seth|em|bond|br|ovirtmgmt|vlan|usb|ib|p\d+p|en(o|(p\d+)?s(?:\d+f)?(?:\d+d)?))\d+|enx[[:xdigit:]]{12})(\.\d+)?';
     # $1 is the device name
     foreach my $file (grep(/$dev_regexp/, readdir(DIR))) {
         my $msg;

--- a/ncm-network/src/test/perl/bridge.t
+++ b/ncm-network/src/test/perl/bridge.t
@@ -6,6 +6,21 @@ use Test::Quattor qw(bridge);
 use helper;
 use NCM::Component::network;
 
+use Readonly;
+
+Readonly my $BR0 => <<EOF;
+ONBOOT=yes
+NM_CONTROLLED='no'
+DEVICE=br0
+TYPE=Ethernet
+BOOTPROTO=static
+IPADDR=4.3.2.1
+NETMASK=255.255.255.0
+BROADCAST=4.3.2.255
+STP=on
+DELAY=5
+BRIDGING_OPTS='hairpin_mode=5'
+EOF
 
 =pod
 
@@ -28,5 +43,7 @@ like($fh, qr/DELAY=\d+/m, "set bridge delay");
 like($fh, qr/BRIDGING_OPTS='.*hairpin_mode=5.*'/m, "set bridge_opts");
 
 unlike($fh, qr/IPV6/, "No IPv6 config details");
+
+is("$fh", $BR0, "exact bridge config");
 
 done_testing();

--- a/ncm-network/src/test/perl/ipv6.t
+++ b/ncm-network/src/test/perl/ipv6.t
@@ -6,6 +6,32 @@ use Test::Quattor qw(ipv6);
 use helper;
 use NCM::Component::network;
 
+use Readonly;
+
+Readonly my $NETWORK => <<EOF;
+NETWORKING=yes
+HOSTNAME=somehost.test.domain
+GATEWAY=4.3.2.254
+IPV6_DEFAULTGW=2001:678:123:e012::2
+IPV6_DEFAULTDEV=eth0
+NETWORKING_IPV6=yes
+EOF
+
+Readonly my $ETH0 => <<EOF;
+ONBOOT=yes
+NM_CONTROLLED='no'
+DEVICE=eth0
+TYPE=Ethernet
+BOOTPROTO=static
+IPADDR=4.3.2.1
+NETMASK=255.255.255.0
+BROADCAST=4.3.2.255
+IPV6ADDR=2001:678:123:e012::45/64
+IPV6ADDR_SECONDARIES='2001:678:123:e012::46/64 2001:678:123:e012::47/64'
+IPV6_AUTOCONF=no
+IPV6INIT=yes
+EOF
+
 =pod
 
 =head1 DESCRIPTION
@@ -32,6 +58,8 @@ like($fh, qr/^GATEWAY=/m, "Set default gateway");
 like($fh, qr/^NETWORKING_IPV6=yes$/m, "Enable IPv6 networking");
 like($fh, qr/^IPV6_DEFAULTDEV=eth0$/m, "Set IPv6 defaultdev via ipv6/gatewaydev");
 
+is("$fh", $NETWORK, "exact network config");
+
 $fh = get_file($cmp->gen_backup_filename("/etc/sysconfig/network-scripts/ifcfg-eth0").NCM::Component::network::FAILED_SUFFIX);
 isa_ok($fh,"CAF::FileWriter","This is a CAF::FileWriter network/ifcfg-eth0 file written");
 
@@ -39,5 +67,7 @@ like($fh, qr/^IPV6ADDR=2001:678:123:e012::45\/64$/m, "set ipv6 addr");
 like($fh, qr/^IPV6ADDR_SECONDARIES='2001:678:123:e012::46\/64 2001:678:123:e012::47\/64'$/m, "set ipv6 addr");
 like($fh, qr/^IPV6_AUTOCONF=no$/m, "IPV6 autoconf disabled");
 like($fh, qr/^IPV6INIT=yes$/m, "IPv6 INIT (implicitly) enabled");
+
+is("$fh", $ETH0, "exact eth0 config");
 
 done_testing();

--- a/ncm-network/src/test/perl/ovs.t
+++ b/ncm-network/src/test/perl/ovs.t
@@ -6,6 +6,31 @@ use Test::Quattor qw(ovs);
 use helper;
 use NCM::Component::network;
 
+use Readonly;
+
+Readonly my $BR => <<EOF;
+ONBOOT=yes
+NM_CONTROLLED='no'
+DEVICE=br-ex
+TYPE=OVSBridge
+DEVICETYPE='ovs'
+BOOTPROTO=static
+IPADDR=4.3.2.1
+NETMASK=255.255.255.0
+BROADCAST=4.3.2.255
+EOF
+
+Readonly my $ETH0 => <<EOF;
+ONBOOT=yes
+NM_CONTROLLED='no'
+DEVICE=eth0
+TYPE=OVSPort
+DEVICETYPE='ovs'
+OVS_BRIDGE='br-ex'
+BOOTPROTO=none
+EOF
+
+
 =pod
 
 =head1 DESCRIPTION
@@ -28,6 +53,8 @@ like($bfh, qr/^BOOTPROTO=static$/m, "set bootproto for the OVS bridge");
 
 unlike($bfh, qr/IPV6/, "No IPv6 config details");
 
+is("$bfh", $BR, "exact br config");
+
 my $ifh = get_file($cmp->gen_backup_filename("/etc/sysconfig/network-scripts/ifcfg-eth0").NCM::Component::network::FAILED_SUFFIX);
 isa_ok($ifh,"CAF::FileWriter","This is a CAF::FileWriter network/ifcfg-eth0 file written");
 
@@ -37,5 +64,7 @@ like($ifh, qr/^OVS_BRIDGE='br-ex'$/m, "set bridge for the OVS port");
 like($ifh, qr/^BOOTPROTO=none$/m, "set bootproto for the OVS port");
 
 unlike($ifh, qr/IPV6/, "No IPv6 config details");
+
+is("$ifh", $ETH0, "exact eth0 config");
 
 done_testing();

--- a/ncm-network/src/test/perl/simple.t
+++ b/ncm-network/src/test/perl/simple.t
@@ -7,6 +7,25 @@ use Test::Quattor qw(simple simple_realhostname);
 use helper;
 use NCM::Component::network;
 
+use Readonly;
+
+Readonly my $NETWORK => <<EOF;
+NETWORKING=yes
+HOSTNAME=somehost.test.domain
+GATEWAY=4.3.2.254
+EOF
+
+Readonly my $ETH0 => <<EOF;
+ONBOOT=yes
+NM_CONTROLLED='no'
+DEVICE=eth0
+TYPE=Ethernet
+BOOTPROTO=static
+IPADDR=4.3.2.1
+NETMASK=255.255.255.0
+BROADCAST=4.3.2.255
+EOF
+
 =pod
 
 =head1 DESCRIPTION
@@ -32,6 +51,8 @@ like($fh, qr/^GATEWAY=/m, "Set default gateway");
 
 unlike($fh, qr/IPV6/, "No IPv6 config details");
 
+is("$fh", $NETWORK, "Exact network config");
+
 
 $fh = get_file($cmp->gen_backup_filename("/etc/sysconfig/network-scripts/ifcfg-eth0").NCM::Component::network::FAILED_SUFFIX);
 isa_ok($fh,"CAF::FileWriter","This is a CAF::FileWriter network/ifcfg-eth0 file written");
@@ -46,6 +67,9 @@ like($fh, qr/^NETMASK=/m, "fixed netmask");
 like($fh, qr/^BROADCAST=/m, "fixed broadcast");
 
 unlike($fh, qr/IPV6/, "No IPv6 config details");
+
+is("$fh", $ETH0, "Exact network config");
+
 
 # Check that realhostname is used correctly
 $cfg = get_config_for_profile('simple_realhostname');


### PR DESCRIPTION
Fixes #1069
