### PR TITLE
ncm-authconfig: Remove deprecated startstop property

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -248,10 +248,6 @@ type authconfig_component = {
     @{Enable or disable nscd operation.}
     "usecache" ? boolean
     "enableforcelegacy" : boolean = false
-    "startstop" ? boolean with {
-        deprecated(0, 'The startstop property will be removed from ncm-authconfig in a future release.');
-        true;
-    }
     @{Enable the use of MD5 hashed password.}
     "usemd5" : boolean
     @{dict of authentication methods to enable. Supported


### PR DESCRIPTION
The property served no purpose and was deprecated in c5be6d26aa802584b0ecaedcea4d5e99b247f9d7,
this completes the cleanup and removal.

Fixes #1145 (which in turn resolves #1143).