### PR TITLE
ncm-metaconfig: ganesha: make exports usable for ces

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/ganesha/2.2/main.tt
+++ b/ncm-metaconfig/src/main/metaconfig/ganesha/2.2/main.tt
@@ -1,3 +1,4 @@
+[%- block_order = ["CLIENT", "FSAL"] -%]
 [% FOREACH section IN main %]
 [%      section.key %] {
 [%      FOREACH pair IN section.value.pairs -%]
@@ -9,7 +10,18 @@
 [%- FOREACH export IN exports %]
 EXPORT {
 [%      FOREACH pair IN export.pairs -%]
-[%-         INCLUDE "metaconfig/ganesha/2.2/attribute.tt" FILTER indent %]
+[%-         SWITCH pair.key -%] 
+[%-             CASE block_order -%]
+[%-             CASE -%]
+[%-                 INCLUDE "metaconfig/ganesha/2.2/attribute.tt" FILTER indent %]
+[%         END -%]
 [%      END -%]
+[%      FOREACH pair IN export.pairs -%]
+[%-         SWITCH pair.key -%] 
+[%-             CASE block_order -%]
+[%-                 INCLUDE "metaconfig/ganesha/2.2/attribute.tt" FILTER indent %]
+[%-             CASE -%]
+[%         END -%]
+[%      END %]
 }
 [% END %]

--- a/ncm-metaconfig/src/main/metaconfig/ganesha/2.2/tests/regexps/config2/export
+++ b/ncm-metaconfig/src/main/metaconfig/ganesha/2.2/tests/regexps/config2/export
@@ -3,6 +3,14 @@ Tests for export config
 /etc/ganesha/ganesha.conf
 ---
 ^EXPORT \{$
+^\s{4}Export_id = 76;$
+^\s{4}Filesystem_id = 192.168;$
+^\s{4}NFS_Commit = TRUE;$
+^\s{4}Path = "/gpfs/scratchtest/home/gent";$
+^\s{4}Protocols = 4;$
+^\s{4}Pseudo = "/user/home/gent";$
+^\s{4}Tag = "home";$
+^\s{4}Transports = TCP;$
 ^\s{4}CLIENT \{ $
 ^\s{8}Access_Type = "RW";$
 ^\s{8}Clients = \*.vsc;$
@@ -11,31 +19,13 @@ Tests for export config
 ^\s{4}CLIENT \{ $
 ^\s{8}Clients = \*.domain;$
 ^\s{4}\}$
-^$
-^\s{4}Export_id = 76;$
 ^\s{4}FSAL \{$
 ^\s{8}name = "GPFS";$
 ^\s{4}\}$
-^\s{4}Filesystem_id = 192.168;$
-^\s{4}NFS_Commit = TRUE;$
-^\s{4}Path = "/gpfs/scratchtest/home/gent";$
-^\s{4}Protocols = 4;$
-^\s{4}Pseudo = "/user/home/gent";$
-^\s{4}Tag = "home";$
-^\s{4}Transports = TCP;$
 ^\}$
 ^$
 ^EXPORT \{$
-^\s{4}CLIENT \{ $
-^\s{8}Access_Type = "RW";$
-^\s{8}Clients = \*.vsc;$
-^\s{8}Squash = "root_squash";$
-^\s{4}\}$
-^$
 ^\s{4}Export_id = 77;$
-^\s{4}FSAL \{$
-^\s{8}name = "GPFS";$
-^\s{4}\}$
 ^\s{4}Filesystem_id = 192.168;$
 ^\s{4}NFS_Commit = TRUE;$
 ^\s{4}Path = "/gpfs/scratchtest/data/gent";$
@@ -43,5 +33,14 @@ Tests for export config
 ^\s{4}Pseudo = "/user/data/gent";$
 ^\s{4}Tag = "data";$
 ^\s{4}Transports = TCP;$
+^\s{4}CLIENT \{ $
+^\s{8}Access_Type = "RW";$
+^\s{8}Clients = \*.vsc;$
+^\s{8}Squash = "root_squash";$
+^\s{4}\}$
+^\s{4}FSAL \{$
+^\s{8}name = "GPFS";$
+^\s{4}\}$
 ^\}$
+^$
 


### PR DESCRIPTION
gpfs ces need CLIENT and FSAL blocks last in the export config