### PR TITLE
ncm-authconfig : Update ldap.tt (Issue #1100)

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/ldap.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/ldap.pan
@@ -95,7 +95,7 @@ type authconfig_sssd_ldap = {
 
     "krb5_backup_server" ? string
     "krb5_canonicalize" ? boolean
-    "krb5_realm" ? string[]
+    "krb5_realm" ? string
     "krb5_server" ? string
     "access_filter" ? string
     "access_order" : ldap_order = "filter"
@@ -122,6 +122,5 @@ type authconfig_sssd_ldap = {
     "referrals" : boolean = true
     "rootdse_last_usn" ? string
     "search_timeout" : long = 6
-    "use_object_class" : string = "posixAccount"
     "account_expire_policy" ? string with match(SELF, "^(shadow|ad|rhds|ipa|389ds|nds)$")
 };

--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/user.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/user.pan
@@ -12,6 +12,7 @@
 declaration template components/authconfig/sssd/user;
 
 type sssd_user = {
+    "object_class" : string = "posixAccount"
     "uid_number" : string = "uidNumber"
     "gid_number" : string = "gidNumber"
     "gecos" : string = "gecos"

--- a/ncm-authconfig/src/main/resources/domains/ldap.tt
+++ b/ncm-authconfig/src/main/resources/domains/ldap.tt
@@ -24,7 +24,7 @@
 [%-         SWITCH name -%]
 [%-             CASE ['krb5_canonicalize'] -%]
 [%-                 desc.$name ? 'True' : 'False' %]
-[%-             CASE -%]
+[%             CASE -%]
 [%-                 desc.$name %]
 [%          END -%]
 [%      END -%]

--- a/ncm-authconfig/src/main/resources/tests/profiles/ldap.pan
+++ b/ncm-authconfig/src/main/resources/tests/profiles/ldap.pan
@@ -16,4 +16,4 @@ prefix "/desc";
 "tls/cipher_suite" = list("c1", "c2");
 "user/shell" = "us";
 "uri" = list("u1","u2");
-
+"user/object_class"="user"

--- a/ncm-authconfig/src/main/resources/tests/profiles/ldap.pan
+++ b/ncm-authconfig/src/main/resources/tests/profiles/ldap.pan
@@ -17,3 +17,5 @@ prefix "/desc";
 "user/shell" = "us";
 "uri" = list("u1","u2");
 "user/object_class"="user"
+"ldap/krb5_canonicalize"="true"
+"ldap/krb5_realm"="realm"

--- a/ncm-authconfig/src/main/resources/tests/regexps/ldap/value
+++ b/ncm-authconfig/src/main/resources/tests/regexps/ldap/value
@@ -17,4 +17,6 @@ contentspath=/
 ^ldap_sudo_hostnames = sh$
 ^ldap_sudorule_hostnames = sh$
 ^ldap_uri = u1,u2$
-
+^ldap_user_object_class= user$
+^ldap_krb5_canonicalize= True$
+^ldap_krb5_realm= realm$


### PR DESCRIPTION
When I do an ncm-ncd --configure authconfig, the /etc/sssd.conf file contains the following line:
Krb5_canonicalize = Falsekrb5_realm = LAPP.IN2P3.EN
While it should be:
Krb5_canonicalize = False
Krb5_realm = LAPP.IN2P3.EN

This is due to an error in the file /usr/share/templates/quattor/authconfig/domains/ldap.tt

[% - SWITCH name -%]
[% - CASE ['krb5_canonicalize'] -%]
[% - desc. $ Name? 'True': 'False'%]
[% - CASE -%]
[% - desc. $ Name%]
[% END -%]

  should be

[% - SWITCH name -%]
[% - CASE ['krb5_canonicalize'] -%]
[% - desc. $ Name? 'True': 'False'%]
[% CASE -%]
[% - desc. $ Name%]
[% END -%]

Fixes #1100
