### PR TITLE
ncm-spma (yum): Allow unmanaged repositories to be controlled seperately from packages

### DIFF
--- a/ncm-spma/src/main/pan/components/spma/yum/schema.pan
+++ b/ncm-spma/src/main/pan/components/spma/yum/schema.pan
@@ -65,6 +65,8 @@ type component_spma_yum = {
     "quattor_os_release" ? string # string to write to quattor_os_file
     "plugins" ? spma_yum_plugins
     "main_options" ? spma_yum_main_options
+    @{ Allow user defined (i.e. unmanaged) repositories to be used }
+    "userrepos" : boolean = false
 };
 
 bind "/software/components/spma" = component_spma_yum;

--- a/ncm-spma/src/main/perl/spma/yum.pm
+++ b/ncm-spma/src/main/perl/spma/yum.pm
@@ -109,7 +109,7 @@ sub _match_noaction_tempdir
 # in the system that are not listed in $allowed_repos.
 sub cleanup_old_repos
 {
-    my ($self, $repo_dir, $allowed_repos, $allow_user_pkgs) = @_;
+    my ($self, $repo_dir, $allowed_repos, $allow_user_repos) = @_;
 
     if ($NoAction) {
         if($self->_match_noaction_tempdir($repo_dir)) {
@@ -128,7 +128,7 @@ sub cleanup_old_repos
     }
 
     # Test this after the NoAction bit for unittesting
-    return 1 if $allow_user_pkgs;
+    return 1 if $allow_user_repos;
 
     my $dir;
     if (!opendir($dir, $repo_dir)) {
@@ -1138,11 +1138,11 @@ sub Configure
     $t->{run} = $t->{run} eq 'yes';
     $t->{userpkgs} = defined($t->{userpkgs}) && $t->{userpkgs} eq 'yes';
 
-    # When userpkgs are allowed, there is no control over what is in the reposdir
-    # If they are not allowed, and retry is allowed, use a non-standard location
-    # to avoid any repositories getting added during the retries (e.g. from rpms).
-    my $main_repos_dir = ($NoAction || $t->{userpkgs} || (!$t->{userpkgs_retry})) ?
-                             REPOS_DIR_DEFAULT : REPOS_DIR_QUATTOR;
+    # When userrepos are allowed, there is no control over what is in the reposdir
+    # If they are not allowed, use a non-standard location to avoid any repositories
+    # getting added during the retries (e.g. from rpms).
+    my $main_repos_dir = ($NoAction || $t->{userrepos}) ? REPOS_DIR_DEFAULT : REPOS_DIR_QUATTOR;
+    $self->debug(5, "Using '$main_repos_dir' as yum repository directory");
 
     my $repos = $config->getTree(REPOS_TREE);
     my $pkgs = $config->getTree(PKGS_TREE);
@@ -1171,7 +1171,7 @@ sub Configure
 
     my $quattor_managed_reposdir = _prefix_noaction_prefix($main_repos_dir);
     $self->initialize_repos_dir($quattor_managed_reposdir) or return 0;
-    $self->cleanup_old_repos($quattor_managed_reposdir, $repos, $t->{userpkgs}) or return 0;
+    $self->cleanup_old_repos($quattor_managed_reposdir, $repos, $t->{userrepos}) or return 0;
     $res = $self->generate_repos($quattor_managed_reposdir, $repos, REPOS_TEMPLATE,
                                           $t->{proxyhost}, $t->{proxytype},
                                           $t->{proxyport});

--- a/ncm-spma/src/test/perl/yum-cleanup.t
+++ b/ncm-spma/src/test/perl/yum-cleanup.t
@@ -3,8 +3,6 @@
 # ${author-info}
 # ${build-info}
 
-=pod
-
 =head1 DESCRIPTION
 
 Tests for the C<configure_yum> method.  This method modifies the
@@ -44,8 +42,6 @@ my $extra_opts = {
     retries => 100,
 };
 
-=pod
-
 =item * If they don't exist, it is appended.
 
 =cut
@@ -61,8 +57,6 @@ like("$fh", qr{^$REPOSDIR=/dir/1,/dir/2}m, "Reposdir is expanded properly");
 like("$fh", qr{^exclude=something else}m, "exclude is addedd properly (space separated)");
 like("$fh", qr{^retries=100}m, "reries is added");
 
-=pod
-
 =item * If it exists but has wrong value, it is modified
 
 =cut
@@ -71,8 +65,6 @@ set_file_contents($YUM_FILE, "$COR=fubar");
 $cmp->configure_yum($YUM_FILE, 0, "/my/pluginpath", [qw(/dir/1 /dir/2)]);
 $fh = get_file($YUM_FILE);
 like("$fh", qr{^$COR=1$}m, "Correct substitution");
-
-=pod
 
 =item * If it exists and is correct, nothing happens
 
@@ -84,8 +76,6 @@ $fh = get_file($YUM_FILE);
 is("$fh",
    "$COR=1\n$OBSOLETES=0\n$PLUGINCONFPATH=/my/pluginpath\n$REPOSDIR=/dir/1,/dir/2\nsomething=else",
    "The method is idempotent");
-
-=pod
 
 =item * Handle special characters
 
@@ -101,3 +91,5 @@ is("$fh",
 
 
 done_testing();
+
+=back

--- a/ncm-spma/src/test/perl/yum-configure.t
+++ b/ncm-spma/src/test/perl/yum-configure.t
@@ -3,8 +3,6 @@
 # ${author-info}
 # ${build-info}
 
-=pod
-
 =head1 DESCRIPTION
 
 Tests for the C<Configure> method.  This method should just call a few
@@ -62,8 +60,6 @@ my %calls;
 
 is($cmp->Configure($cfg), 1, "Simple configuration succeeds");
 
-=pod
-
 =head2 Simple profile
 
 We use the simplest profile for this, which doesn't allow for user
@@ -85,8 +81,6 @@ ok(!$args[4], "No user packages allowed in update_pkgs_retry");
 ok(exists($args[1]->{ConsoleKit}),
   "A package list is passed to UPDATE_PKGS");
 
-=pod
-
 =head3 Correct arguments to each callee
 
 =cut
@@ -104,16 +98,12 @@ while (my ($name, $args) = $mock->next_call()) {
 ok(defined($calls{configure_plugins}),
    "configure_plugins called, t->{plugins} are passed (undef since not defined)");
 
-=over
-
 =item * C<initialize_repos_dir>
 
 =cut
 
 is($calls{initialize_repos_dir}->[1], "/etc/yum.repos.d",
    "Correct Yum repository directory initialized");
-
-=pod
 
 =item * C<cleanup_old_repos>
 
@@ -128,8 +118,6 @@ is(ref($args[2]), 'ARRAY',
 is($args[2]->[0]->{name}, $repos->[0]->{name},
    "The profile's list of repositories is passed to cleanup_old_repos");
 ok(!$args[3], "No user repositories allowed");
-
-=pod
 
 =item * C<generate_repos>
 
@@ -146,7 +134,8 @@ like($args[3], qr{^repository$},
      "Correct repository template passed");
 ok(!$args[4], "No proxy passed to generate_repos");
 
-=pod
+
+=back
 
 =head2 Proxy settings
 
@@ -168,8 +157,6 @@ is($args[-3], $t->{proxyhost}, "Correct proxy host passed to generate_repos");
 is($args[-2], $t->{proxytype}, "Correct proxy type passed to generate_repos");
 is($args[-1], $t->{proxyport}, "Correct proxy port passed to generate_repos");
 
-=pod
-
 =head2 SPMA disabled
 
 It must show up when calling C<update_pkgs_retry>
@@ -183,8 +170,6 @@ $mock->clear();
 $cmp->Configure($cfg);
 @args = $mock->call_args($UPDATE_PKGS);
 ok(!$args[3], "No run is correctly passed to update_pkgs_retry");
-
-=pod
 
 =head2 User packages allowed
 
@@ -203,8 +188,6 @@ while (my ($n, $a) = $mock->next_call()) {
 	ok($a->[3], "User packages are passed correctly to $name");
     }
 }
-
-=pod
 
 =head2 Error handling
 
@@ -225,8 +208,6 @@ $mock->set_false('update_pkgs_retry');
 is($cmp->Configure($cfg), 0, "Failure in update_pkgs_retry is propagated");
 $mock->called_ok('update_pkgs_retry', "update_pkgs_retry is called");
 
-=pod
-
 =item * Any other method fails
 
 The error is propagated, and C<update_pkgs_retry> is never called
@@ -242,8 +223,6 @@ foreach my $f (qw(generate_repos cleanup_old_repos initialize_repos_dir)) {
     $mock->set_true($f);
 }
 
-=pod
-
 =item * The LANG environment variable is kept
 
 =cut
@@ -257,7 +236,6 @@ done_testing();
 
 __END__
 
-=pod
 
 =back
 

--- a/ncm-spma/src/test/perl/yum-configure.t
+++ b/ncm-spma/src/test/perl/yum-configure.t
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use Readonly;
 use Test::More;
-use Test::Quattor qw(simple with_proxy without_spma with_pkgs);
+use Test::Quattor qw(simple with_proxy without_spma with_pkgs with_repos);
 use NCM::Component::spma::yum;
 use Test::MockObject::Extends;
 use CAF::Object;
@@ -102,7 +102,7 @@ ok(defined($calls{configure_plugins}),
 
 =cut
 
-is($calls{initialize_repos_dir}->[1], "/etc/yum.repos.d",
+is($calls{initialize_repos_dir}->[1], "/etc/yum.quattor.repos.d",
    "Correct Yum repository directory initialized");
 
 =item * C<cleanup_old_repos>
@@ -111,7 +111,7 @@ is($calls{initialize_repos_dir}->[1], "/etc/yum.repos.d",
 
 @args = @{$calls{cleanup_old_repos}};
 
-is($args[1], "/etc/yum.repos.d",
+is($args[1], "/etc/yum.quattor.repos.d",
    "Correct Yum repository directory to be cleaned up");
 is(ref($args[2]), 'ARRAY',
    'A list with repositories is passed to clean up non-existing repos');
@@ -124,7 +124,7 @@ ok(!$args[3], "No user repositories allowed");
 =cut
 
 @args = @{$calls{generate_repos}};
-is($args[1], "/etc/yum.repos.d",
+is($args[1], "/etc/yum.quattor.repos.d",
    "Correct Yum repository directory to be initialised");
 is(ref($args[2]), 'ARRAY',
    "A list of repositories is passed to generate_repos");
@@ -173,7 +173,7 @@ ok(!$args[3], "No run is correctly passed to update_pkgs_retry");
 
 =head2 User packages allowed
 
-They show up in C<cleanup_old_repos> and C<update_pkgs_retry>
+They show up in C<update_pkgs_retry>
 
 =cut
 
@@ -184,7 +184,7 @@ $mock->clear();
 $cmp->Configure($cfg);
 
 while (my ($n, $a) = $mock->next_call()) {
-    if ($n eq 'update_pkgs_retry' || $n eq 'cleanup_old_repos') {
+    if ($n eq 'update_pkgs_retry') {
 	ok($a->[3], "User packages are passed correctly to $name");
     }
 }
@@ -232,10 +232,36 @@ $mock->mock('generate_repos', sub {
 		    return 1;
 	    });
 
+=back
+
+=head2 User packages allowed
+
+They show up in C<cleanup_old_repos>
+
+=cut
+
+$cfg = get_config_for_profile("with_repos");
+
+$mock->clear();
+
+$cmp->Configure($cfg);
+
+while (my ($name, $args) = $mock->next_call()) {
+    $calls{$name} = $args;
+}
+
+=over
+
+=item * C<initialize_repos_dir>
+
+=cut
+
+is($calls{initialize_repos_dir}->[1], "/etc/yum.repos.d", "Correct Yum repository directory initialized with userrepos set");
+
+
 done_testing();
 
 __END__
-
 
 =back
 

--- a/ncm-spma/src/test/perl/yum-transaction-complete.t
+++ b/ncm-spma/src/test/perl/yum-transaction-complete.t
@@ -3,8 +3,6 @@
 # ${author-info}
 # ${build-info}
 
-=pod
-
 =head1 DESCRIPTION
 
 Tests for the C<complete_transaction> method.  This method just runs
@@ -33,10 +31,6 @@ set_desired_err($CMD, "");
 set_desired_output($CMD, "");
 
 my $cmp = NCM::Component::spma::yum->new("spma");
-
-=pod
-
-=back
 
 =head2 Transaction completions
 

--- a/ncm-spma/src/test/perl/yum-transaction.t
+++ b/ncm-spma/src/test/perl/yum-transaction.t
@@ -3,8 +3,6 @@
 # ${author-info}
 # ${build-info}
 
-=pod
-
 =head1 DESCRIPTION
 
 Tests for the C<apply_transaction> method.  This method executes the
@@ -41,10 +39,6 @@ my $cmp = NCM::Component::spma::yum->new("spma");
 
 set_desired_err($YUM, "");
 set_desired_output($YUM, "Transaction");
-
-=pod
-
-=back
 
 =head2 Transaction executions
 

--- a/ncm-spma/src/test/perl/yum-update-pkgs-retry.t
+++ b/ncm-spma/src/test/perl/yum-update-pkgs-retry.t
@@ -3,8 +3,6 @@
 # ${author-info}
 # ${build-info}
 
-=pod
-
 =head1 DESCRIPTION
 
 Tests for the C<update_pkgs_retry> method.
@@ -41,8 +39,6 @@ $mock->mock("update_pkgs",  sub {
 
 my $cmp = NCM::Component::spma::yum->new("spma");
 
-=pod
-
 =head2 Update success
 
 First call returns success
@@ -61,8 +57,6 @@ ok (! $args[0]->[5], "1st (and only) update_pkgs call has tx_error_is_warn=false
 ok (! $args[0]->[7], "1st update_pkgs call does not reuse cache");
 is ($cmp->{ERROR}, 0, "No errors logged");
 
-=pod
-
 =head2 Update fails, no retry
 
 First call returns fail, no retry allowed
@@ -79,8 +73,6 @@ is($called, 1, "Basic invocation makes 1 update_pkgs call (with update_pkgs=fail
 ok (! $args[0]->[5], "1st (and only) update_pkgs call has tx_error_is_warn=false");
 ok (! $args[0]->[7], "1st update_pkgs call does not reuse cache");
 is ($cmp->{ERROR}, 0, "No errors logged by update_pkgs_retry (expect something else to log them)");
-
-=pod
 
 =head2 Update fails, userpaks and retry allowed
 
@@ -99,14 +91,12 @@ ok(! $args[0]->[5], "1st (and only) update_pkgs call has tx_error_is_warn=false"
 ok (! $args[0]->[7], "1st update_pkgs call does not reuse cache");
 is ($cmp->{ERROR}, 0, "No errors logged by update_pkgs_retry (expect something else to log them)");
 
-=pod
 
 =head2 Update fails twice
 
 update_pkgs fails 2 times (2nd failure with user pakgs allowed)
 
 =cut
-
 
 $called = 0;
 @args= ();
@@ -127,8 +117,6 @@ ok ($args[1]->[7], "2nd update_pkgs call reuses cache");
 
 is ($cmp->{ERROR}, 1, "1 error logged by update_pkgs_retry");
 
-
-=pod
 
 =head2 Update fails with userpakages not allowed
 
@@ -155,8 +143,6 @@ ok (! $args[2]->[5], "3rd update_pkgs call has tx_error_is_warn=false");
 ok ($args[2]->[7], "3rd update_pkgs call reuses cache");
 
 is ($cmp->{ERROR}, 1, "1 error logged by update_pkgs_retry");
-
-=pod
 
 =head2 Succesful retry
 
@@ -185,8 +171,6 @@ ok ($args[2]->[7], "3rd update_pkgs call reuses cache");
 
 is ($cmp->{ERROR}, 0, "No error logged by update_pkgs_retry");
 
-=pod
-
 =head2 Test all expected arguments are passed
 
 In succesful retry, the 3 update_pkgs calls receive all expected arguments
@@ -199,7 +183,6 @@ is_deeply($args[0], ["pkgs", "groups", "run", 0, "purge", 1, "fullsearch", 0], "
 is_deeply($args[1], ["pkgs", "groups", "run", 1, "purge", 0, "fullsearch", 1], "2nd update_pkgs expected args");
 is_deeply($args[2], ["pkgs", "groups", "run", 0, "purge", 0, "fullsearch", 1], "3rd update_pkgs expected args");
 
-=pod
 
 =head2 with NoAction, do not retry on failure
 
@@ -216,9 +199,3 @@ is ($cmp->{ERROR}, 0, "No error logged by update_pkgs_retry with NoAction");
 
 
 done_testing();
-
-=pod
-
-=back
-
-=cut

--- a/ncm-spma/src/test/resources/simple.pan
+++ b/ncm-spma/src/test/resources/simple.pan
@@ -17,3 +17,4 @@ prefix "/software/components/spma";
 "active" = true;
 "dispatch" = true;
 "userpkgs" = "no";
+"userrepos" = false;

--- a/ncm-spma/src/test/resources/with_repos.pan
+++ b/ncm-spma/src/test/resources/with_repos.pan
@@ -1,0 +1,7 @@
+object template with_repos;
+
+"/" = value("simple:/");
+
+prefix "/software/components/spma";
+
+"userrepos" = true;


### PR DESCRIPTION
This allows spma to cooperate with other tools (e.g. RedHat subscription manager) that configure repositories essential to the system. The implementation matches what I have done for APT in #821 based on an idea originally proposed by @ned21.

This is backwards incompatible as the the behaviour of yum based spma on systems that currently have `userpkgs` set will change unless `userrepos` is also set.