### PR TITLE
ncm-syslog: Start with an empty list in edit mode

### DIFF
--- a/ncm-syslog/src/main/perl/syslog.pm
+++ b/ncm-syslog/src/main/perl/syslog.pm
@@ -116,7 +116,7 @@ sub edit
 
     my %directive_found;
 
-    my @syslogcontents = ("");
+    my @syslogcontents = ();
 
     # old style, we accept entries from other sources in syslog.conf
     $self->debug(2, "edit: fullcontrol is not defined or false");

--- a/ncm-syslog/src/test/perl/configure.t
+++ b/ncm-syslog/src/test/perl/configure.t
@@ -32,7 +32,6 @@ EOF
 my $edit_new = <<EOF;
 directive one                            # ncm-syslog
 directive three                          # ncm-syslog
-
 # comment
 random stuff
 *.* super*powers


### PR DESCRIPTION
This fixes the proliferation of blank lines seen in quattor/release#301
