### PR TITLE
ncm-syslog: Expand facility regex to allow comma seperated lists

### DIFF
--- a/ncm-syslog/src/main/pan/components/syslog/schema.pan
+++ b/ncm-syslog/src/main/pan/components/syslog/schema.pan
@@ -3,10 +3,12 @@ ${componentschema}
 include 'quattor/types/component';
 
 type component_syslog_selector_type = {
-    "facility" : string with match (SELF, '^(\*|auth|authpriv|cron|daemon|kern|'+
-                    'lpr|mail|mark|news|security|syslog|user|uucp|local[0-7])$')
-    "priority" : string with match (SELF, '^(\*|debug|info|notice|none|warning|'+
-                    'warn|err|error|crit|alert|emerg|panic)$')
+    "facility" : string with match(SELF,
+        '^(?:(\*|auth|authpriv|cron|daemon|kern|lpr|mail|mark|news|security|syslog|user|uucp|local[0-7])(,|$))+$'
+    )
+    "priority" : string with match(SELF,
+        '^(\*|debug|info|notice|none|warning|warn|err|error|crit|alert|emerg|panic)$'
+    )
 };
 
 type component_syslog_legacy_rule = {

--- a/ncm-syslog/src/test/perl/configure.t
+++ b/ncm-syslog/src/test/perl/configure.t
@@ -43,6 +43,7 @@ random stuff
 *.* other action
 user.crit\tawesome
 mail.debug\tawesome
+uucp,news.crit\t/var/log/spooler
 EOF
 
 set_file_contents($edit_fn, $edit_orig);
@@ -75,6 +76,7 @@ directive three                          # ncm-syslog
 
 # already wrapped
 user.crit;mail.debug\tawesome
+uucp,news.crit\t/var/log/spooler
 EOF
 
 set_file_contents($render_fn, $render_orig);

--- a/ncm-syslog/src/test/resources/basic.pan
+++ b/ncm-syslog/src/test/resources/basic.pan
@@ -28,3 +28,13 @@ prefix "/software/components/syslog";
         dict("facility", 'mail', "priority", 'debug')),
     "action", 'awesome',
     "comment", "\n# already wrapped\n"));
+
+"config" = append(dict(
+    'selector', list(
+        dict(
+            'facility', 'uucp,news',
+            'priority', 'crit',
+        ),
+    ),
+    'action', '/var/log/spooler',
+));


### PR DESCRIPTION
Fixes problem reported in 17.7.0-rc1 (quattor/release#300).