### PR TITLE
ncm-authconfig : Change auth_provider, reconnection_retries, user object_class and ldap_uri

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd.pan
@@ -12,9 +12,14 @@ include 'components/authconfig/sssd/ldap';
 include 'components/authconfig/sssd/ipa';
 
 @{
-    Valid SSSD providers.  For now we only implement ldap, simple and local
+    Valid SSSD providers.
 }
 type sssd_provider_string = string with match(SELF, "^(ldap|simple|local|permit|ipa)$");
+
+@{
+    Valid SSSD auth providers.
+}
+type sssd_auth_provider_string = string with match(SELF, "^(ldap|krb5|local|permit|ipa)$");
 
 
 @{
@@ -31,37 +36,39 @@ type authconfig_sssd_simple = {
 type sssd_service = string with match(SELF, "^(nss|pam|sudo|autofs|ssh|pac)$");
 
 type sssd_global = {
-    "debug_level" : long = 0x01F0
+    "debug_level" ? long
     "config_file_version" : long = 2
     "services" : sssd_service[]
-    "reconnection_retries" : long = 3
+    "reconnection_retries" ? long
     "re_expression" ? string
     "full_name_format" ? string
-    "try_inotify" : boolean = true
+    "try_inotify" ? boolean
     "krb5_rcache_dir" ? string
     "default_domain_suffix" ? string
 };
 
 type sssd_pam = {
-    "debug_level" : long = 0x01F0
-    "offline_credentials_expiration" : long = 0
-    "offline_failed_login_attempts" : long = 0
-    "offline_failed_login_delay" : long =  5
-    "pam_verbosity" : long =  1
-    "pam_id_timeout" : long =  5
-    "pam_pwd_expiration_warning" : long =  0
-    "get_domains_timeout" : long =  60
+    "debug_level" ? long
+    "reconnection_retries" ? long
+    "offline_credentials_expiration" ? long
+    "offline_failed_login_attempts" ? long
+    "offline_failed_login_delay" ? long
+    "pam_verbosity" ? long
+    "pam_id_timeout" ? long
+    "pam_pwd_expiration_warning" ? long
+    "get_domains_timeout" ? long
 };
 
 type sssd_nss = {
-    "debug_level" : long = 0x01F0
-    "enum_cache_timeout" : long = 120
+    "debug_level" ? long
+    "reconnection_retries" ? long
+    "enum_cache_timeout" ? long
     "entry_cache_nowait_percentage" ? long
-    "entry_negative_timeout" : long = 15
-    "filter_users" : string = "root"
-    "filter_users_in_groups" : boolean = true
-    "filter_groups" : string = "root"
-    "memcache_timeout" : long = 300
+    "entry_negative_timeout" ? long
+    "filter_users" ? string
+    "filter_users_in_groups" ? boolean
+    "filter_groups" ? string
+    "memcache_timeout" ? long
 };
 
 type authconfig_sssd_local = {
@@ -76,29 +83,30 @@ type authconfig_sssd_local = {
 };
 
 type authconfig_sssd_domain  = {
+    "reconnection_retries" ? long
     "ldap" ? authconfig_sssd_ldap
     "ipa" ? authconfig_sssd_ipa
     "simple" ? authconfig_sssd_simple
     "local" ? authconfig_sssd_local
     "access_provider" ? sssd_provider_string
     "id_provider" ? sssd_provider_string
-    "auth_provider" ? sssd_provider_string
-    "chpass_provider" ? sssd_provider_string
-    "debug_level" : long = 0x01F0
+    "auth_provider" ? sssd_auth_provider_string
+    "chpass_provider" ? sssd_auth_provider_string
+    "debug_level" ? long
     "sudo_provider" ? string
     "selinux_provider" ? string
     "subdomains_provider" ? string
     "autofs_provider" ? string
     "hostid_provider" ? string
-    "re_expression" : string = "(?P<name>[^@]+)@?(?P<domain>[^@]*$)"
+    "re_expression" ? string
     "full_name_format" : string = "%1$s@%2$s"
     "lookup_family_order" : string = "ipv4_first"
     "dns_resolver_timeout" : long = 5
     "dns_discovery_domain" ? string
     "override_gid" ? long
     "case_sensitive" : boolean = true
-    "proxy_fast_alias" : boolean = false
-    "subdomain_homedir" : string = "/home/%d/%u"
+    "proxy_fast_alias" ? boolean
+    "subdomain_homedir" ? string
     "proxy_pam_target" ? string
     "proxy_lib_name" ? string
     "min_id" : long = 1

--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/ldap.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/ldap.pan
@@ -87,7 +87,7 @@ type authconfig_sssd_ldap = {
     "tls" ? sssd_tls
     "netgroup" ? sssd_netgroup
     "autofs" ? sssd_autofs
-    "uri" : type_absoluteURI[]
+    "uri" ? type_absoluteURI[]
     "backup_uri" ? type_absoluteURI[]
     "search_base" ? string
     "schema" : ldap_schema = "rfc2307"
@@ -100,7 +100,6 @@ type authconfig_sssd_ldap = {
     "access_filter" ? string
     "access_order" : ldap_order = "filter"
     "connection_expire_timeout" : long = 900
-    "deref" : ldap_deref = "never"
     "deref" ? string
     "deref_threshold" ? long
     "disable_paging" : boolean = false
@@ -111,17 +110,16 @@ type authconfig_sssd_ldap = {
     "force_upper_case_realm" : boolean = false
     "groups_use_matching_rule_in_chain" ? boolean
     "id_use_start_tls" ? boolean
-    "id_mapping" : boolean = false
+    "id_mapping" ? boolean = false
     "network_timeout" : long = 6
-    "ns_account_lock" : string = "nsAccountLock"
+    "ns_account_lock" ? string
     "offline_timeout" ? long
     "opt_timeout" : long = 6
     "page_size" : long = 1000
     "purge_cache_timeout" : long = 10800
     "pwd_policy" : string = "none"
-    "referrals" : boolean = true
+    "referrals" ? boolean
     "rootdse_last_usn" ? string
     "search_timeout" : long = 6
-    "use_object_class" : string = "posixAccount"
     "account_expire_policy" ? string with match(SELF, "^(shadow|ad|rhds|ipa|389ds|nds)$")
 };

--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/user.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/user.pan
@@ -12,33 +12,35 @@
 declaration template components/authconfig/sssd/user;
 
 type sssd_user = {
-    "uid_number" : string = "uidNumber"
-    "gid_number" : string = "gidNumber"
-    "gecos" : string = "gecos"
-    "home_directory" : string = "homeDirectory"
-    "shell" : string = "loginShell"
-    "uuid" : string = "nsUniqueId"
+    "object_class" : string = "posixAccount"
+    "uid_number" ? string
+    "gid_number" ? string
+    "name" ? string
+    "gecos" ? string
+    "home_directory" ? string
+    "shell" ? string
+    "uuid" ? string
     "objectsid" ? string
-    "modify_timestamp" : string = "modifyTimestamp"
-    "shadow_last_change" : string = "shadowLastChange"
-    "shadow_min" : string = "shadowMin"
-    "shadow_max" : string = "shadowMax"
-    "shadow_warning" : string = "shadowWarning"
-    "shadow_inactive" : string = "shadowInactive"
-    "shadow_expire" : string = "shadowExpire"
-    "krb_last_pwd_change" : string = "krbLastPwdChange"
-    "krb_password_expiration" : string = "krbPasswordExpiration"
-    "ad_account_expires" : string = "accountExpires"
-    "ad_user_account_control" : string = "userAccountControl"
-    "nds_login_disabled" : string = "loginDisabled"
-    "nds_login_expiration_time" : string = "loginDisabled"
-    "nds_login_allowed_time_map" : string = "loginAllowedTimeMap"
-    "principal" : string = "krbPrincipalName"
+    "modify_timestamp" ? string
+    "shadow_last_change" ? string
+    "shadow_min" ? string
+    "shadow_max" ? string
+    "shadow_warning" ? string
+    "shadow_inactive" ? string
+    "shadow_expire" ? string
+    "krb_last_pwd_change" ? string
+    "krb_password_expiration" ? string
+    "ad_account_expires" ? string
+    "ad_user_account_control" ? string
+    "nds_login_disabled" ? string
+    "nds_login_expiration_time" ? string
+    "nds_login_allowed_time_map" ? string
+    "principal" ? string
     "ssh_public_key" ? string
-    "fullname" : string = "cn"
-    "member_of" : string = "memberOf"
-    "authorized_service" : string = "authorizedService"
-    "authorized_host" : string = "host"
+    "fullname" ? string
+    "member_of" ? string
+    "authorized_service" ? string
+    "authorized_host" ? string
     "search_base" ? string
     "search_filter" ? string
 };
@@ -47,13 +49,13 @@ type sssd_user = {
 
 type sssd_group = {
     "object_class" : string = "posixGroup"
-    "name" : string = "cn"
-    "gid_number" : string = "gidNumber"
-    "member" : string = "memberuid"
-    "uuid" : string = "nsUniqueId"
+    "name" ? string = "cn"
+    "gid_number" ? string
+    "member" ? string
+    "uuid" ? string
     "objectsid" ? string
-    "modify_timestamp" : string = "modifyTimestamp"
-    "nesting_level" : long = 2
+    "modify_timestamp" ? string
+    "nesting_level" ? long
     "search_base" ? string
     "search_filter" ? string
 };

--- a/ncm-authconfig/src/main/resources/tests/profiles/basic.pan
+++ b/ncm-authconfig/src/main/resources/tests/profiles/basic.pan
@@ -90,7 +90,6 @@ prefix "/software/components/authconfig/method/sssd/domains";
 "test1/ldap/tls/reqcert" = "hard";
 "test1/ldap/uri/0" = "ldaps://mymainserver.mydomain";
 "test1/ldap/uri/1" = "ldaps://myothermainserver.mydomain";
-"test1/ldap/use_object_class" = "posixAccount";
 "test1/ldap/user/ad_account_expires" = "accountExpires";
 "test1/ldap/user/ad_user_account_control" = "userAccountControl";
 "test1/ldap/user/authorized_host" = "host";
@@ -106,6 +105,7 @@ prefix "/software/components/authconfig/method/sssd/domains";
 "test1/ldap/user/nds_login_allowed_time_map" = "loginAllowedTimeMap";
 "test1/ldap/user/nds_login_disabled" = "loginDisabled";
 "test1/ldap/user/nds_login_expiration_time" = "loginDisabled";
+"test1/ldap/user/object_class" = "posixAccount";
 "test1/ldap/user/principal" = "krbPrincipalName";
 "test1/ldap/user/shadow_expire" = "shadowExpire";
 "test1/ldap/user/shadow_inactive" = "shadowInactive";
@@ -123,7 +123,7 @@ prefix "/software/components/authconfig/method/sssd/domains";
 "test1/re_expression" = "(?P<name>[^@]+)@?(?P<domain>[^@]*$)";
 "test1/subdomain_homedir" = "/home/%d/%u";
 "test1/access_provider" = "simple";
-"test1/simple/allow_groups" = list("group1","group2");
+"test1/simple/allow_groups" = list("group1", "group2");
 
 # IPA
 "test2/auth_provider" = "ipa";

--- a/ncm-authconfig/src/main/resources/tests/regexps/basic/value
+++ b/ncm-authconfig/src/main/resources/tests/regexps/basic/value
@@ -44,6 +44,7 @@ contentspath=/software/components/authconfig/method/sssd
 ^ldap_user_nds_login_allowed_time_map = loginAllowedTimeMap$
 ^ldap_user_nds_login_disabled = loginDisabled$
 ^ldap_user_nds_login_expiration_time = loginDisabled$
+^ldap_user_object_class = posixAccount$
 ^ldap_user_principal = krbPrincipalName$
 ^ldap_user_shadow_expire = shadowExpire$
 ^ldap_user_shadow_inactive = shadowInactive$
@@ -90,7 +91,6 @@ contentspath=/software/components/authconfig/method/sssd
 ^ldap_search_base = dc=domain,dc=wahtever$
 ^ldap_search_timeout = 6$
 ^ldap_uri = ldaps://mymainserver.mydomain,ldaps://myothermainserver.mydomain$
-^ldap_use_object_class = posixAccount$
 ^simple_allow_groups = group1,group2$
 ^access_provider = simple$
 ^account_cache_expiration = 0$


### PR DESCRIPTION
- Make most inputs optional
- Add sssd_auth_provider_string that accepts krb5 but not simple
- Add "reconnection_retries" in sssd_pam and sssd_nss
- Make most inputs optional n sssd_global, sssd_pam and sssd_nss
- Add  "reconnection_retries" in sssd_domain
- Make some inputs optional
- Remove use_object_class in sssd_ldap because this option is not available in the SSSD configuration but there is a user_object_class option.
- Add object_class and name in sssd/user
- Make most inputs optional
- Make ldap_uri optional