### PR TITLE
WIP ncm-metaconfig: support for logstash yml

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_5.0.pan
@@ -10,3 +10,5 @@ prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.
 "group" = "root";
 "mode" = 0644;
 "module" = format("logstash/%s/main" , METACONFIG_LOGSTASH_VERSION);
+
+

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/daemon_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/daemon_5.0.pan
@@ -1,0 +1,13 @@
+unique template metaconfig/logstash/daemon_5.0;
+
+include 'metaconfig/logstash/schema_5.0';
+
+bind "/software/components/metaconfig/services/{/etc/logstash/logstash.yml}/contents" = type_logstash_yml;
+
+prefix "/software/components/metaconfig/services/{/etc/logstash/logstash.yml}";
+"daemons/logstash" = "restart";
+"owner" = "root";
+"group" = "root";
+"mode" = 0644;
+"module" = "yaml";
+

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_5.0.pan
@@ -365,3 +365,60 @@ type type_logstash_forwarder = {
     "network" : type_logstash_forwarder_network
     "files" : type_logstash_forwarder_file[]
 };
+
+type type_logstash_yml_node = {
+    "name" ? string
+};
+
+type type_logstash_yml_pipeline = {
+    "workers" ? long
+    "output.workers" ? long
+    "batch.size" ? long
+    "unsafe_shutdown" ? boolean
+};
+
+type type_logstash_yml_path = {
+    "config" ? string
+    "data" ? string
+    "logs" ? string
+    "plugins" ? string[]
+    "queue" ? string
+};
+
+type type_logstash_yml_config = {
+    "string" ? string
+    "test_and_exit" ? boolean
+    "reload.automatic" ? boolean
+    "reload.interval" ? long
+    "debug" ? boolean
+};
+
+type type_logstash_yml_queue = {
+    "type" ? string
+    "page_capacity" ? string
+    "max_events" ? long
+    "max_bytes" ? long
+    "checkpoint.acks" ? long
+    "checkpoint.writes" ? long
+    "checkpoint.interval" ? long
+};
+
+type type_logstash_yml_http = {
+    "host" ? string
+    "port" ? string
+};
+
+type type_logstash_yml_log = {
+    "level" ? string with match(SELF, "(fatal|error|warn|info|debug|trace)")
+};
+
+type type_logstash_yml = {
+    "node" ? type_logstash_yml_node
+    "pipeline" ? type_logstash_yml_pipeline
+    "path" ? type_logstash_yml_path
+    "config" ? type_logstash_yml_config
+    "queue" ? type_logstash_yml_queue
+    "http" ? type_logstash_yml_http
+    "log" ? type_logstash_yml_log
+};
+


### PR DESCRIPTION
Adding a schema and a bind to it for `/etc/logstash/logstash.yml` to allow configuring the logstash service for logstash >= 5.0.

- This should be rebased on master once #1028 has been merged since it requires the distinction between 1.2, 2.0 and 5.0 logstash services.
- Requires tests
