### PR TITLE
ncm-accounts: Fix annotations and whitespace lint

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/functions.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/functions.pan
@@ -38,7 +38,7 @@ function is_user_or_group = {
         error(
             "2nd argument is either a list (list of names) or " +
             "a string (2nd and other arguments as list of names), " +
-            " got "+to_string(ARGV)
+            " got " + to_string(ARGV)
         );
     };
     pref = "/software/components/accounts";
@@ -204,7 +204,7 @@ function create_accounts_from_db = {
         account_list = undef;
     };
 
-    if ( ARGC >=3 && (ARGV[2] == 1) ) {
+    if ( ARGC >= 3 && (ARGV[2] == 1) ) {
         accountType = 'group';
     } else {
         accountType = 'user';
@@ -268,7 +268,7 @@ function keep_user_group = {
         ARGV[0] = list(tmp);
     };
 
-    foreach (i;v;ARGV[0]) {
+    foreach (i; v; ARGV[0]) {
         SELF[v] = '';
     };
 

--- a/ncm-accounts/src/main/pan/components/accounts/functions.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/functions.pan
@@ -17,12 +17,12 @@ variable ACCOUNTS_GROUP_COMMENT ?= 'Created by ncm-accounts';
     descr = Test if (list of) user(s) or group(s) is defined in either users/groups or kept_users/groups.
     arg = the type ('user' or 'group')
     arg = the name(s). Can be more than one argument or a single list of names. All arguments have to be defined.
-};
+}
 @example{
     is_user_or_group("user", "root", "nagios", "foo", "bar")
     or 2nd element is a list of name(s)
     is_user_or_group("user", list("root", "nagios", "foo", "bar"))
-};
+}
 function is_user_or_group = {
     if ((ARGC < 2) || ! (ARGV[0] == 'user' || ARGV[0] == 'group')) {
         error("is_user_or_group expects at least 2 arguments : first the type (user or group)");


### PR DESCRIPTION
* Allow `is_user_or_group` function to be annotated   
    The annotation parser does not allow for anything other than whitespace
    between a set of annotation blocks and the item being annotated. The
    semicolons here were preventing the annotation from being associated with
    the function and were effectively "stealing" the annotations.
* Fix whitespace lint around operators and semicolons