### PR TITLE
ncm-authconfig: Deprecate unused startstop property

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -248,7 +248,10 @@ type authconfig_component = {
     @{Enable or disable nscd operation.}
     "usecache" ? boolean
     "enableforcelegacy" : boolean = false
-    "startstop" ? boolean
+    "startstop" ? boolean with {
+        deprecated(0, 'The startstop property will be removed from ncm-authconfig in a future release.');
+        true;
+    }
     @{Enable the use of MD5 hashed password.}
     "usemd5" : boolean
     @{dict of authentication methods to enable. Supported

--- a/ncm-authconfig/src/main/perl/authconfig.pm
+++ b/ncm-authconfig/src/main/perl/authconfig.pm
@@ -25,7 +25,6 @@ It will also enable/disable NSCD support on the client.
     "usemd5" = true;
     "useshadow" = true;
     "usecache" = true;
-    "startstop" = true;
 
     prefix "/software/components/authconfig/method/files";
     "enable" = true;


### PR DESCRIPTION
This appears to never have been used and looks like copypasta.

As discussed in #1143.