### PR TITLE
ncm-metaconfig: logstash: Refactor schema to allow testing

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_1.2.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_1.2.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/config_1.2;
 
 include 'metaconfig/logstash/schema_1.2';
 
-bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}/contents" = type_logstash;
+bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}/contents" = type_logstash_12;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}";
 "daemons/logstash" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_2.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_2.0.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/config_2.0;
 
 include 'metaconfig/logstash/schema_2.0';
 
-bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}/contents" = type_logstash;
+bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}/contents" = type_logstash_20;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}";
 "daemons/logstash" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/config_5.0.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/config_5.0;
 
 include 'metaconfig/logstash/schema_5.0';
 
-bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}/contents" = type_logstash;
+bind "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}/contents" = type_logstash_50;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash/conf.d/logstash.conf}";
 "daemons/logstash" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/daemon_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/daemon_5.0.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/daemon_5.0;
 
 include 'metaconfig/logstash/schema_5.0';
 
-bind "/software/components/metaconfig/services/{/etc/logstash/logstash.yml}/contents" = type_logstash_yml;
+bind "/software/components/metaconfig/services/{/etc/logstash/logstash.yml}/contents" = type_logstash_50_yml;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash/logstash.yml}";
 "daemons/logstash" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder_1.2.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder_1.2.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/forwarder_1.2;
 
 include 'metaconfig/logstash/schema_1.2';
 
-bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_forwarder;
+bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_12_forwarder;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}";
 "daemons/logstash-forwarder" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder_2.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder_2.0.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/forwarder_2.0;
 
 include 'metaconfig/logstash/schema_2.0';
 
-bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_forwarder;
+bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_20_forwarder;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}";
 "daemons/logstash-forwarder" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/forwarder_5.0.pan
@@ -2,7 +2,7 @@ unique template metaconfig/logstash/forwarder_5.0;
 
 include 'metaconfig/logstash/schema_5.0';
 
-bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_forwarder;
+bind "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}/contents" = type_logstash_50_forwarder;
 
 prefix "/software/components/metaconfig/services/{/etc/logstash-forwarder.conf}";
 "daemons/logstash-forwarder" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -1,4 +1,3 @@
 declaration template metaconfig/logstash/schema;
 
-include 'metaconfig/logstash/version';
-include format('metaconfig/logstash/schema_%s', METACONFIG_LOGSTASH_VERSION);
+@{ Definitions of types common across logstash version, of which there are currently none. }

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_1.2.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_1.2.pan
@@ -6,9 +6,9 @@ http://logstash.net/docs/1.2.2/ for all the details.
 
 include 'pan/types';
 
-type logstash_port_range = long(1..)[] with length(SELF) == 2;
+type logstash_12_port_range = long(1..)[] with length(SELF) == 2;
 
-type logstash_ssl = {
+type logstash_12_ssl = {
     "ssl_cacert" ? string
     "ssl_cert" ? string
     "ssl_key" ? string
@@ -17,7 +17,7 @@ type logstash_ssl = {
     "ssl_verify" ? boolean
 };
 
-type logstash_conditional_expression = {
+type logstash_12_conditional_expression = {
     # [join] [[left] test] right (eg: and left > right; ! right;)
     "join" ? string with match(SELF, '^(and|or|nand|xor)$')
     "left" : string
@@ -26,58 +26,58 @@ type logstash_conditional_expression = {
 };
 
 # no nesting (yet)
-type logstash_conditional = {
+type logstash_12_conditional = {
     # ifelseif: first one is 'if', rest is 'if else'
     # ifelseifelse: first one is 'if', last is 'else', rest is 'if else'
     "type" : string = 'if' with match(SELF, '^(if|if else|else|ifelseif|ifelseifelse)$')
-    "expr" : logstash_conditional_expression[]
+    "expr" : logstash_12_conditional_expression[]
 };
 
 @{ Common portion for all plugins }
-type logstash_plugin_common = {
+type logstash_12_plugin_common = {
     @{using _conditional to avoid name clash with plugin option name.
       The conditional is only for the single plugin and has to be type 'if' (the default).}
-    "_conditional" ? logstash_conditional with { if (SELF['type'] != 'if') {
+    "_conditional" ? logstash_12_conditional with { if (SELF['type'] != 'if') {
         error('plugin _conditional has to be type if (the default)'); }; true;
     }
 };
 
 # list not complete at all
-type logstash_codec_charset = string with match(SELF, "^(UTF-8|locale|external|filesystem|internal)$");
+type logstash_12_codec_charset = string with match(SELF, "^(UTF-8|locale|external|filesystem|internal)$");
 
-type logstash_codec_common = {
+type logstash_12_codec_common = {
     # there are codecs without any values to set. this should stay empty?
 };
 
-type logstash_codec_plain = {
-    include logstash_codec_common
-    "charset" ? logstash_codec_charset
+type logstash_12_codec_plain = {
+    include logstash_12_codec_common
+    "charset" ? logstash_12_codec_charset
     "format" ? string
 };
 
-type logstash_codec_json = {
-    include logstash_codec_common
-    "charset" ? logstash_codec_charset
+type logstash_12_codec_json = {
+    include logstash_12_codec_common
+    "charset" ? logstash_12_codec_charset
 };
 
-type logstash_input_codec = {
-    "json" ? logstash_codec_json
-    "plain" ? logstash_codec_plain
+type logstash_12_input_codec = {
+    "json" ? logstash_12_codec_json
+    "plain" ? logstash_12_codec_plain
 } with length(SELF) == 1;
 
 @{ Common portion for all input plugins }
-type logstash_input_plugin_common = {
-    include logstash_plugin_common
+type logstash_12_input_plugin_common = {
+    include logstash_12_plugin_common
     "type" : string
     "debug" ? boolean
     "tags" ? string[]
     "add_field" ? string{}
-    "codec" ? logstash_input_codec
+    "codec" ? logstash_12_input_codec
 };
 
 @{ File-based input }
-type logstash_input_file = {
-    include logstash_input_plugin_common
+type logstash_12_input_file = {
+    include logstash_12_input_plugin_common
     "path" : string[]
     "exclude" ? string[]
     "sincedb_path" ? string
@@ -87,32 +87,32 @@ type logstash_input_file = {
 };
 
 @{ Collecting from tcp }
-type logstash_input_tcp = {
-    include logstash_input_plugin_common
-    include logstash_ssl
+type logstash_12_input_tcp = {
+    include logstash_12_input_plugin_common
+    include logstash_12_ssl
     "port" : type_port
     "host" ? type_hostname
 };
 
 @{ Collecting from udp }
-type logstash_input_udp = {
-    include logstash_input_plugin_common
-    include logstash_ssl
+type logstash_12_input_udp = {
+    include logstash_12_input_plugin_common
+    include logstash_12_ssl
     "port" : type_port
     "host" ? type_hostname
 };
 
 @{ GELF input }
-type logstash_input_gelf = {
-    include logstash_input_plugin_common
+type logstash_12_input_gelf = {
+    include logstash_12_input_plugin_common
     "port" : type_port = 12201
     "host" ? type_hostname
     "remap" : boolean = true
 };
 
 @{ Lumberjack/logstash-forwarder input }
-type logstash_input_lumberjack = {
-    include logstash_input_plugin_common
+type logstash_12_input_lumberjack = {
+    include logstash_12_input_plugin_common
     "port" : type_port = 12201
     "host" ? type_hostname
     "ssl_certificate" : string
@@ -121,50 +121,50 @@ type logstash_input_lumberjack = {
 };
 
 @{ beats input }
-type logstash_input_beats = {
-    include logstash_input_lumberjack
+type logstash_12_input_beats = {
+    include logstash_12_input_lumberjack
     'ssl' ? boolean
     'congestion_threshold' ? long(0..)
 };
 
-type logstash_input_plugin = {
-    "file" ? logstash_input_file
-    "gelf" ? logstash_input_gelf
-    "tcp" ? logstash_input_tcp
-    "udp" ? logstash_input_udp
-    "lumberjack" ? logstash_input_lumberjack
-    "beats" ? logstash_input_beats
+type logstash_12_input_plugin = {
+    "file" ? logstash_12_input_file
+    "gelf" ? logstash_12_input_gelf
+    "tcp" ? logstash_12_input_tcp
+    "udp" ? logstash_12_input_udp
+    "lumberjack" ? logstash_12_input_lumberjack
+    "beats" ? logstash_12_input_beats
 } with length(SELF) == 1;
 
 
 @{ Base for all filters }
-type logstash_name_pattern = {
+type logstash_12_name_pattern = {
     "name" : string
     "pattern" : string
 };
 
-type logstash_name_patterns = {
+type logstash_12_name_patterns = {
     "name" : string
     "pattern" : string[]
 };
 
 @{A name_patterdict is rendered differently than a name_patterns}
-type logstash_filter_name_patterdict = {
+type logstash_12_filter_name_patterdict = {
     "name" : string
     "pattern" : string[]
 };
 
-type logstash_filter_plugin_common = {
-    include logstash_plugin_common
+type logstash_12_filter_plugin_common = {
+    include logstash_12_plugin_common
     "add_field" ? string{}
     "add_tag" ? string[]
     "remove_field" ? string[]
     "remove_tag" ? string[]
 };
 
-type logstash_filter_grok = {
-    include logstash_filter_plugin_common
-    "match" ? logstash_name_patterns[]
+type logstash_12_filter_grok = {
+    include logstash_12_filter_plugin_common
+    "match" ? logstash_12_name_patterns[]
     "break_on_match" : boolean = true
     "drop_if_match" ? boolean
     "keep_empty_captures" ? boolean
@@ -172,35 +172,35 @@ type logstash_filter_grok = {
     "patterns_dir" ? string[]
 };
 
-type logstash_filter_bytes2human = {
-    include logstash_filter_plugin_common
+type logstash_12_filter_bytes2human = {
+    include logstash_12_filter_plugin_common
     "convert" : string{}
 };
 
-type logstash_filter_date = {
-    include logstash_filter_plugin_common
-    "match" : logstash_filter_name_patterdict
+type logstash_12_filter_date = {
+    include logstash_12_filter_plugin_common
+    "match" : logstash_12_filter_name_patterdict
 };
 
-type logstash_filter_grep = {
-    include logstash_filter_plugin_common
-    "match" ? logstash_name_pattern[]
+type logstash_12_filter_grep = {
+    include logstash_12_filter_plugin_common
+    "match" ? logstash_12_name_pattern[]
     "drop" : boolean = true
     "negate" : boolean = false
 };
 
-type logstash_filter_drop = {
-    include logstash_filter_plugin_common
+type logstash_12_filter_drop = {
+    include logstash_12_filter_plugin_common
     "percentage" ? long(0..100)
     "periodic_flush" ? boolean
 };
 
-type logstash_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
+type logstash_12_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
 
-type logstash_filter_mutate = {
-    include logstash_filter_plugin_common
-    "convert" ? logstash_filter_mutate_convert{}
-    "replace" ? logstash_name_pattern[]
+type logstash_12_filter_mutate = {
+    include logstash_12_filter_plugin_common
+    "convert" ? logstash_12_filter_mutate_convert{}
+    "replace" ? logstash_12_name_pattern[]
     "rename" ? string{}
     "split" ? string{}
     "update" ? string{}
@@ -209,8 +209,8 @@ type logstash_filter_mutate = {
     }
 };
 
-type logstash_filter_kv = {
-    include logstash_filter_plugin_common
+type logstash_12_filter_kv = {
+    include logstash_12_filter_plugin_common
     "default_keys" ? string{}
     "exclude_keys" ? string[]
     "include_keys" ? string[]
@@ -222,32 +222,32 @@ type logstash_filter_kv = {
     "value_split" ? string
 };
 
-type logstash_filter_plugin = {
-    "grok" ? logstash_filter_grok
-    "date" ? logstash_filter_date
-    "grep" ? logstash_filter_grep with {
+type logstash_12_filter_plugin = {
+    "grok" ? logstash_12_filter_grok
+    "date" ? logstash_12_filter_date
+    "grep" ? logstash_12_filter_grep with {
         deprecated(0, 'grep filter is removed from 2.0, use e.g. conditional drop'); true;
     }
-    "drop" ? logstash_filter_drop
-    "mutate" ? logstash_filter_mutate
-    "kv" ? logstash_filter_kv
-    "bytes2human" ? logstash_filter_bytes2human
+    "drop" ? logstash_12_filter_drop
+    "mutate" ? logstash_12_filter_mutate
+    "kv" ? logstash_12_filter_kv
+    "bytes2human" ? logstash_12_filter_bytes2human
 } with length(SELF) == 1;
 
 @{ Common output }
-type logstash_output_codec = {
-    "plain" ? logstash_codec_plain
+type logstash_12_output_codec = {
+    "plain" ? logstash_12_codec_plain
 } with length(SELF) == 1;
 
-type logstash_output_plugin_common = {
-    include logstash_plugin_common
-    "codec" ? logstash_output_codec
+type logstash_12_output_plugin_common = {
+    include logstash_12_plugin_common
+    "codec" ? logstash_12_output_codec
     "workers" ? long(1..)
 };
 
 @{ GELF-based output }
-type logstash_output_gelf = {
-    include logstash_output_plugin_common
+type logstash_12_output_gelf = {
+    include logstash_12_output_plugin_common
     "host" : type_fqdn
     "level" : string[] = list("info")
     "port" : type_port = 12201
@@ -259,18 +259,18 @@ type logstash_output_gelf = {
 };
 
 @{ stdout-based output }
-type logstash_output_stdout = {
-    include logstash_output_plugin_common
+type logstash_12_output_stdout = {
+    include logstash_12_output_plugin_common
     "debug" ? boolean
 };
 
 @{ elasticsearch-based output }
-type logstash_output_elasticsearch = {
-    include logstash_output_plugin_common
+type logstash_12_output_elasticsearch = {
+    include logstash_12_output_plugin_common
     "bind_host" ? type_hostname
     "hosts" ? type_hostport[]
     "host" ? type_hostname with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
-    "port" ? logstash_port_range with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
+    "port" ? logstash_12_port_range with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
     "cluster" ? string with {deprecated(0, 'removed in version 2.0'); true; }
     "embedded" ? boolean = false with {deprecated(0, 'removed in version 2.0'); true; }
     "index" : string = "logstash-%{+YYYY.MM.dd}"
@@ -280,73 +280,73 @@ type logstash_output_elasticsearch = {
     "template_overwrite" ? boolean
 };
 
-type logstash_output_plugin = {
-    "gelf" ? logstash_output_gelf
-    "stdout" ? logstash_output_stdout
-    "elasticsearch" ? logstash_output_elasticsearch
+type logstash_12_output_plugin = {
+    "gelf" ? logstash_12_output_gelf
+    "stdout" ? logstash_12_output_stdout
+    "elasticsearch" ? logstash_12_output_elasticsearch
 } with length(SELF) == 1;
 
-type logstash_input_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_input_plugin[]
+type logstash_12_input_conditional = {
+    include logstash_12_conditional
+    "plugins" ? logstash_12_input_plugin[]
 };
 
-type logstash_filter_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_filter_plugin[]
+type logstash_12_filter_conditional = {
+    include logstash_12_conditional
+    "plugins" ? logstash_12_filter_plugin[]
 };
 
-type logstash_output_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_output_plugin[]
+type logstash_12_output_conditional = {
+    include logstash_12_conditional
+    "plugins" ? logstash_12_output_plugin[]
 };
 
-type logstash_input = {
-    "plugins" ? logstash_input_plugin[]
-    "conditionals" ? logstash_input_conditional[]
+type logstash_12_input = {
+    "plugins" ? logstash_12_input_plugin[]
+    "conditionals" ? logstash_12_input_conditional[]
 };
 
-type logstash_filter = {
-    "plugins" ? logstash_filter_plugin[]
-    "conditionals" ? logstash_filter_conditional[]
+type logstash_12_filter = {
+    "plugins" ? logstash_12_filter_plugin[]
+    "conditionals" ? logstash_12_filter_conditional[]
 };
 
-type logstash_output = {
-    "plugins" ? logstash_output_plugin[]
-    "conditionals" ? logstash_output_conditional[]
+type logstash_12_output = {
+    "plugins" ? logstash_12_output_plugin[]
+    "conditionals" ? logstash_12_output_conditional[]
 };
 
 @{ The configuration is made of input, filter and output section }
-type type_logstash = {
-    "input" : logstash_input
-    "filter" ? logstash_filter
-    "output" : logstash_output
+type type_logstash_12 = {
+    "input" : logstash_12_input
+    "filter" ? logstash_12_filter
+    "output" : logstash_12_output
 };
 
 @{ logstash-forwarder type }
-type type_logstash_forwarder_network_server = {
+type type_logstash_12_forwarder_network_server = {
     "host" : type_hostname
     "port" : long(0..)
 };
 
-type type_logstash_forwarder_network = {
-    "servers" : type_logstash_forwarder_network_server[]
+type type_logstash_12_forwarder_network = {
+    "servers" : type_logstash_12_forwarder_network_server[]
     "ssl_certificate" ? string
     "ssl_key" ? string
     "ssl_ca" ? string
     "timeout" : long(0..) = 15
 };
 
-type type_logstash_forwarder_file_fields = {
+type type_logstash_12_forwarder_file_fields = {
     "type" : string
 };
 
-type type_logstash_forwarder_file = {
+type type_logstash_12_forwarder_file = {
     "paths" : string[]
-    "fields" : type_logstash_forwarder_file_fields
+    "fields" : type_logstash_12_forwarder_file_fields
 };
 
-type type_logstash_forwarder = {
-    "network" : type_logstash_forwarder_network
-    "files" : type_logstash_forwarder_file[]
+type type_logstash_12_forwarder = {
+    "network" : type_logstash_12_forwarder_network
+    "files" : type_logstash_12_forwarder_file[]
 };

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_2.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_2.0.pan
@@ -6,9 +6,9 @@ https://www.elastic.co/guide/en/logstash/2.0/index.html for all the details.
 
 include 'pan/types';
 
-type logstash_port_range = long(1..)[] with length(SELF) == 2;
+type logstash_20_port_range = long(1..)[] with length(SELF) == 2;
 
-type logstash_ssl = {
+type logstash_20_ssl = {
     "ssl_cacert" ? string
     "ssl_cert" ? string
     "ssl_key" ? string
@@ -17,7 +17,7 @@ type logstash_ssl = {
     "ssl_verify" ? boolean
 };
 
-type logstash_conditional_expression = {
+type logstash_20_conditional_expression = {
     # [join] [[left] test] right (eg: and left > right; ! right;)
     "join" ? string with match(SELF, '^(and|or|nand|xor)$')
     "left" : string
@@ -26,58 +26,58 @@ type logstash_conditional_expression = {
 };
 
 # no nesting (yet)
-type logstash_conditional = {
+type logstash_20_conditional = {
     # ifelseif: first one is 'if', rest is 'if else'
     # ifelseifelse: first one is 'if', last is 'else', rest is 'if else'
     "type" : string = 'if' with match(SELF, '^(if|if else|else|ifelseif|ifelseifelse)$')
-    "expr" : logstash_conditional_expression[]
+    "expr" : logstash_20_conditional_expression[]
 };
 
 @{ Common portion for all plugins }
-type logstash_plugin_common = {
+type logstash_20_plugin_common = {
     @{using _conditional to avoid name clash with plugin option name.
       The conditional is only for the single plugin and has to be type 'if' (the default).}
-    "_conditional" ? logstash_conditional with { if (SELF['type'] != 'if') {
+    "_conditional" ? logstash_20_conditional with { if (SELF['type'] != 'if') {
         error('plugin _conditional has to be type if (the default)'); }; true;
     }
 };
 
 # list not complete at all
-type logstash_codec_charset = string with match(SELF, "^(UTF-8|locale|external|filesystem|internal)$");
+type logstash_20_codec_charset = string with match(SELF, "^(UTF-8|locale|external|filesystem|internal)$");
 
-type logstash_codec_common = {
+type logstash_20_codec_common = {
     # there are codecs without any values to set. this should stay empty?
 };
 
-type logstash_codec_plain = {
-    include logstash_codec_common
-    "charset" ? logstash_codec_charset
+type logstash_20_codec_plain = {
+    include logstash_20_codec_common
+    "charset" ? logstash_20_codec_charset
     "format" ? string
 };
 
-type logstash_codec_json = {
-    include logstash_codec_common
-    "charset" ? logstash_codec_charset
+type logstash_20_codec_json = {
+    include logstash_20_codec_common
+    "charset" ? logstash_20_codec_charset
 };
 
-type logstash_input_codec = {
-    "json" ? logstash_codec_json
-    "plain" ? logstash_codec_plain
+type logstash_20_input_codec = {
+    "json" ? logstash_20_codec_json
+    "plain" ? logstash_20_codec_plain
 } with length(SELF) == 1;
 
 @{ Common portion for all input plugins }
-type logstash_input_plugin_common = {
-    include logstash_plugin_common
+type logstash_20_input_plugin_common = {
+    include logstash_20_plugin_common
     "type" : string
     "debug" ? boolean
     "tags" ? string[]
     "add_field" ? string{}
-    "codec" ? logstash_input_codec
+    "codec" ? logstash_20_input_codec
 };
 
 @{ File-based input }
-type logstash_input_file = {
-    include logstash_input_plugin_common
+type logstash_20_input_file = {
+    include logstash_20_input_plugin_common
     "path" : string[]
     "exclude" ? string[]
     "sincedb_path" ? string
@@ -87,32 +87,32 @@ type logstash_input_file = {
 };
 
 @{ Collecting from tcp }
-type logstash_input_tcp = {
-    include logstash_input_plugin_common
-    include logstash_ssl
+type logstash_20_input_tcp = {
+    include logstash_20_input_plugin_common
+    include logstash_20_ssl
     "port" : type_port
     "host" ? type_hostname
 };
 
 @{ Collecting from udp }
-type logstash_input_udp = {
-    include logstash_input_plugin_common
-    include logstash_ssl
+type logstash_20_input_udp = {
+    include logstash_20_input_plugin_common
+    include logstash_20_ssl
     "port" : type_port
     "host" ? type_hostname
 };
 
 @{ GELF input }
-type logstash_input_gelf = {
-    include logstash_input_plugin_common
+type logstash_20_input_gelf = {
+    include logstash_20_input_plugin_common
     "port" : type_port = 12201
     "host" ? type_hostname
     "remap" : boolean = true
 };
 
 @{ Lumberjack/logstash-forwarder input }
-type logstash_input_lumberjack = {
-    include logstash_input_plugin_common
+type logstash_20_input_lumberjack = {
+    include logstash_20_input_plugin_common
     "port" : type_port = 12201
     "host" ? type_hostname
     "ssl_certificate" : string
@@ -121,50 +121,50 @@ type logstash_input_lumberjack = {
 };
 
 @{ beats input }
-type logstash_input_beats = {
-    include logstash_input_lumberjack
+type logstash_20_input_beats = {
+    include logstash_20_input_lumberjack
     'ssl' ? boolean
     'congestion_threshold' ? long(0..)
 };
 
-type logstash_input_plugin = {
-    "file" ? logstash_input_file
-    "gelf" ? logstash_input_gelf
-    "tcp" ? logstash_input_tcp
-    "udp" ? logstash_input_udp
-    "lumberjack" ? logstash_input_lumberjack
-    "beats" ? logstash_input_beats
+type logstash_20_input_plugin = {
+    "file" ? logstash_20_input_file
+    "gelf" ? logstash_20_input_gelf
+    "tcp" ? logstash_20_input_tcp
+    "udp" ? logstash_20_input_udp
+    "lumberjack" ? logstash_20_input_lumberjack
+    "beats" ? logstash_20_input_beats
 } with length(SELF) == 1;
 
 
 @{ Base for all filters }
-type logstash_name_pattern = {
+type logstash_20_name_pattern = {
     "name" : string
     "pattern" : string
 };
 
-type logstash_name_patterns = {
+type logstash_20_name_patterns = {
     "name" : string
     "pattern" : string[]
 };
 
 @{A name_patterdict is rendered differently than a name_patterns}
-type logstash_filter_name_patterdict = {
+type logstash_20_filter_name_patterdict = {
     "name" : string
     "pattern" : string[]
 };
 
-type logstash_filter_plugin_common = {
-    include logstash_plugin_common
+type logstash_20_filter_plugin_common = {
+    include logstash_20_plugin_common
     "add_field" ? string{}
     "add_tag" ? string[]
     "remove_field" ? string[]
     "remove_tag" ? string[]
 };
 
-type logstash_filter_grok = {
-    include logstash_filter_plugin_common
-    "match" ? logstash_name_patterns[]
+type logstash_20_filter_grok = {
+    include logstash_20_filter_plugin_common
+    "match" ? logstash_20_name_patterns[]
     "break_on_match" : boolean = true
     "drop_if_match" ? boolean
     "keep_empty_captures" ? boolean
@@ -172,35 +172,35 @@ type logstash_filter_grok = {
     "patterns_dir" ? string[]
 };
 
-type logstash_filter_bytes2human = {
-    include logstash_filter_plugin_common
+type logstash_20_filter_bytes2human = {
+    include logstash_20_filter_plugin_common
     "convert" : string{}
 };
 
-type logstash_filter_date = {
-    include logstash_filter_plugin_common
-    "match" : logstash_filter_name_patterdict
+type logstash_20_filter_date = {
+    include logstash_20_filter_plugin_common
+    "match" : logstash_20_filter_name_patterdict
 };
 
-type logstash_filter_grep = {
-    include logstash_filter_plugin_common
-    "match" ? logstash_name_pattern[]
+type logstash_20_filter_grep = {
+    include logstash_20_filter_plugin_common
+    "match" ? logstash_20_name_pattern[]
     "drop" : boolean = true
     "negate" : boolean = false
 };
 
-type logstash_filter_drop = {
-    include logstash_filter_plugin_common
+type logstash_20_filter_drop = {
+    include logstash_20_filter_plugin_common
     "percentage" ? long(0..100)
     "periodic_flush" ? boolean
 };
 
-type logstash_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
+type logstash_20_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
 
-type logstash_filter_mutate = {
-    include logstash_filter_plugin_common
-    "convert" ? logstash_filter_mutate_convert{}
-    "replace" ? logstash_name_pattern[]
+type logstash_20_filter_mutate = {
+    include logstash_20_filter_plugin_common
+    "convert" ? logstash_20_filter_mutate_convert{}
+    "replace" ? logstash_20_name_pattern[]
     "rename" ? string{}
     "split" ? string{}
     "update" ? string{}
@@ -209,8 +209,8 @@ type logstash_filter_mutate = {
     }
 };
 
-type logstash_filter_kv = {
-    include logstash_filter_plugin_common
+type logstash_20_filter_kv = {
+    include logstash_20_filter_plugin_common
     "default_keys" ? string{}
     "exclude_keys" ? string[]
     "include_keys" ? string[]
@@ -222,32 +222,32 @@ type logstash_filter_kv = {
     "value_split" ? string
 };
 
-type logstash_filter_plugin = {
-    "grok" ? logstash_filter_grok
-    "date" ? logstash_filter_date
-    "grep" ? logstash_filter_grep with {
+type logstash_20_filter_plugin = {
+    "grok" ? logstash_20_filter_grok
+    "date" ? logstash_20_filter_date
+    "grep" ? logstash_20_filter_grep with {
         deprecated(0, 'grep filter is removed from 2.0, use e.g. conditional drop'); true;
     }
-    "drop" ? logstash_filter_drop
-    "mutate" ? logstash_filter_mutate
-    "kv" ? logstash_filter_kv
-    "bytes2human" ? logstash_filter_bytes2human
+    "drop" ? logstash_20_filter_drop
+    "mutate" ? logstash_20_filter_mutate
+    "kv" ? logstash_20_filter_kv
+    "bytes2human" ? logstash_20_filter_bytes2human
 } with length(SELF) == 1;
 
 @{ Common output }
-type logstash_output_codec = {
-    "plain" ? logstash_codec_plain
+type logstash_20_output_codec = {
+    "plain" ? logstash_20_codec_plain
 } with length(SELF) == 1;
 
-type logstash_output_plugin_common = {
-    include logstash_plugin_common
-    "codec" ? logstash_output_codec
+type logstash_20_output_plugin_common = {
+    include logstash_20_plugin_common
+    "codec" ? logstash_20_output_codec
     "workers" ? long(1..)
 };
 
 @{ GELF-based output }
-type logstash_output_gelf = {
-    include logstash_output_plugin_common
+type logstash_20_output_gelf = {
+    include logstash_20_output_plugin_common
     "host" : type_fqdn
     "level" : string[] = list("info")
     "port" : type_port = 12201
@@ -259,18 +259,18 @@ type logstash_output_gelf = {
 };
 
 @{ stdout-based output }
-type logstash_output_stdout = {
-    include logstash_output_plugin_common
+type logstash_20_output_stdout = {
+    include logstash_20_output_plugin_common
     "debug" ? boolean
 };
 
 @{ elasticsearch-based output }
-type logstash_output_elasticsearch = {
-    include logstash_output_plugin_common
+type logstash_20_output_elasticsearch = {
+    include logstash_20_output_plugin_common
     "bind_host" ? type_hostname
     "hosts" ? type_hostport[]
     "host" ? type_hostname with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
-    "port" ? logstash_port_range with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
+    "port" ? logstash_20_port_range with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
     "cluster" ? string with {deprecated(0, 'removed in version 2.0'); true; }
     "embedded" ? boolean = false with {deprecated(0, 'removed in version 2.0'); true; }
     "index" : string = "logstash-%{+YYYY.MM.dd}"
@@ -280,73 +280,73 @@ type logstash_output_elasticsearch = {
     "template_overwrite" ? boolean
 };
 
-type logstash_output_plugin = {
-    "gelf" ? logstash_output_gelf
-    "stdout" ? logstash_output_stdout
-    "elasticsearch" ? logstash_output_elasticsearch
+type logstash_20_output_plugin = {
+    "gelf" ? logstash_20_output_gelf
+    "stdout" ? logstash_20_output_stdout
+    "elasticsearch" ? logstash_20_output_elasticsearch
 } with length(SELF) == 1;
 
-type logstash_input_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_input_plugin[]
+type logstash_20_input_conditional = {
+    include logstash_20_conditional
+    "plugins" ? logstash_20_input_plugin[]
 };
 
-type logstash_filter_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_filter_plugin[]
+type logstash_20_filter_conditional = {
+    include logstash_20_conditional
+    "plugins" ? logstash_20_filter_plugin[]
 };
 
-type logstash_output_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_output_plugin[]
+type logstash_20_output_conditional = {
+    include logstash_20_conditional
+    "plugins" ? logstash_20_output_plugin[]
 };
 
-type logstash_input = {
-    "plugins" ? logstash_input_plugin[]
-    "conditionals" ? logstash_input_conditional[]
+type logstash_20_input = {
+    "plugins" ? logstash_20_input_plugin[]
+    "conditionals" ? logstash_20_input_conditional[]
 };
 
-type logstash_filter = {
-    "plugins" ? logstash_filter_plugin[]
-    "conditionals" ? logstash_filter_conditional[]
+type logstash_20_filter = {
+    "plugins" ? logstash_20_filter_plugin[]
+    "conditionals" ? logstash_20_filter_conditional[]
 };
 
-type logstash_output = {
-    "plugins" ? logstash_output_plugin[]
-    "conditionals" ? logstash_output_conditional[]
+type logstash_20_output = {
+    "plugins" ? logstash_20_output_plugin[]
+    "conditionals" ? logstash_20_output_conditional[]
 };
 
 @{ The configuration is made of input, filter and output section }
-type type_logstash = {
-    "input" : logstash_input
-    "filter" ? logstash_filter
-    "output" : logstash_output
+type type_logstash_20 = {
+    "input" : logstash_20_input
+    "filter" ? logstash_20_filter
+    "output" : logstash_20_output
 };
 
 @{ logstash-forwarder type }
-type type_logstash_forwarder_network_server = {
+type type_logstash_20_forwarder_network_server = {
     "host" : type_hostname
     "port" : long(0..)
 };
 
-type type_logstash_forwarder_network = {
-    "servers" : type_logstash_forwarder_network_server[]
+type type_logstash_20_forwarder_network = {
+    "servers" : type_logstash_20_forwarder_network_server[]
     "ssl_certificate" ? string
     "ssl_key" ? string
     "ssl_ca" ? string
     "timeout" : long(0..) = 15
 };
 
-type type_logstash_forwarder_file_fields = {
+type type_logstash_20_forwarder_file_fields = {
     "type" : string
 };
 
-type type_logstash_forwarder_file = {
+type type_logstash_20_forwarder_file = {
     "paths" : string[]
-    "fields" : type_logstash_forwarder_file_fields
+    "fields" : type_logstash_20_forwarder_file_fields
 };
 
-type type_logstash_forwarder = {
-    "network" : type_logstash_forwarder_network
-    "files" : type_logstash_forwarder_file[]
+type type_logstash_20_forwarder = {
+    "network" : type_logstash_20_forwarder_network
+    "files" : type_logstash_20_forwarder_file[]
 };

--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_5.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema_5.0.pan
@@ -6,9 +6,9 @@ https://www.elastic.co/guide/en/logstash/5.0/index.html for all the details.
 
 include 'pan/types';
 
-type logstash_port_range = long(1..)[] with length(SELF) == 2;
+type logstash_50_port_range = long(1..)[] with length(SELF) == 2;
 
-type logstash_ssl = {
+type logstash_50_ssl = {
     "ssl_cert" ? string
     "ssl_key" ? string
     "ssl_key_passphrase" ? string
@@ -16,7 +16,7 @@ type logstash_ssl = {
     "ssl_verify" ? boolean
 };
 
-type logstash_conditional_expression = {
+type logstash_50_conditional_expression = {
     # [join] [[left] test] right (eg: and left > right; ! right;)
     "join" ? string with match(SELF, '^(and|or|nand|xor)$')
     "left" : string
@@ -25,48 +25,48 @@ type logstash_conditional_expression = {
 };
 
 # no nesting (yet)
-type logstash_conditional = {
+type logstash_50_conditional = {
     # ifelseif: first one is 'if', rest is 'if else'
     # ifelseifelse: first one is 'if', last is 'else', rest is 'if else'
     "type" : string = 'if' with match(SELF, '^(if|if else|else|ifelseif|ifelseifelse)$')
-    "expr" : logstash_conditional_expression[]
+    "expr" : logstash_50_conditional_expression[]
 };
 
 @{ Common portion for all plugins }
-type logstash_plugin_common = {
+type logstash_50_plugin_common = {
     @{using _conditional to avoid name clash with plugin option name.
       The conditional is only for the single plugin and has to be type 'if' (the default).}
-    "_conditional" ? logstash_conditional with { if (SELF['type'] != 'if') {
+    "_conditional" ? logstash_50_conditional with { if (SELF['type'] != 'if') {
         error('plugin _conditional has to be type if (the default)'); }; true;
     }
 };
 
 # list not complete at all
-type logstash_codec_charset = string with match(SELF, "^(UTF-8|locale|external|filesystem|internal)$");
+type logstash_50_codec_charset = string with match(SELF, "^(UTF-8|locale|external|filesystem|internal)$");
 
-type logstash_codec_common = {
+type logstash_50_codec_common = {
     # there are codecs without any values to set. this should stay empty?
 };
 
-type logstash_codec_plain = {
-    include logstash_codec_common
-    "charset" ? logstash_codec_charset
+type logstash_50_codec_plain = {
+    include logstash_50_codec_common
+    "charset" ? logstash_50_codec_charset
     "format" ? string
 };
 
-type logstash_codec_json = {
-    include logstash_codec_common
-    "charset" ? logstash_codec_charset
+type logstash_50_codec_json = {
+    include logstash_50_codec_common
+    "charset" ? logstash_50_codec_charset
 };
 
-type logstash_input_codec = {
-    "json" ? logstash_codec_json
-    "plain" ? logstash_codec_plain
+type logstash_50_input_codec = {
+    "json" ? logstash_50_codec_json
+    "plain" ? logstash_50_codec_plain
 } with length(SELF) == 1;
 
 @{ Common portion for all input plugins }
-type logstash_input_plugin_common = {
-    include logstash_plugin_common
+type logstash_50_input_plugin_common = {
+    include logstash_50_plugin_common
     "type" : string
     "debug" ? boolean
     "tags" ? string[]
@@ -75,8 +75,8 @@ type logstash_input_plugin_common = {
 };
 
 @{ File-based input }
-type logstash_input_file = {
-    include logstash_input_plugin_common
+type logstash_50_input_file = {
+    include logstash_50_input_plugin_common
     "path" : string[]
     "exclude" ? string[]
     "sincedb_path" ? string
@@ -86,9 +86,9 @@ type logstash_input_file = {
 };
 
 @{ Collecting from tcp }
-type logstash_input_tcp = {
-    include logstash_input_plugin_common
-    include logstash_ssl
+type logstash_50_input_tcp = {
+    include logstash_50_input_plugin_common
+    include logstash_50_ssl
     "ssl_extra_chain_certs" ? string[]
     "port" : type_port
     "host" ? type_hostname
@@ -96,24 +96,24 @@ type logstash_input_tcp = {
 };
 
 @{ Collecting from udp }
-type logstash_input_udp = {
-    include logstash_input_plugin_common
-    include logstash_ssl
+type logstash_50_input_udp = {
+    include logstash_50_input_plugin_common
+    include logstash_50_ssl
     "port" : type_port
     "host" ? type_hostname
 };
 
 @{ GELF input }
-type logstash_input_gelf = {
-    include logstash_input_plugin_common
+type logstash_50_input_gelf = {
+    include logstash_50_input_plugin_common
     "port" : type_port = 12201
     "host" ? type_hostname
     "remap" : boolean = true
 };
 
 @{ Lumberjack/logstash-forwarder input }
-type logstash_input_lumberjack = {
-    include logstash_input_plugin_common
+type logstash_50_input_lumberjack = {
+    include logstash_50_input_plugin_common
     "port" : type_port = 12201
     "host" ? type_hostname
     "ssl_certificate" : string
@@ -122,15 +122,15 @@ type logstash_input_lumberjack = {
 };
 
 @{ beats input }
-type logstash_input_beats = {
-    include logstash_input_lumberjack
+type logstash_50_input_beats = {
+    include logstash_50_input_lumberjack
     'ssl_certificate_authorities' ? string[]
     'ssl' ? boolean
 };
 
 @{ zeromq input }
-type logstash_input_zeromq = {
-    include logstash_input_plugin_common
+type logstash_50_input_zeromq = {
+    include logstash_50_input_plugin_common
     "address" ? string[] = list("tcp://*:2120")
     "mode" ? string = "server" with match(SELF, ("server|client"))
     "sender" ? string
@@ -139,45 +139,45 @@ type logstash_input_zeromq = {
     "topology" : string with match(SELF, ("pushpull|pubsub|pair"))
 };
 
-type logstash_input_plugin = {
-    "file" ? logstash_input_file
-    "gelf" ? logstash_input_gelf
-    "tcp" ? logstash_input_tcp
-    "udp" ? logstash_input_udp
-    "lumberjack" ? logstash_input_lumberjack
-    "beats" ? logstash_input_beats
-    "zeromq" ? logstash_input_zeromq
+type logstash_50_input_plugin = {
+    "file" ? logstash_50_input_file
+    "gelf" ? logstash_50_input_gelf
+    "tcp" ? logstash_50_input_tcp
+    "udp" ? logstash_50_input_udp
+    "lumberjack" ? logstash_50_input_lumberjack
+    "beats" ? logstash_50_input_beats
+    "zeromq" ? logstash_50_input_zeromq
 } with length(SELF) == 1;
 
 
 @{ Base for all filters }
-type logstash_name_pattern = {
+type logstash_50_name_pattern = {
     "name" : string
     "pattern" : string
 };
 
-type logstash_name_patterns = {
+type logstash_50_name_patterns = {
     "name" : string
     "pattern" : string[]
 };
 
 @{A name_patternlist is rendered differently than a name_patterns}
-type logstash_filter_name_patternlist = {
+type logstash_50_filter_name_patternlist = {
     "name" : string
     "pattern" : string[]
 };
 
-type logstash_filter_plugin_common = {
-    include logstash_plugin_common
+type logstash_50_filter_plugin_common = {
+    include logstash_50_plugin_common
     "add_field" ? string{}
     "add_tag" ? string[]
     "remove_field" ? string[]
     "remove_tag" ? string[]
 };
 
-type logstash_filter_grok = {
-    include logstash_filter_plugin_common
-    "match" ? logstash_name_patterns[]
+type logstash_50_filter_grok = {
+    include logstash_50_filter_plugin_common
+    "match" ? logstash_50_name_patterns[]
     "break_on_match" : boolean = true
     "drop_if_match" ? boolean
     "keep_empty_captures" ? boolean
@@ -185,35 +185,35 @@ type logstash_filter_grok = {
     "patterns_dir" ? string[]
 };
 
-type logstash_filter_bytes2human = {
-    include logstash_filter_plugin_common
+type logstash_50_filter_bytes2human = {
+    include logstash_50_filter_plugin_common
     "convert" : string{}
 };
 
-type logstash_filter_date = {
-    include logstash_filter_plugin_common
-    "match" : logstash_filter_name_patternlist
+type logstash_50_filter_date = {
+    include logstash_50_filter_plugin_common
+    "match" : logstash_50_filter_name_patternlist
 };
 
-type logstash_filter_grep = {
-    include logstash_filter_plugin_common
-    "match" ? logstash_name_pattern[]
+type logstash_50_filter_grep = {
+    include logstash_50_filter_plugin_common
+    "match" ? logstash_50_name_pattern[]
     "drop" : boolean = true
     "negate" : boolean = false
 };
 
-type logstash_filter_drop = {
-    include logstash_filter_plugin_common
+type logstash_50_filter_drop = {
+    include logstash_50_filter_plugin_common
     "percentage" ? long(0..100)
     "periodic_flush" ? boolean
 };
 
-type logstash_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
+type logstash_50_filter_mutate_convert = string with match(SELF, '^(integer|float|string|boolean)$');
 
-type logstash_filter_mutate = {
-    include logstash_filter_plugin_common
-    "convert" ? logstash_filter_mutate_convert{}
-    "replace" ? logstash_name_pattern[]
+type logstash_50_filter_mutate = {
+    include logstash_50_filter_plugin_common
+    "convert" ? logstash_50_filter_mutate_convert{}
+    "replace" ? logstash_50_name_pattern[]
     "rename" ? string{}
     "split" ? string{}
     "update" ? string{}
@@ -222,8 +222,8 @@ type logstash_filter_mutate = {
     }
 };
 
-type logstash_filter_kv = {
-    include logstash_filter_plugin_common
+type logstash_50_filter_kv = {
+    include logstash_50_filter_plugin_common
     "default_keys" ? string{}
     "exclude_keys" ? string[]
     "include_keys" ? string[]
@@ -235,31 +235,31 @@ type logstash_filter_kv = {
     "value_split" ? string
 };
 
-type logstash_filter_plugin = {
-    "grok" ? logstash_filter_grok
-    "date" ? logstash_filter_date
-    "grep" ? logstash_filter_grep with {
+type logstash_50_filter_plugin = {
+    "grok" ? logstash_50_filter_grok
+    "date" ? logstash_50_filter_date
+    "grep" ? logstash_50_filter_grep with {
         deprecated(0, 'grep filter is removed from 2.0, use e.g. conditional drop'); true;
     }
-    "drop" ? logstash_filter_drop
-    "mutate" ? logstash_filter_mutate
-    "kv" ? logstash_filter_kv
-    "bytes2human" ? logstash_filter_bytes2human
+    "drop" ? logstash_50_filter_drop
+    "mutate" ? logstash_50_filter_mutate
+    "kv" ? logstash_50_filter_kv
+    "bytes2human" ? logstash_50_filter_bytes2human
 } with length(SELF) == 1;
 
 @{ Common output }
-type logstash_output_codec = {
-    "plain" ? logstash_codec_plain
+type logstash_50_output_codec = {
+    "plain" ? logstash_50_codec_plain
 } with length(SELF) == 1;
 
-type logstash_output_plugin_common = {
-    include logstash_plugin_common
-    "codec" ? logstash_output_codec
+type logstash_50_output_plugin_common = {
+    include logstash_50_plugin_common
+    "codec" ? logstash_50_output_codec
 };
 
 @{ GELF-based output }
-type logstash_output_gelf = {
-    include logstash_output_plugin_common
+type logstash_50_output_gelf = {
+    include logstash_50_output_plugin_common
     "host" : type_fqdn
     "level" : string[] = list("info")
     "port" : type_port = 12201
@@ -271,9 +271,9 @@ type logstash_output_gelf = {
 };
 
 @{ tcp-based output }
-type logstash_output_tcp = {
-    include logstash_output_plugin_common
-    include logstash_ssl
+type logstash_50_output_tcp = {
+    include logstash_50_output_plugin_common
+    include logstash_50_ssl
     "ssl_cacert" ? string
     "enable_metric" ? boolean = true
     "host" : type_fqdn
@@ -285,18 +285,18 @@ type logstash_output_tcp = {
 };
 
 @{ stdout-based output }
-type logstash_output_stdout = {
-    include logstash_output_plugin_common
+type logstash_50_output_stdout = {
+    include logstash_50_output_plugin_common
     "debug" ? boolean
 };
 
 @{ elasticsearch-based output }
-type logstash_output_elasticsearch = {
-    include logstash_output_plugin_common
+type logstash_50_output_elasticsearch = {
+    include logstash_50_output_plugin_common
     "bind_host" ? type_hostname
     "hosts" ? type_hostport[]
     "host" ? type_hostname with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
-    "port" ? logstash_port_range with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
+    "port" ? logstash_50_port_range with {deprecated(0, 'removed in version 2.0 (use hosts instead)'); true; }
     "cluster" ? string with {deprecated(0, 'removed in version 2.0'); true; }
     "embedded" ? boolean = false with {deprecated(0, 'removed in version 2.0'); true; }
     "index" : string = "logstash-%{+YYYY.MM.dd}"
@@ -306,90 +306,90 @@ type logstash_output_elasticsearch = {
     "template_overwrite" ? boolean
 };
 
-type logstash_output_plugin = {
-    "elasticsearch" ? logstash_output_elasticsearch
-    "gelf" ? logstash_output_gelf
-    "stdout" ? logstash_output_stdout
-    "tcp" ? logstash_output_tcp
+type logstash_50_output_plugin = {
+    "elasticsearch" ? logstash_50_output_elasticsearch
+    "gelf" ? logstash_50_output_gelf
+    "stdout" ? logstash_50_output_stdout
+    "tcp" ? logstash_50_output_tcp
 } with length(SELF) == 1;
 
-type logstash_input_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_input_plugin[]
+type logstash_50_input_conditional = {
+    include logstash_50_conditional
+    "plugins" ? logstash_50_input_plugin[]
 };
 
-type logstash_filter_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_filter_plugin[]
+type logstash_50_filter_conditional = {
+    include logstash_50_conditional
+    "plugins" ? logstash_50_filter_plugin[]
 };
 
-type logstash_output_conditional = {
-    include logstash_conditional
-    "plugins" ? logstash_output_plugin[]
+type logstash_50_output_conditional = {
+    include logstash_50_conditional
+    "plugins" ? logstash_50_output_plugin[]
 };
 
-type logstash_input = {
-    "plugins" ? logstash_input_plugin[]
-    "conditionals" ? logstash_input_conditional[]
+type logstash_50_input = {
+    "plugins" ? logstash_50_input_plugin[]
+    "conditionals" ? logstash_50_input_conditional[]
 };
 
-type logstash_filter = {
-    "plugins" ? logstash_filter_plugin[]
-    "conditionals" ? logstash_filter_conditional[]
+type logstash_50_filter = {
+    "plugins" ? logstash_50_filter_plugin[]
+    "conditionals" ? logstash_50_filter_conditional[]
 };
 
-type logstash_output = {
-    "plugins" ? logstash_output_plugin[]
-    "conditionals" ? logstash_output_conditional[]
+type logstash_50_output = {
+    "plugins" ? logstash_50_output_plugin[]
+    "conditionals" ? logstash_50_output_conditional[]
 };
 
 @{ The configuration is made of input, filter and output section }
-type type_logstash = {
-    "input" : logstash_input
-    "filter" ? logstash_filter
-    "output" : logstash_output
+type type_logstash_50 = {
+    "input" : logstash_50_input
+    "filter" ? logstash_50_filter
+    "output" : logstash_50_output
 };
 
 @{ logstash-forwarder type }
-type type_logstash_forwarder_network_server = {
+type type_logstash_50_forwarder_network_server = {
     "host" : type_hostname
     "port" : long(0..)
 };
 
-type type_logstash_forwarder_network = {
-    "servers" : type_logstash_forwarder_network_server[]
+type type_logstash_50_forwarder_network = {
+    "servers" : type_logstash_50_forwarder_network_server[]
     "ssl_certificate" ? string
     "ssl_key" ? string
     "ssl_ca" ? string
     "timeout" : long(0..) = 15
 };
 
-type type_logstash_forwarder_file_fields = {
+type type_logstash_50_forwarder_file_fields = {
     "type" : string
 };
 
-type type_logstash_forwarder_file = {
+type type_logstash_50_forwarder_file = {
     "paths" : string[]
-    "fields" : type_logstash_forwarder_file_fields
+    "fields" : type_logstash_50_forwarder_file_fields
 };
 
-type type_logstash_forwarder = {
-    "network" : type_logstash_forwarder_network
-    "files" : type_logstash_forwarder_file[]
+type type_logstash_50_forwarder = {
+    "network" : type_logstash_50_forwarder_network
+    "files" : type_logstash_50_forwarder_file[]
 };
 
-type type_logstash_yml_node = {
+type type_logstash_50_yml_node = {
     "name" ? string
 };
 
-type type_logstash_yml_pipeline = {
+type type_logstash_50_yml_pipeline = {
     "workers" ? long
     "output.workers" ? long
     "batch.size" ? long
     "unsafe_shutdown" ? boolean
 };
 
-type type_logstash_yml_path = {
+type type_logstash_50_yml_path = {
     "config" ? string
     "data" ? string
     "logs" ? string
@@ -397,7 +397,7 @@ type type_logstash_yml_path = {
     "queue" ? string
 };
 
-type type_logstash_yml_config = {
+type type_logstash_50_yml_config = {
     "string" ? string
     "test_and_exit" ? boolean
     "reload.automatic" ? boolean
@@ -405,7 +405,7 @@ type type_logstash_yml_config = {
     "debug" ? boolean
 };
 
-type type_logstash_yml_queue = {
+type type_logstash_50_yml_queue = {
     "type" ? string
     "page_capacity" ? string
     "max_events" ? long
@@ -415,22 +415,22 @@ type type_logstash_yml_queue = {
     "checkpoint.interval" ? long
 };
 
-type type_logstash_yml_http = {
+type type_logstash_50_yml_http = {
     "host" ? string
     "port" ? string
 };
 
-type type_logstash_yml_log = {
+type type_logstash_50_yml_log = {
     "level" ? string with match(SELF, "(fatal|error|warn|info|debug|trace)")
 };
 
-type type_logstash_yml = {
-    "node" ? type_logstash_yml_node
-    "pipeline" ? type_logstash_yml_pipeline
-    "path" ? type_logstash_yml_path
-    "config" ? type_logstash_yml_config
-    "queue" ? type_logstash_yml_queue
-    "http" ? type_logstash_yml_http
-    "log" ? type_logstash_yml_log
+type type_logstash_50_yml = {
+    "node" ? type_logstash_50_yml_node
+    "pipeline" ? type_logstash_50_yml_pipeline
+    "path" ? type_logstash_50_yml_path
+    "config" ? type_logstash_50_yml_config
+    "queue" ? type_logstash_50_yml_queue
+    "http" ? type_logstash_50_yml_http
+    "log" ? type_logstash_50_yml_log
 };
 


### PR DESCRIPTION
The multiple schema versions contain duplicate types which break tests when they are copied to the template library, so refactor the schema to avoid this.

* Rename duplicate type definitions.
* Include and bind version specific schema from version specific configs.
* Replace `logstash/pan/schema` with an empty common schema. The original was non-functional, it tried to include a template which did not exist.