### PR TITLE
ncm-download: kinit: add a possibility to pass arguments

### DIFF
--- a/ncm-download/src/main/pan/components/download/schema.pan
+++ b/ncm-download/src/main/pan/components/download/schema.pan
@@ -63,4 +63,6 @@ type download_component = extensible {
     "head_timeout" ? long
     @{seconds, total timeout for fetch of file, can be overridden per file}
     "timeout" ? long
+    @{argumensts to be passed in kinit -k called in ncm-download}
+    "kinit_args" ? string[]
 };

--- a/ncm-download/src/main/perl/download.pm
+++ b/ncm-download/src/main/perl/download.pm
@@ -64,7 +64,7 @@ my $_cached_gss;
 
 sub get_gss_token
 {
-    my $self = shift;
+    my ($self, $tree) = @_;
 
     # Return module wide cache value
     return $_cached_gss if $_cached_gss;
@@ -80,7 +80,9 @@ sub get_gss_token
 
     # Assume "kinit" is in the PATH.
     my $errs = "";
-    my $proc = CAF::Process->new(["kinit", "-k"],
+    my @kinit_cmd = ("kinit", "-k");
+    push(@kinit_cmd, @{$tree->{kinit_args}}) if ($tree->{kinit_args});
+    my $proc = CAF::Process->new(\@kinit_cmd,
                                  stderr => \$errs,
                                  log => $self,
                                  keeps_state => 1);
@@ -122,7 +124,7 @@ sub Configure
         $file->{head_timeout} = $tree->{head_timeout};
 
         if ($file->{gssapi}) {
-            $file->{gss_ccache} = $self->get_gss_token();
+            $file->{gss_ccache} = $self->get_gss_token($tree);
             # immediate failure
             return 0 if ! $file->{gss_ccache};
         }


### PR DESCRIPTION
kinit -k, called by get_gss_token, sometimes may need exstra arguments
passed in. Introducing kinit_args in the $tree makes it possible.
The change does not introduce any backwards incompatibilities - if kinit_args is not set, the default "kinit -k" will be called.
