### PR TITLE
Escape / unescape functions from CCM::Path

### DIFF
--- a/ncm-amandaserver/src/main/perl/amandaserver.pm
+++ b/ncm-amandaserver/src/main/perl/amandaserver.pm
@@ -1,30 +1,10 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-# File: amandaserver.pm
 # Implementation of ncm-amandaserver
 # Author: Laura del Caño Novales <laura.delcano@ft.uam.es>
-# Version: 2.1.0 : 03/04/09 12:39
-#  ** Generated file : do not edit **
-#
-# Note: all methods in this component are called in a
-# $self->$method ($config) way, unless explicitly stated.
 
-package NCM::Component::amandaserver;
-
-#
-# a few standard statements, mandatory for all components
-#
-
-use strict;
-use warnings;
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-
-use EDG::WP4::CCM::Element;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
 use CAF::Process;
 use CAF::FileWriter;

--- a/ncm-chkconfig/src/main/perl/chkconfig.pm
+++ b/ncm-chkconfig/src/main/perl/chkconfig.pm
@@ -1,12 +1,12 @@
-#${PMpre} NCM::Component::chkconfig${PMpost}
+#${PMcomponent}
 
 use parent qw(NCM::Component);
 
 our $EC = LC::Exception::Context->new->will_store_all;
 
-$NCM::Component::chkconfig::NoActionSupported = 1;
+our $NoActionSupported = 1;
 
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw(unescape);
 use CAF::Process;
 use Readonly;
 

--- a/ncm-cups/src/main/perl/cups.pm
+++ b/ncm-cups/src/main/perl/cups.pm
@@ -1,7 +1,4 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-
+#${PMcomponent}
 #
 # NCM cups component
 #
@@ -27,18 +24,8 @@
 #
 ################################################################################
 
-package NCM::Component::cups;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-
-our @ISA = qw(NCM::Component);
+use parent qw(NCM::Component);
 our $EC  = LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-
-use EDG::WP4::CCM::Element;
 
 use LC::File qw(file_contents);
 use LC::Check;

--- a/ncm-dirperm/src/main/perl/dirperm.pm
+++ b/ncm-dirperm/src/main/perl/dirperm.pm
@@ -1,18 +1,7 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-
-package NCM::Component::dirperm;
-
-use strict;
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-
-use EDG::WP4::CCM::Element;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
 use CAF::FileEditor;
 use File::Path;
@@ -25,9 +14,8 @@ use constant MTAB_PATH => "/etc/mtab";
 my @configured_mounts;
 my %available_mounts;
 
-##########################################################################
-sub Configure() {
-##########################################################################
+sub Configure
+{
 
     my ($self, $config) = @_;
 

--- a/ncm-filecopy/src/main/perl/filecopy.pm
+++ b/ncm-filecopy/src/main/perl/filecopy.pm
@@ -1,20 +1,10 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
+use LC::Check;
 
-package NCM::Component::filecopy;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC  = LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw(unescape);
 
 use File::Basename;
 use File::Path;

--- a/ncm-ganglia/src/main/perl/ganglia.pm
+++ b/ncm-ganglia/src/main/perl/ganglia.pm
@@ -1,20 +1,12 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
+#${PMcomponent}
 
-package NCM::Component::ganglia;
-
-use strict;
-use warnings;
-
-use base qw(NCM::Component);
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
 use LC::Exception;
 use LC::Find;
 use LC::File qw(copy makedir);
 
-use EDG::WP4::CCM::Element;
 use CAF::FileWriter;
 use CAF::FileEditor;
 use CAF::Process;
@@ -23,8 +15,6 @@ use File::Path;
 
 use Readonly;
 Readonly::Scalar my $PATH => '/software/components/ganglia';
-
-our $EC=LC::Exception::Context->new->will_store_all;
 
 my $header = '####
 #
@@ -64,7 +54,7 @@ sub Configure {
 
    $client_contents =  configureClient($t->{client});
    $client_file     = $t->{client}->{config_file};
-   
+
    if ( $daemon_file ne '' ) {
 	my $daemon = LC::Check::file(
 		"$daemon_file",
@@ -237,10 +227,10 @@ sub configureClient {
    $contents .= "    ip = ".$i->{ip}."\n";
    $contents .= "    mask = ".$i->{mask}."\n";
    $contents .= "    action = \"".$i->{action}."\"\n";
-   $contents .= "   }\n"; 
+   $contents .= "   }\n";
   }
   $contents .= "  }\n";
- } 
+ }
  $contents .= "}\n\n";
 
  #
@@ -341,7 +331,7 @@ sub configureClient {
    }
    $contents .=  " }\n";
   }
-  $contents .= "}\n\n"; 
+  $contents .= "}\n\n";
  }
 
  return $contents;

--- a/ncm-hostsaccess/src/main/perl/hostsaccess.pm
+++ b/ncm-hostsaccess/src/main/perl/hostsaccess.pm
@@ -1,21 +1,8 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-
-package NCM::Component::hostsaccess;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 use File::Copy;
-
-use EDG::WP4::CCM::Element;
 
 sub Configure
 {

--- a/ncm-icinga/src/main/perl/icinga.pm
+++ b/ncm-icinga/src/main/perl/icinga.pm
@@ -1,33 +1,15 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
-
-#
-# Note: all methods in this component are called in a
-# $self->$method ($config) way, unless explicitly stated.
-
-# Note in style: all methods return their file handle object, even if
-# it will be discarded (and thus closed). This way, it's possible to
-# write tests that verify the in-memory contents of the files, and
-# running them without any special privileges.
-
-package NCM::Component::icinga;
+#${PMcomponent}
 
 use 5.10.1;
-use strict;
-use warnings;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all();
 
-use NCM::Component;
-use EDG::WP4::CCM::Element qw (unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw (unescape);
 use Socket;
 use CAF::Process;
 use CAF::FileWriter;
 use LC::Exception qw (throw_error);
 use File::Path;
-
-our @ISA = qw (NCM::Component);
-our $EC  = LC::Exception::Context->new->will_store_all();
 
 use constant ICINGA_FILES => {
     general             => '/etc/icinga/icinga.cfg',

--- a/ncm-ipmi/src/main/perl/ipmi.pm
+++ b/ncm-ipmi/src/main/perl/ipmi.pm
@@ -1,30 +1,13 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
-package NCM::Component::ipmi;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
 use File::Copy;
 use CAF::Process;
-use EDG::WP4::CCM::Element;
-
-use LC::Check;
-
-use Encode qw(encode_utf8);
 
 use constant IPMI_EXEC => "/usr/bin/ipmitool";
 use constant BASEPATH => "/software/components/ipmi/";
-
-use EDG::WP4::CCM::Element;
 
 sub Configure
 {

--- a/ncm-ldconf/src/main/perl/ldconf.pm
+++ b/ncm-ldconf/src/main/perl/ldconf.pm
@@ -1,21 +1,8 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-
-package NCM::Component::ldconf;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-
-use EDG::WP4::CCM::Element;
-
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
+use LC::Check;
 use File::Basename;
 
 my $ldconfig_config_dir = '/etc/ld.so.conf.d';

--- a/ncm-mysql/src/main/perl/mysql.pm
+++ b/ncm-mysql/src/main/perl/mysql.pm
@@ -1,19 +1,9 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
-package NCM::Component::mysql;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw(unescape);
 
 use CAF::FileEditor;
 use CAF::FileWriter;

--- a/ncm-named/src/main/perl/named.pm
+++ b/ncm-named/src/main/perl/named.pm
@@ -1,31 +1,16 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-package NCM::Component::named;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-require Exporter;
-our @ISA = qw(NCM::Component Exporter);
-$EC=LC::Exception::Context->new->will_store_all;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 use Readonly;
-use NCM::Check;
 use Encode qw(encode_utf8);
 
-use EDG::WP4::CCM::Element;
 use CAF::FileEditor qw(ENDING_OF_FILE);
 use CAF::FileWriter;
 use CAF::Process;
 use CAF::Service;
 
 our $NoActionSupported = 1;
-
-# To ease testing
-our @EXPORT = qw($NAMED_CONFIG_FILE $NAMED_SYSCONFIG_FILE $RESOLVER_CONF_FILE);
 
 # Define paths for convenience.
 Readonly our $NAMED_CONFIG_FILE => '/etc/named.conf';

--- a/ncm-named/src/test/perl/configure.t
+++ b/ncm-named/src/test/perl/configure.t
@@ -9,6 +9,10 @@ use Readonly;
 use CAF::Object;
 Test::NoWarnings::clear_warnings();
 
+my $NAMED_CONFIG_FILE = $NCM::Component::named::NAMED_CONFIG_FILE;
+my $NAMED_SYSCONFIG_FILE = $NCM::Component::named::NAMED_SYSCONFIG_FILE;
+my $RESOLVER_CONF_FILE = $NCM::Component::named::RESOLVER_CONF_FILE;
+
 
 # $RESOLV_CONF_CONTENTS_1 is the expected file.
 # Comments are preceded by 2 tabs.

--- a/ncm-named/src/test/perl/get_named_root_dir.t
+++ b/ncm-named/src/test/perl/get_named_root_dir.t
@@ -9,6 +9,11 @@ use Readonly;
 use CAF::Object;
 Test::NoWarnings::clear_warnings();
 
+my $NAMED_CONFIG_FILE = $NCM::Component::named::NAMED_CONFIG_FILE;
+my $NAMED_SYSCONFIG_FILE = $NCM::Component::named::NAMED_SYSCONFIG_FILE;
+my $RESOLVER_CONF_FILE = $NCM::Component::named::RESOLVER_CONF_FILE;
+
+
 # This is the content of the default file on SL6 (with single quote removed in the text)
 use constant TEST_SYSCONFIG_HEADER => '# BIND named process options
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ncm-openldap/src/main/perl/openldap.pm
+++ b/ncm-openldap/src/main/perl/openldap.pm
@@ -1,24 +1,14 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-package NCM::Component::openldap;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
 use CAF::FileWriter;
 use CAF::Process;
 use File::Path;
 use File::Basename;
 use File::Copy;
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw(unescape);
 use Encode qw(encode_utf8);
 
 use constant SLAPTEST => qw(/usr/sbin/slaptest -v -u -f);

--- a/ncm-pam/src/main/perl/pam.pm
+++ b/ncm-pam/src/main/perl/pam.pm
@@ -1,38 +1,15 @@
-# ex: set expandtab softtabstop=4 shiftwidth=4: -*- cperl-indent-level: 4; indent-tabs-mode: nil -*-
+#${PMcomponent}
 
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-
-#########################################################################
-# Coding style: emulate <TAB> characters with 4 spaces, thanks!
-#########################################################################
-#
-# Component to configure PAM
-#
-#########################################################################
-
-package NCM::Component::pam;
-
-#
-# a few standard statements, mandatory for all components
-#
-
-use strict;
-use warnings;
-
-#use NCM::Component;
-use base qw(NCM::Component);
+use parent qw(NCM::Component);
 our $EC = LC::Exception::Context->new->will_store_all;
 our $NoActionSupported = 1;
 
 use CAF::FileWriter;
-use EDG::WP4::CCM::Element qw(BOOLEAN);
+use EDG::WP4::CCM::CacheManager::Encode 17.3.0 qw(BOOLEAN);
 
-##########################################################################
-sub Configure {
-##########################################################################
-  my ($self,$config)=@_;
+sub Configure
+{
+  my ($self, $config) = @_;
   my $prefix = "/software/components/pam";
   # Now do something...
   if (!$config->elementExists("$prefix")) {

--- a/ncm-pnp4nagios/src/main/perl/pnp4nagios.pm
+++ b/ncm-pnp4nagios/src/main/perl/pnp4nagios.pm
@@ -1,52 +1,36 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-# File: pnp4nagios.pm
+#
 # Implementation of ncm-pnp4nagios
 # Author: Laura del Cano Novales <laura.delcano@uam.es>
-# Version: 2.1.0 : 03/04/09 14:39
-#  ** Generated file : do not edit **
 #
-# Note: all methods in this component are called in a
-# $self->$method ($config) way, unless explicitly stated.
 
-# Note in style: all methods return their file handle object, even if
-# it will be discarded (and thus closed). This way, it's possible to
-# write tests that verify the in-memory contents of the files, and
-# running them without any special privileges.
-
-package NCM::Component::pnp4nagios;
-
-use strict;
-use warnings;
-use NCM::Component ;
-use EDG::WP4::CCM::Element qw (unescape);
 use Socket;
 use CAF::Process;
 use CAF::FileWriter;
 use LC::Exception qw (throw_error);
 use File::Path;
 
-our @ISA = qw (NCM::Component);
+use parent qw(NCM::Component);
 our $EC = LC::Exception::Context->new->will_store_all();
 
-use constant PNP4NAGIOS_FILES => { nagios	=>  '/etc/pnp4nagios/nagios.cfg',
-			       				   php      =>  '/etc/pnp4nagios/config.php',
-			       				   npcd	    =>  '/etc/pnp4nagios/npcd.cfg',
-			       				   perfdata	=>  '/etc/pnp4nagios/process_perfdata.cfg',
-			     };
-			     
+use constant PNP4NAGIOS_FILES => {
+    nagios => '/etc/pnp4nagios/nagios.cfg',
+    php => '/etc/pnp4nagios/config.php',
+    npcd => '/etc/pnp4nagios/npcd.cfg',
+    perfdata => '/etc/pnp4nagios/process_perfdata.cfg',
+};
+
 use constant BASEPATH => "/software/components/pnp4nagios/";
-			     
+
 my $PNP4NAGIOS_USR;
 my $PNP4NAGIOS_GRP;
 
-#thank you npcd for requiring a correctly ordened config file
-use constant NPCD_OPTIONS => qw(user group log_type log_file max_logfile_size log_level 
+# thank you npcd for requiring a correctly ordened config file
+use constant NPCD_OPTIONS => qw(user group log_type log_file max_logfile_size log_level
 						perfdata_spool_dir perfdata_file_run_cmd perfdata_file_run_cmd_args identify_npcd npcd_max_threads
  						sleep_time load_threshold pid_file perfdata_file perfdata_spool_filename perfdata_file_processing_interval);
-			     
+
 
 # Prints all settings for nagios
 sub print_nagios
@@ -81,13 +65,13 @@ sub print_npcd
 				    mode => 0444);
 
 	foreach my $something (NPCD_OPTIONS) {
-	
+
 		my $val = $t -> {$something};
 		print $fh "$something = $val\n";
 
 	}
 	print $fh "\n";
-	
+
     return $fh;
 }
 
@@ -122,7 +106,7 @@ sub print_php
 				    group => $PNP4NAGIOS_GRP,
 				    log => $self,
 				    mode => 0444);
-				    
+
 	print $fh "<\?php\n";
 
     while (my ($opt, $val) = each (%$t)) {
@@ -133,14 +117,14 @@ sub print_php
     		} else {
     			print $fh "\$conf['$opt']=FALSE;\n";
     		}
-    		
+
     	} else {
     		#write views
     		if ( $opt eq "views"){
             	foreach my $it (@$val) {
                 	print $fh "\$views[]= array('title' => '$it->{title}', 'start' => ($it->{start}) );\n";
                 }
-    			
+
     		} else {
 	            #write template_dirs
                 if ( $opt eq "template_dirs"){
@@ -149,15 +133,15 @@ sub print_php
         	       }
 
     			} else {
-    			
+
     				if ( $opt eq "rrd_daemon_opts"){
     					print $fh "\$conf['".uc($opt)."']=\"$val\";\n";
-    					
-    				} else {    			
+
+    				} else {
 	    				#Don't quote a number
 						if ( $val =~ /^[+-]?\d+$/ ) {
 							print $fh "\$conf['$opt']=$val;\n";
-							
+
 						#Write the rest
 						} else {
 		    				print $fh "\$conf['$opt']=\"$val\";\n";
@@ -167,12 +151,12 @@ sub print_php
 			}
 		}
     }
-    
+
     print $fh "?\>\n";
-    
+
     return $fh;
 }
-	     
+
 # Restarts the npcd daemon if needed.
 sub restart_npcd
 {
@@ -183,7 +167,7 @@ sub restart_npcd
     $cmd->run();
     return $cmd;
 }
-			     
+
 # Configure method. Writes all the configuration files and starts or
 # reloads the npcd service
 sub Configure
@@ -199,7 +183,7 @@ sub Configure
     $self->print_php ($t->{php});
     $self->print_perfdata ($t->{perfdata});
 	$self->print_npcd ($t->{npcd});
-	
+
     $self->restart_npcd();
 
     return !$?;

--- a/ncm-postfix/src/main/perl/postfix.pm
+++ b/ncm-postfix/src/main/perl/postfix.pm
@@ -1,12 +1,11 @@
-#${PMpre} NCM::Component::postfix${PMpost}
+#${PMcomponent}
 
-use base qw(NCM::Component);
+use parent qw(NCM::Component);
 
 use LC::Exception;
 use LC::Find;
 use LC::File qw(copy makedir);
 
-use EDG::WP4::CCM::Element;
 use EDG::WP4::CCM::TextRender;
 use CAF::FileWriter;
 use CAF::FileEditor;

--- a/ncm-postgresql/src/main/perl/postgresql.pm
+++ b/ncm-postgresql/src/main/perl/postgresql.pm
@@ -1,11 +1,4 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-
-package NCM::Component::postgresql;
-
-use strict;
-use warnings;
+#${PMcomponent}
 
 use parent qw(NCM::Component);
 
@@ -15,8 +8,6 @@ use NCM::Component::Postgresql::Commands;
 use LC::Exception qw(SUCCESS);
 our $EC = LC::Exception::Context->new->will_store_all;
 use CAF::Object;
-
-use EDG::WP4::CCM::Element;
 
 use POSIX qw(strftime);
 use Digest::MD5 qw(md5_hex);

--- a/ncm-postgresql/src/test/perl/configure.t
+++ b/ncm-postgresql/src/test/perl/configure.t
@@ -15,8 +15,6 @@ my $caf_trd = mock_textrender();
 
 # service variant set to linux_sysv
 
-set_caf_file_close_diff(1);
-
 my $cmp = NCM::Component::postgresql->new("postgresql");
 my $cfg = get_config_for_profile('configure');
 

--- a/ncm-postgresql/src/test/perl/iam.t
+++ b/ncm-postgresql/src/test/perl/iam.t
@@ -14,8 +14,6 @@ my $caf_trd = mock_textrender();
 
 # service variant set to linux_sysv
 
-set_caf_file_close_diff(1);
-
 my $cmp = NCM::Component::postgresql->new("postgresql");
 my $cfg = get_config_for_profile('iam');
 

--- a/ncm-profile/src/main/perl/profile.pm
+++ b/ncm-profile/src/main/perl/profile.pm
@@ -1,21 +1,9 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
-package NCM::Component::profile;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-use File::Copy;
-
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw(unescape);
 
 use File::Path;
 use File::Basename;

--- a/ncm-puppet/src/main/perl/puppet.pm
+++ b/ncm-puppet/src/main/perl/puppet.pm
@@ -1,19 +1,9 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
+#${PMcomponent}
 
-package NCM::Component::${project.artifactId};
+use parent qw(NCM::Component);
+our $EC  = LC::Exception::Context->new->will_store_all;
 
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-use base qw(NCM::Component);
-$EC  = LC::Exception::Context->new->will_store_all;
-
-use EDG::WP4::CCM::Element qw(unescape);
+use EDG::WP4::CCM::Path 16.8.0 qw(unescape);
 
 use CAF::Process;
 use CAF::FileWriter;

--- a/ncm-symlink/src/main/perl/symlink.pm
+++ b/ncm-symlink/src/main/perl/symlink.pm
@@ -1,19 +1,7 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-package NCM::Component::symlink;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-
-use EDG::WP4::CCM::Element;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
 use File::Path;
 use File::Copy;

--- a/ncm-sysconfig/src/main/perl/sysconfig.pm
+++ b/ncm-sysconfig/src/main/perl/sysconfig.pm
@@ -1,20 +1,7 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
-
-package NCM::Component::sysconfig;
-
-use strict;
-use warnings;
-
-use NCM::Component;
-use vars qw(@ISA $EC);
-@ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-use NCM::Check;
-
-use EDG::WP4::CCM::Element;
+use parent qw(NCM::Component);
+our $EC = LC::Exception::Context->new->will_store_all;
 
 use LC::Check;
 

--- a/ncm-sysctl/src/main/perl/sysctl.pm
+++ b/ncm-sysctl/src/main/perl/sysctl.pm
@@ -1,6 +1,4 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
+#${PMcomponent}
 
 #######################################################################
 #
@@ -13,20 +11,13 @@
 #
 #######################################################################
 
-package NCM::Component::sysctl;
-#
-# a few standard statements, mandatory for all components
-#
-use strict;
-use NCM::Component;
-our @ISA = qw(NCM::Component);
+use parent qw(NCM::Component);
 use LC::Exception qw(throw_error);
-our $EC=LC::Exception::Context->new->will_store_all;
+our $EC = LC::Exception::Context->new->will_store_all;
 our $NoActionSupported = 1;
 
 use CAF::FileWriter;
 use CAF::Process;
-use EDG::WP4::CCM::Element;
 use NCM::Check;
 
 sub Configure

--- a/ncm-sysctl/src/test/perl/configure.t
+++ b/ncm-sysctl/src/test/perl/configure.t
@@ -25,9 +25,6 @@ my $cmp = NCM::Component::sysctl->new('sysctl');
 my $cfg = get_config_for_profile('simple');
 my $testfile = "/etc/sysctl.d/50-quattor.conf";
 my $testcmd = "/sbin/sysctl -e -p $testfile";
-# XX: remove this once CAF::FileWriter::close() has been updated not to
-# return undef when running in NoAction mode (CAF#72)
-set_caf_file_close_diff(1);
 
 is($cmp->Configure($cfg), 1, "Configure succeeds");
 my $fh = get_file($testfile);


### PR DESCRIPTION
Fixes #1083 

(except for deprecated `directoryserver` and `mcx`; and `cron`, `metaconfig` and `network` that have existing cleanup PRs)
