### PR TITLE
ncm-metaconfig: kibana: configuration location is now under /etc

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/kibana/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/kibana/pan/config.pan
@@ -2,9 +2,9 @@ unique template metaconfig/kibana/config;
 
 include 'metaconfig/kibana/schema';
 
-bind "/software/components/metaconfig/services/{/opt/kibana/config/kibana.yml}/contents" = kibana_service;
+bind "/software/components/metaconfig/services/{/etc/kibana/kibana.yml}/contents" = kibana_service;
 
-prefix "/software/components/metaconfig/services/{/opt/kibana/config/kibana.yml}";
+prefix "/software/components/metaconfig/services/{/etc/kibana/kibana.yml}";
 "daemons/kibana" = "restart";
 "module" = "yaml";
 "mode" = 0644;

--- a/ncm-metaconfig/src/main/metaconfig/kibana/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/kibana/tests/profiles/config.pan
@@ -2,5 +2,5 @@ object template config;
 
 include 'metaconfig/kibana/config';
 
-prefix "/software/components/metaconfig/services/{/opt/kibana/config/kibana.yml}/contents";
+prefix "/software/components/metaconfig/services/{/etc/kibana/kibana.yml}/contents";
 "elasticsearch_url" = format("http://%s:9200", "mysupersecret.host.domain");

--- a/ncm-metaconfig/src/main/metaconfig/kibana/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/kibana/tests/regexps/config/base
@@ -1,6 +1,6 @@
 Base test for config
 ---
-/opt/kibana/config/kibana.yml
+/etc/kibana/kibana.yml
 ---
 ^---$
 ^bundled_plugin_ids:$


### PR DESCRIPTION
Since kibana 5.0 release, kibana configuration from the rpm package is under /etc

Partial fix of #997