### PR TITLE
ncm-accounts: add colord to protected user/group list

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/sysgroups.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/sysgroups.pan
@@ -98,4 +98,5 @@ unique template components/accounts/sysgroups;
     'mongodb', '',
     'rabbitmq', '',
     'memcached', '',
+    'colord', "",
 );

--- a/ncm-accounts/src/main/pan/components/accounts/sysusers.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/sysusers.pan
@@ -94,4 +94,5 @@ unique template components/accounts/sysusers;
     'mongodb', '',
     'rabbitmq', '',
     'memcached', '',
+    'colord', "",
 );


### PR DESCRIPTION
`colord` (standard) package creates a `colord` user and group that are not protected in `ncm-accounts`. Hence, they are removed by the first run of `ncm-accounts` after the package installation.