### PR TITLE
CCM cleanup fallout

### DIFF
--- a/ncm-iptables/src/main/perl/iptables.pm
+++ b/ncm-iptables/src/main/perl/iptables.pm
@@ -14,9 +14,6 @@ use CAF::Process;
 use CAF::FileWriter;
 use Readonly;
 
-use EDG::WP4::CCM::Element;
-use EDG::WP4::CCM::Resource;
-
 $NCM::Component::iptables::NoActionSupported = 1;
 
 # Global variables

--- a/ncm-systemd/src/main/perl/Systemd/Service/Chkconfig.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service/Chkconfig.pm
@@ -11,7 +11,7 @@ use warnings;
 
 use parent qw(NCM::Component::Systemd::Service::Unit);
 
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path qw(unescape);
 
 use NCM::Component::Systemd::Service::Unit qw(:targets $DEFAULT_TARGET
     $TYPE_SYSV $TYPE_TARGET $DEFAULT_STARTSTOP $DEFAULT_STATE

--- a/ncm-systemd/src/main/perl/Systemd/Service/Unit.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service/Unit.pm
@@ -12,7 +12,7 @@ use warnings;
 use LC::Exception qw (SUCCESS);
 
 use parent qw(CAF::Object Exporter);
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path qw(unescape);
 
 use NCM::Component::Systemd::UnitFile;
 use NCM::Component::Systemd::Systemctl qw(
@@ -1419,11 +1419,11 @@ sub is_ufstate
 =item _getTree
 
 The C<getTree> method is similar to the regular
-B<EDG::WP4::CCM::Element::getTree>, except that
+B<EDG::WP4::CCM::CacheManager::Element::getTree>, except that
 it keeps the unitfile configuration as an Element instance
 (as required by B<NCM::Component::Systemd::UnitFile>).
 
-It takes as arguments a B<EDG::WP4::CCM::Configuration> instance
+It takes as arguments a B<EDG::WP4::CCM::CacheManager::Configuration> instance
 C<$config> and a C<$path> to the root of the whole unit tree.
 
 =cut

--- a/ncm-systemd/src/main/perl/Systemd/UnitFile.pm
+++ b/ncm-systemd/src/main/perl/Systemd/UnitFile.pm
@@ -20,6 +20,7 @@ use LC::Exception qw (SUCCESS);
 use Readonly;
 use LC::Check;
 
+use EDG::WP4::CCM::TextRender 17.2.1;
 use NCM::Component::Systemd::Systemctl qw(systemctl_daemon_reload);
 
 Readonly my $UNITFILE_DIRECTORY => '/etc/systemd/system';
@@ -61,7 +62,7 @@ The unit (full C<name.type>).
 
 =item config
 
-A C<EDG::WP4::CCM::Element> instance with the unitfile configuration.
+A C<EDG::WP4::CCM::CacheManager::Element> instance with the unitfile configuration.
 
 (An element instance is required becasue the rendering of
 the configuration is pan-basetype sensistive).
@@ -192,7 +193,7 @@ sub write
     my ($self) = @_;
 
     if (!(blessed($self->{config}) &&
-           $self->{config}->isa("EDG::WP4::CCM::Element"))) {
+           $self->{config}->isa("EDG::WP4::CCM::CacheManager::Element"))) {
         $self->error("config has to be an Element instance");
         return;
     }

--- a/ncm-systemd/src/test/perl/service-unit.t
+++ b/ncm-systemd/src/test/perl/service-unit.t
@@ -565,7 +565,7 @@ my @uf_write;
 $mockuf->mock("write", sub {
     my $self = shift;
     # also tested by the getTree call
-    isa_ok($self->{config}, 'EDG::WP4::CCM::Element',
+    isa_ok($self->{config}, 'EDG::WP4::CCM::CacheManager::Element',
            "config on write for $self->{unit} is an Element instance");
     push(@uf_write, [$self->{unit}, $self->{replace}, $self->{backup}, $self->{config}->getTree(), $self->{custom}]);
     return 1;

--- a/ncm-systemd/src/test/perl/service.t
+++ b/ncm-systemd/src/test/perl/service.t
@@ -72,7 +72,7 @@ my @uf_write;
 $mockuf->mock("write", sub {
     my $self = shift;
     # also tested by the getTree call
-    isa_ok($self->{config}, 'EDG::WP4::CCM::Element',
+    isa_ok($self->{config}, 'EDG::WP4::CCM::CacheManager::Element',
            "config on write for $self->{unit} is an Element instance");
     push(@uf_write, [$self->{unit}, $self->{replace}, $self->{backup}, $self->{config}->getTree(), $self->{custom}]);
     return 1;

--- a/ncm-systemd/src/test/perl/unitfile.t
+++ b/ncm-systemd/src/test/perl/unitfile.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use EDG::WP4::CCM::Element qw(escape);
+use EDG::WP4::CCM::Path qw(escape);
 use Test::Quattor qw(unitfile_config);
 use NCM::Component::systemd;
 use NCM::Component::Systemd::UnitFile;


### PR DESCRIPTION
After https://github.com/quattor/CCM/pull/162 usage of `CCM::Resource` and direct class testing with old name are not supported anymore