### PR TITLE
ncm-nfs: when no mounts are defined, do not process any mounts

### DIFF
--- a/ncm-nfs/src/main/pan/components/nfs/schema.pan
+++ b/ncm-nfs/src/main/pan/components/nfs/schema.pan
@@ -47,6 +47,10 @@ type ${project.artifactId}_component = {
       If the mounts change, then the component will attempt to unmount any
       mounts which are removed and mount any new ones.  If the options
       change, then the volume will be remounted.
+
+      If the list is empty, all supported mounts in fstab will be removed.
+      If you don't want ncm-nfs to modify /etc/fstab, do not set the mounts
+      attribute at all.
     }
     'mounts' ? structure_nfs_mounts[]
 };

--- a/ncm-nfs/src/main/perl/nfs.pm
+++ b/ncm-nfs/src/main/perl/nfs.pm
@@ -485,7 +485,11 @@ sub Configure
         $self->verbose("Not a NFS server configuration");
     };
 
-    $self->process_mounts($tree);
+    if (exists($tree->{mounts})) {
+        $self->process_mounts($tree);
+    } else {
+        $self->verbose("No mounts exists");
+    };
 
     return 1;
 }

--- a/ncm-nfs/src/test/perl/configure.t
+++ b/ncm-nfs/src/test/perl/configure.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Quattor qw(configure configure_noserver);
+use Test::Quattor qw(configure configure_noserver configure_nomounts);
 use Test::MockModule;
 
 use Test::Quattor::RegexpTest;
@@ -60,6 +60,13 @@ foreach my $change (qw(exports fstab_changed action)){
     is($cmp->Configure($nosrvcfg), 1, "Configure returns 1 (change $change) with server=false");
     ok(command_history_ok(undef, [qr{service nfs reload}]), "no nfs service reload when $change changed with server=false");
 };
+
+# noserver config
+my $nomounts = get_config_for_profile('configure_nomounts');
+command_history_reset();
+$process_mounts_arg = undef;
+is($cmp->Configure($nomounts), 1, "Configure returns 1 without mounts");
+ok(!defined($process_mounts_arg), "no nfs process_mounts without mounts");
 
 
 done_testing();

--- a/ncm-nfs/src/test/resources/configure_nomounts.pan
+++ b/ncm-nfs/src/test/resources/configure_nomounts.pan
@@ -1,0 +1,5 @@
+object template configure_nomounts;
+
+include 'fstab_simple';
+
+"/software/components/nfs/mounts" = null;


### PR DESCRIPTION
Allows ncm-fstab to coexist with nfs server managed by ncm-nfs.