### PR TITLE
ncm-network: NoActionSupported

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -80,6 +80,8 @@ use parent qw(NCM::Component CAF::Path);
 
 our $EC = LC::Exception::Context->new->will_store_all;
 
+our $NoActionSupported = 1;
+
 use EDG::WP4::CCM::Fetch qw(NOQUATTOR_EXITCODE);
 
 use Net::Ping;


### PR DESCRIPTION
Only `CAF::` is used, all should be noaction safe
Fixes #1086 