### PR TITLE
ncm-systemd: fix typo in test description

### DIFF
--- a/ncm-systemd/src/main/resources/custom/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/custom/tests/regexps/unitfile0/value
@@ -1,4 +1,4 @@
-Test uniffile configuration generation 0
+Test unitfile configuration generation 0
 ---
 //
 rendermodule=unitfile

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -1,4 +1,4 @@
-Test uniffile configuration generation 0
+Test unitfile configuration generation 0
 ---
 //
 rendermodule=unitfile


### PR DESCRIPTION
Just another typo that bothered me.

uniffile → unitfile