### PR TITLE
ncm-metaconfig: devicemapper: support (recent) max_sectors_kb option

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/devicemapper/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/devicemapper/pan/schema.pan
@@ -23,6 +23,8 @@ type multipath_types_shared = {
     'rr_weight' ? string
     'no_path_retry' ? string with match(SELF, '^(fail|queue)$') || to_long(SELF) > 0 #  default 0
     'flush_on_last_del' ? boolean # default false
+    @{Set max_sectors_kb on multipath and paths (requires device-mapper-multipath gt 0.4.9-99)}
+    'max_sectors_kb' ? long(0..)
 };
 
 type multipath_types_multipaths_only = {

--- a/ncm-metaconfig/src/main/metaconfig/devicemapper/tests/profiles/multipath.pan
+++ b/ncm-metaconfig/src/main/metaconfig/devicemapper/tests/profiles/multipath.pan
@@ -11,6 +11,7 @@ prefix "/software/components/metaconfig/services/{/etc/multipath.conf}/contents/
 'detect_prio' = true;
 'path_selector' = list('round-robin', 0);
 'features' = list(1, list('queue_if_no_path'));
+'max_sectors_kb' = 1024;
 
 prefix "/software/components/metaconfig/services/{/etc/multipath.conf}/contents";
 "multipaths/0/wwid" = "3600c0ff00012c51bacb68a4e01000000";

--- a/ncm-metaconfig/src/main/metaconfig/devicemapper/tests/regexps/multipath/base
+++ b/ncm-metaconfig/src/main/metaconfig/devicemapper/tests/regexps/multipath/base
@@ -7,6 +7,7 @@ multiline
 ^\s{4}detect_prio yes$
 ^\s{4}failback immediate$
 ^\s{4}features "1 queue_if_no_path"$
+^\s{4}max_sectors_kb 1024$
 ^\s{4}path_checker hp_sw$
 ^\s{4}path_grouping_policy group_by_prio$
 ^\s{4}path_selector "round-robin 0"$


### PR DESCRIPTION
Requires recent devicemapper (see https://rhn.redhat.com/errata/RHEA-2017-1300.html)