### PR TITLE
ncm-accounts: is_user_or_group function can be used without component

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/functions.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/functions.pan
@@ -42,6 +42,11 @@ function is_user_or_group = {
         );
     };
     pref = "/software/components/accounts";
+    # not all sites use ncm-accounts, e.g. users and groups may be provisioned
+    # via LDAP instead so return now we've confirmed it is a string
+    if (!path_exists(pref)) {
+        return(true);
+    };
 
     name_exists = true;
     while(idx < length(names)) {


### PR DESCRIPTION
The is_user_or_group() function needs to take into account that some
sites use mechanisms other than ncm-accounts to provision users and
groups. Following the pattern introduced into ncm-ccm, allow the
function to be called but always return true if the
/software/components/accounts tree is not present.

Fixes #1166