### PR TITLE
ncm-metaconfig: elasticsearch: Refactor schema to allow testing

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config.pan
@@ -1,12 +1,4 @@
 unique template metaconfig/elasticsearch/config;
 
 variable METACONFIG_ELASTICSEARCH_VERSION ?= '5.0';
-include 'metaconfig/elasticsearch/schema';
-
-bind "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}/contents" = elasticsearch_service;
-
-prefix "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}";
-"module" = "yaml";
-"mode" = 0640;
-"group" = "elasticsearch";
-"daemons" = dict("elasticsearch", "restart");
+include format('metaconfig/elasticsearch/config_%s', METACONFIG_ELASTICSEARCH_VERSION);

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config_0.9.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config_0.9.pan
@@ -1,0 +1,11 @@
+unique template metaconfig/elasticsearch/config_0.9;
+
+include 'metaconfig/elasticsearch/schema_0.9';
+
+bind "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}/contents" = elasticsearch_09_service;
+
+prefix "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}";
+"module" = "yaml";
+"mode" = 0640;
+"group" = "elasticsearch";
+"daemons" = dict("elasticsearch", "restart");

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config_5.0.pan
@@ -1,0 +1,11 @@
+unique template metaconfig/elasticsearch/config_5.0;
+
+include 'metaconfig/elasticsearch/schema_5.0';
+
+bind "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}/contents" = elasticsearch_50_service;
+
+prefix "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}";
+"module" = "yaml";
+"mode" = 0640;
+"group" = "elasticsearch";
+"daemons" = dict("elasticsearch", "restart");

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema.pan
@@ -87,7 +87,3 @@ type elasticsearch_discovery_zen = {
 type elasticsearch_discovery = {
     "zen" ? elasticsearch_discovery_zen
 };
-
-@{include version specific types at the end}
-include format('metaconfig/elasticsearch/schema_%s', METACONFIG_ELASTICSEARCH_VERSION);
-

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema.pan
@@ -21,14 +21,14 @@ type elasticsearch_index_search = {
 
 
 type elasticsearch_translog = {
-    "flush_threshold_ops" : long = 5000 with {deprecated(0, "Removed in ES 5.0"); true;}
+    "flush_threshold_ops" : long = 5000 with { deprecated(0, "Removed in ES 5.0"); true; }
 };
 
 type elasticsearch_index = {
     "number_of_shards" ? long(0..)
-    "number_of_replicas" ? long(0..) with {deprecated(0, "Removed in ES 5.0"); true;}
+    "number_of_replicas" ? long(0..) with { deprecated(0, "Removed in ES 5.0"); true; }
     "search" ? elasticsearch_index_search
-    "refresh" ? long(0..) with {deprecated(0, "Removed in ES 5.0"); true;}
+    "refresh" ? long(0..) with { deprecated(0, "Removed in ES 5.0"); true; }
     "translog" ? elasticsearch_translog
 };
 

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema_0.9.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema_0.9.pan
@@ -2,11 +2,14 @@ declaration template metaconfig/elasticsearch/schema_0.9;
 
 @{version specific types for Elasticsearch version 0.9 until (but not including) 5.0}
 
-type elasticsearch_bootstrap = {
+# include common types first
+include 'metaconfig/elasticsearch/schema';
+
+type elasticsearch_09_bootstrap = {
     "mlockall" ? boolean
 };
 
-type elasticsearch_thread_search = {
+type elasticsearch_09_thread_search = {
     "type" : string with match(SELF, "^(fixed|cached|blocking)$")
     "size" : long(0..)
     "min" ? long
@@ -18,24 +21,24 @@ type elasticsearch_thread_search = {
     Thread pool management.  See
     http://www.elasticsearch.org/guide/reference/modules/threadpool/
 @}
-type elasticsearch_threadpool = {
-    "search" : elasticsearch_thread_search
-    "index" : elasticsearch_thread_search
-    "get" ? elasticsearch_thread_search
-    "bulk" ? elasticsearch_thread_search
-    "warmer" ? elasticsearch_thread_search
-    "refresh" ? elasticsearch_thread_search
+type elasticsearch_09_threadpool = {
+    "search" : elasticsearch_09_thread_search
+    "index" : elasticsearch_09_thread_search
+    "get" ? elasticsearch_09_thread_search
+    "bulk" ? elasticsearch_09_thread_search
+    "warmer" ? elasticsearch_09_thread_search
+    "refresh" ? elasticsearch_09_thread_search
 };
 
-type elasticsearch_service = {
+type elasticsearch_09_service = {
     "node" ? elasticsearch_node
     "index" ? elasticsearch_index
     "gateway" ? elasticsearch_gw
     "indices" ? elasticsearch_indices
     "network" : elasticsearch_network = dict("host", "localhost")
     "monitor.jvm" : elasticsearch_monitoring = dict()
-    "threadpool" ? elasticsearch_threadpool
-    "bootstrap" ? elasticsearch_bootstrap
+    "threadpool" ? elasticsearch_09_threadpool
+    "bootstrap" ? elasticsearch_09_bootstrap
     "cluster" ? elasticsearch_cluster
     "transport" ? elasticsearch_transport
     "discovery" ? elasticsearch_discovery

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema_5.0.pan
@@ -2,22 +2,25 @@ declaration template metaconfig/elasticsearch/schema_5.0;
 
 @{version specific types for Elasticsearch version 5.0 and later}
 
-type elasticsearch_bootstrap = {
+# include common types first
+include 'metaconfig/elasticsearch/schema';
+
+type elasticsearch_50_bootstrap = {
     "memory_lock" ? boolean
 };
 
-type elasticsearch_path = {
+type elasticsearch_50_path = {
     "repo" ? absolute_file_path[]
 };
 
 @{fixed thread pool}
-type elasticsearch_thread_pool_fixed = {
+type elasticsearch_50_thread_pool_fixed = {
     "size" ? long(0..)
     "queue_size" ? long(-1..)
 };
 
 @{scaling thread pool}
-type elasticsearch_thread_pool_scaling = {
+type elasticsearch_50_thread_pool_scaling = {
     "core" ? long(1..)
     "max" ? long(1..)
     @{time in seconds to keep idle thread in thread pool}
@@ -28,31 +31,31 @@ type elasticsearch_thread_pool_scaling = {
     Thread pool management.  See
     http://www.elasticsearch.org/guide/reference/modules/threadpool/
 @}
-type elasticsearch_threadpool = {
-    "generic" ? elasticsearch_thread_pool_scaling
-    "search" ? elasticsearch_thread_pool_fixed
-    "index" ? elasticsearch_thread_pool_fixed
-    "get" ? elasticsearch_thread_pool_fixed
-    "bulk" ? elasticsearch_thread_pool_fixed
-    "percolate" ? elasticsearch_thread_pool_fixed
-    "snapshot" ? elasticsearch_thread_pool_scaling
-    "warmer" ? elasticsearch_thread_pool_scaling
-    "refresh" ? elasticsearch_thread_pool_scaling
-    "listener" ? elasticsearch_thread_pool_scaling
+type elasticsearch_50_threadpool = {
+    "generic" ? elasticsearch_50_thread_pool_scaling
+    "search" ? elasticsearch_50_thread_pool_fixed
+    "index" ? elasticsearch_50_thread_pool_fixed
+    "get" ? elasticsearch_50_thread_pool_fixed
+    "bulk" ? elasticsearch_50_thread_pool_fixed
+    "percolate" ? elasticsearch_50_thread_pool_fixed
+    "snapshot" ? elasticsearch_50_thread_pool_scaling
+    "warmer" ? elasticsearch_50_thread_pool_scaling
+    "refresh" ? elasticsearch_50_thread_pool_scaling
+    "listener" ? elasticsearch_50_thread_pool_scaling
 };
 
-type elasticsearch_service = {
+type elasticsearch_50_service = {
     "node" ? elasticsearch_node
     "index" ? elasticsearch_index
     "gateway" ? elasticsearch_gw
     "indices" ? elasticsearch_indices
     "network" : elasticsearch_network = dict("host", "localhost")
     "monitor.jvm.gc" : elasticsearch_monitoring = dict()
-    "thread_pool" ? elasticsearch_threadpool
-    "bootstrap" ? elasticsearch_bootstrap
+    "thread_pool" ? elasticsearch_50_threadpool
+    "bootstrap" ? elasticsearch_50_bootstrap
     "cluster" ? elasticsearch_cluster
     "transport" ? elasticsearch_transport
     "discovery" ? elasticsearch_discovery
-    "path" ? elasticsearch_path
+    "path" ? elasticsearch_50_path
     "processors" ? long(1..)
 };


### PR DESCRIPTION
The multiple schema versions contain duplicate types which break tests when they are copied to the template library, so refactor the schema to avoid this.

* Rename duplicate type definitions.
* Include common schema from version specific schema (rather than the other way round).
