### PR TITLE
ncm-mysql: set initOnce to true by default

### DIFF
--- a/ncm-mysql/src/main/pan/components/mysql/schema.pan
+++ b/ncm-mysql/src/main/pan/components/mysql/schema.pan
@@ -72,7 +72,7 @@ type component_mysql_db_options = {
     'server' : string
     'users' ? component_mysql_db_user{}
     'initScript' ? component_mysql_db_script
-    'initOnce' : boolean = false
+    'initOnce' : boolean = true
     'createDb' : boolean = true
     # tableOptions is a dict of table where value is a dict of parameter/value pairs.
     # If the parameter contains spaces, it must be escaped.

--- a/ncm-mysql/src/main/pan/components/mysql/schema.pan
+++ b/ncm-mysql/src/main/pan/components/mysql/schema.pan
@@ -3,10 +3,7 @@
 # ${author-info}
 
 
-
-
 declaration template components/mysql/schema;
-
 
 include 'quattor/schema';
 
@@ -14,15 +11,15 @@ include 'quattor/schema';
 function component_mysql_valid = {
     function_name = 'component_mysql_valid';
     if ( ARGC != 1 ) {
-        error(function_name+': this function requires 1 argument');
+        error(function_name + ': this function requires 1 argument');
     };
 
 
     conf = SELF;
     if ( exists(conf['databases']) && is_defined(conf['databases']) ) {
-        foreach (db;params;conf['databases']) {
+        foreach (db; params; conf['databases']) {
             if ( !exists(conf['servers'][params['server']]) || !is_defined(conf['servers'][params['server']]) ) {
-                error('Database '+db+' uses server '+params['server']+' but this server is not defined');
+                error('Database ' + db + ' uses server ' + params['server'] + ' but this server is not defined');
             };
         };
     };
@@ -52,7 +49,10 @@ function component_mysql_password_valid = {
 };
 
 
-type component_mysql_user_right = string with match(SELF, '^(ALL( PRIVILEGES)?|ALTER( ROUTINE)?|CREATE( (ROUTINE|TEMPORARY TABLES|USER|VIEW))?|DELETE|DROP|EVENT|EXECUTE|FILE|GRANT OPTION|INDEX|INSERT|LOCK TABLES|PROCESS|REFERENCES|RELOAD|REPLICATION (CLIENT|SLAVE)|SELECT|SHOW (DATABASES|VIEW)|SHUTDOWN|SUPER|TRIGGER|UPDATE|USAGE)$');
+type component_mysql_user_right = string with match(SELF, '^(ALL( PRIVILEGES)?|ALTER( ROUTINE)?|' +
+    'CREATE( (ROUTINE|TEMPORARY TABLES|USER|VIEW))?|DELETE|DROP|EVENT|EXECUTE|FILE|GRANT OPTION|INDEX|INSERT|' +
+    'LOCK TABLES|PROCESS|REFERENCES|RELOAD|REPLICATION (CLIENT|SLAVE)|SELECT|SHOW (DATABASES|VIEW)|SHUTDOWN|' +
+    'SUPER|TRIGGER|UPDATE|USAGE)$');
 
 
 type component_mysql_db_user = {


### PR DESCRIPTION
I ran into a (luckily test) server dropping and recreating the database everytime ncm-mysql ran because this is set to false.

I do believe the use case of recreating every time is less likely than setting it up once. So setting it to true is more "what somebody would expect" IMHO. 