### PR TITLE
ncm-nfs: stop nfs reload when adding comments to empty exports file

### DIFF
--- a/ncm-nfs/src/main/perl/nfs.pm
+++ b/ncm-nfs/src/main/perl/nfs.pm
@@ -181,6 +181,11 @@ sub exports
 {
     my ($self, $tree) = @_;
 
+    # Take the original size of the exports file
+    my $backupsize = -s $EXPORTS;
+    # Initialise the flag for whether only comments are being added
+    my $onlycommentsadded = 0;
+    
     my $fh = CAF::FileWriter->new($EXPORTS, backup => ".old", log => $self);
 
     # Do not include timestamp, otherwise file changes every run
@@ -216,11 +221,19 @@ sub exports
     } else {
         $self->verbose("No exports defined");
         print $fh "# No exports defined\n";
+        if (defined($backupsize) && $backupsize == 0) {
+            $onlycommentsadded = 1;
+        }
     }
 
     my $result = $fh->close();
     if ($result) {
-        $self->info("$EXPORTS created/updated");
+        if (! $onlycommentsadded) {
+            $self->info("$EXPORTS created/updated");
+        } else {
+            $self->verbose("$EXPORTS unmodified");
+            $result = 0;
+        }
     } else {
         $self->verbose("$EXPORTS unmodified");
     }


### PR DESCRIPTION
On ncm-nfs's first run, it adds comment lines to the exports file. Even If there are no exports this will trigger a reload of the nfs service. On RHEL6 this appears harmless as the reload returns 0, but on RHEL 7, systemd returns an error:

 `# /bin/systemctl reload nfs; echo $?`
`Job for nfs-server.service invalid. `
`1`

This patch attempts to stop this. I think should partially address #1029 but any changes to fstab may also make the component reload nfs.