### PR TITLE
ncm-filecopy: remove hardcoded path to component

### DIFF
--- a/ncm-filecopy/src/main/perl/filecopy.pm
+++ b/ncm-filecopy/src/main/perl/filecopy.pm
@@ -27,11 +27,8 @@ sub Configure
 {
     my ( $self, $config ) = @_;
 
-    # Define path for convenience.
-    my $base = "/software/components/filecopy";
-
     # Retrieve component configuration
-    my $confighash = $config->getElement($base)->getTree();
+    my $confighash = $config->getTree($self->prefix());
     my $files = $confighash->{services};
 
     # Determine first if there is anything to do.


### PR DESCRIPTION
Remove the hardcoded path to  /software/components/filecopy to allow subclassing the component

Fixes #1098.