### PR TITLE
ncm-metaconfig: udev : add blockdev udev rules

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/udev/blockdev.tt
+++ b/ncm-metaconfig/src/main/metaconfig/udev/blockdev.tt
@@ -1,0 +1,8 @@
+[%- FOREACH dv IN scsi_run -%]
+SUBSYSTEM=="block", SUBSYSTEMS=="scsi", PROGRAM=="/lib/udev/scsi_id -g -u -d /dev/%k", RUN+="[% dv  %]"
+[% END -%]
+
+[%- FOREACH dv IN dm_run -%] 
+SUBSYSTEM=="block", KERNEL=="dm-*", PROGRAM=="/lib/udev/scsi_id -g -u -d /dev/%k", RUN+="[% dv  %]"
+[% END -%]
+

--- a/ncm-metaconfig/src/main/metaconfig/udev/pan/blockdev_run.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/pan/blockdev_run.pan
@@ -1,0 +1,14 @@
+unique template metaconfig/udev/blockdev_run;
+
+include 'metaconfig/udev/schema';
+
+prefix "/software/components/metaconfig/services/{/etc/udev/rules.d/99-blockdevs.rules}";
+
+"mode" = 0644;
+"owner" = "root";
+"group" = "root";
+"module" = "udev/blockdev";
+
+bind "/software/components/metaconfig/services/{/etc/udev/rules.d/99-blockdevs.rules}/contents/scsi_run" =
+    udev_scsi_run;
+bind "/software/components/metaconfig/services/{/etc/udev/rules.d/99-blockdevs.rules}/contents/dm_run" = udev_dm_run;

--- a/ncm-metaconfig/src/main/metaconfig/udev/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/pan/schema.pan
@@ -1,7 +1,7 @@
 declaration template metaconfig/udev/schema;
 
 type udev_interfaces = dict with {
-    foreach(intf;macaddr;SELF) {
+    foreach(intf; macaddr; SELF) {
         intf_path = format("/hardware/cards/nic/%s", intf);
         mac_path = format("%s/hwaddr", intf_path);
         if (! (exists(intf_path) && exists(mac_path) && value(mac_path) == macaddr)) {
@@ -10,3 +10,7 @@ type udev_interfaces = dict with {
     };
     return(true);
 };
+
+type udev_scsi_run = string[];
+type udev_dm_run = string[];
+

--- a/ncm-metaconfig/src/main/metaconfig/udev/tests/profiles/blockdev_run.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/tests/profiles/blockdev_run.pan
@@ -1,0 +1,7 @@
+object template blockdev_run;
+
+include 'metaconfig/udev/blockdev_run';
+
+prefix "/software/components/metaconfig/services/{/etc/udev/rules.d/99-blockdevs.rules}/contents";
+"dm_run/0" = '/usr/lib/my_dm_script';
+"scsi_run/0" = '/usr/lib/my_scsi_script';

--- a/ncm-metaconfig/src/main/metaconfig/udev/tests/regexps/blockdev_run/base
+++ b/ncm-metaconfig/src/main/metaconfig/udev/tests/regexps/blockdev_run/base
@@ -1,0 +1,7 @@
+Base test for blockdev config
+---
+multiline
+metaconfigservice=/etc/udev/rules.d/99-blockdevs.rules
+---
+^SUBSYSTEM=="block", SUBSYSTEMS=="scsi", PROGRAM=="/lib/udev/scsi_id -g -u -d /dev/%k", RUN\+="/usr/lib/my_scsi_script"$
+^SUBSYSTEM=="block", KERNEL=="dm-\*", PROGRAM=="/lib/udev/scsi_id -g -u -d /dev/%k", RUN\+="/usr/lib/my_dm_script"$


### PR DESCRIPTION
configure udev to run scripts for certain blockdevices