### PR TITLE
ncm-puppet: puppet v4 and v5 compatibility

### DIFF
--- a/ncm-puppet/src/main/pan/components/puppet/schema.pan
+++ b/ncm-puppet/src/main/pan/components/puppet/schema.pan
@@ -3,48 +3,50 @@
 # ${author-info}
 # ${build-info}
 
-declaration template components/${project.artifactId}/schema;
+declaration template components/puppet/schema;
 
 include 'quattor/schema';
 
-type ${project.artifactId}_module = {
+type puppet_module = {
     "version" ? string
 };
 
-type ${project.artifactId}_nodefile = {
+type puppet_nodefile = {
     "contents" ? string
 };
 
-type ${project.artifactId}_puppetconf_main = extensible {
+type puppet_puppetconf_main = extensible {
     "logdir" : string = "/var/log/puppet"
     "rundir" : string = "/var/run/puppet"
 };
 
-
-
-type ${project.artifactId}_puppetconf = extensible {
-    "main" : ${project.artifactId}_puppetconf_main
+type puppet_puppetconf = extensible {
+    "main" : puppet_puppetconf_main
 };
 
 type puppet_hieraconf_yaml = extensible {
     "_3adatadir" : string = "/etc/puppet/hieradata"
 };
 
-type puppet_hieraconf = extensible {
-    "_3abackends" : string[] = list("yaml")
-    "_3ayaml" : puppet_hieraconf_yaml
-    "_3ahierarchy" : string[] = list("quattor")
-};
+type puppet_hieraconf = extensible {};
 
-type ${project.artifactId}_hieradata = extensible {};
+type puppet_hieradata = extensible {};
 
-type ${project.artifactId}_component = {
+type puppet_component = {
     include structure_component
-    "modules" ? ${project.artifactId}_module{}
-    "nodefiles" : ${project.artifactId}_nodefile{}= dict(escape("quattor_default.pp"), dict("contents", "hiera_include('classes')"))
-    "puppetconf" : ${project.artifactId}_puppetconf = dict("main", dict("logdir", "/var/log/puppet", "rundir", "/var/run/puppet"))
-    "hieraconf" : ${project.artifactId}_hieraconf = dict(escape(":backends"), list("yaml"), escape(":yaml"), dict(escape(":datadir"), "/etc/puppet/hieradata"), escape(":hierarchy"), list("quattor"))
-    "hieradata" ? ${project.artifactId}_hieradata
+    "puppet_cmd" : string = "/usr/bin/puppet"
+    "logfile" : string = "/var/log/puppet/log"
+    "modulepath" : string = "/etc/puppet/modules"
+    "modules" ? puppet_module{}
+    "nodefiles" : puppet_nodefile{} = dict(escape("quattor_default.pp"), dict("contents", "hiera_include('classes')"))
+    "nodefiles_path" : string = '/etc/puppet/manifests'
+    "puppetconf" : puppet_puppetconf = dict("main", dict("logdir", "/var/log/puppet", "rundir", "/var/run/puppet"))
+    "puppetconf_file" : string = '/etc/puppet/puppet.conf'
+    "hieraconf" : puppet_hieraconf = dict(escape(":backends"), list("yaml"), escape(":yaml"),
+        dict(escape(":datadir"), "/etc/puppet/hieradata"), escape(":hierarchy"), list("quattor"))
+    "hieraconf_file" : string = "/etc/puppet/hiera.yaml"
+    "hieradata" ? puppet_hieradata
+    "hieradata_file" : string = "/etc/puppet/hieradata/quattor.yaml"
 };
 
-bind '/software/components/${project.artifactId}' = ${project.artifactId}_component;
+bind '/software/components/puppet' = puppet_component;

--- a/ncm-puppet/src/test/perl/apply.t
+++ b/ncm-puppet/src/test/perl/apply.t
@@ -25,7 +25,10 @@ use Readonly;
 Readonly::Scalar my $GOOD => "This is a fake content";
 Readonly::Scalar my $WRONG => "This is a wrong fake content";
 Readonly::Scalar my $FILES_DIR => "/etc/puppet/manifests";
-Readonly::Scalar my $APPLY_CMD => "puppet apply --detailed-exitcodes -v -l /var/log/puppet/log";
+Readonly::Scalar my $MODULES_DIR => "/etc/puppet/modules";
+Readonly::Scalar my $LOGS => "/var/log/puppet/log";
+Readonly::Scalar my $CMD => "puppet";
+Readonly::Scalar my $APPLY_CMD => "$CMD apply --detailed-exitcodes -v -l $LOGS --modulepath $MODULES_DIR";
 
 =pod
 
@@ -38,7 +41,7 @@ my $fh;
 set_file_contents("$FILES_DIR/foo1.pp",$WRONG);
 set_file_contents("$FILES_DIR/foo2.pp",$WRONG);
 $comp->nodefiles({'foo1_2epp' => {'contents'=>$GOOD},
-                  'foo2_2epp' => {'contents'=>$GOOD}});
+                  'foo2_2epp' => {'contents'=>$GOOD}},$FILES_DIR);
 $fh = get_file("$FILES_DIR/foo1.pp");
 is("$fh", $GOOD, "checkfile function puts the correct content in the node files");
 $fh = get_file("$FILES_DIR/foo2.pp");
@@ -65,7 +68,7 @@ Tests that the apply function correctly runs the "puppet apply" command. Three s
 set_command_status("$APPLY_CMD $FILES_DIR/foo1.pp",0);
 set_command_status("$APPLY_CMD $FILES_DIR/foo2.pp",0);
 
-$comp->apply({'foo1_2epp' => {'contents'=>$GOOD},'foo2_2epp' => {'contents'=>$GOOD}});
+$comp->apply({'foo1_2epp' => {'contents'=>$GOOD},'foo2_2epp' => {'contents'=>$GOOD}},$FILES_DIR,$CMD,$MODULES_DIR,$LOGS);
 
 ok(defined(get_command("$APPLY_CMD $FILES_DIR/foo1.pp")), "1st apply command is invoked");
 ok(defined(get_command("$APPLY_CMD $FILES_DIR/foo2.pp")), "2nd apply command is invoked");
@@ -89,7 +92,7 @@ ok(!exists($comp->{INFO}), "No messages when there are no changes");
 set_command_status("$APPLY_CMD $FILES_DIR/foo3.pp",2<<8);
 set_command_status("$APPLY_CMD $FILES_DIR/foo4.pp",0);
 
-$comp->apply({'foo3_2epp' => {'contents'=>$GOOD},'foo4_2epp' => {'contents'=>$GOOD}});
+$comp->apply({'foo3_2epp' => {'contents'=>$GOOD},'foo4_2epp' => {'contents'=>$GOOD}},$FILES_DIR,$CMD,$MODULES_DIR,$LOGS);
 
 ok(defined(get_command("$APPLY_CMD $FILES_DIR/foo3.pp")), "1st apply command is invoked");
 ok(defined(get_command("$APPLY_CMD $FILES_DIR/foo4.pp")), "2nd apply command is invoked");
@@ -114,7 +117,7 @@ ok(exists($comp->{INFO}), "A message is printed to inform that a change was made
 
 set_command_status("$APPLY_CMD $FILES_DIR/foo5.pp",6<<8);
 
-$comp->apply({'foo5_2epp' => {'contents'=>$GOOD}});
+$comp->apply({'foo5_2epp' => {'contents'=>$GOOD}},$FILES_DIR,$CMD,$MODULES_DIR,$LOGS);
 
 ok(defined(get_command("$APPLY_CMD $FILES_DIR/foo5.pp")), "apply command is invoked");
 ok(exists($comp->{ERROR}), "The component exits with error");

--- a/ncm-puppet/src/test/perl/functions.t
+++ b/ncm-puppet/src/test/perl/functions.t
@@ -43,7 +43,8 @@ Readonly::Hash my %HASH_IN => (
 			       "_3akey3" =>  {
 					      "_3akey4" => "_3avalue5",
 					      "_3akey6" => {"_3akey7" => "value8"}
-					     }
+					     },
+			       "_3akey9" => 1234
 			       );
 Readonly::Hash my %HASH_EXP => (
 			       ":key1" => "value1",
@@ -51,7 +52,8 @@ Readonly::Hash my %HASH_EXP => (
 			       ":key3" =>  {
 					      ":key4" => "_3avalue5",
 					      ":key6" => {":key7" => "value8"}
-					     }
+					     },
+			       ":key9" => 1234
 			       );
 
 Readonly::Hash my %HASH_TINY => (
@@ -78,6 +80,7 @@ Readonly::Scalar my $YAML => <<YAML;
   :key4: _3avalue5
   :key6:
     :key7: value8
+:key9: 1234
 YAML
 Readonly::Scalar my $TINY => <<TINY;
 [section1]

--- a/ncm-puppet/src/test/perl/install_modules.t
+++ b/ncm-puppet/src/test/perl/install_modules.t
@@ -23,8 +23,10 @@ $CAF::Object::NoAction = 1;
 my $comp = NCM::Component::puppet->new('puppet');
 
 use Readonly;
-Readonly::Scalar my $UPGRADE =>'puppet module upgrade';
-Readonly::Scalar my $INSTALL =>'puppet module install';
+Readonly::Scalar my $MODULES_DIR => "/etc/puppet/modules";
+Readonly::Scalar my $CMD => "puppet";
+Readonly::Scalar my $UPGRADE =>"$CMD module upgrade --modulepath $MODULES_DIR";
+Readonly::Scalar my $INSTALL =>"$CMD module install --modulepath $MODULES_DIR";
 
 =pod
 
@@ -101,7 +103,7 @@ set_desired_err("$INSTALL NOT_EXISTING_MODULE","stderr");
 set_command_status("$INSTALL NOT_EXISTING_MODULE",1<<8);
 
 
-$comp->install_modules({INSTALLED_MODULE => {},NOT_INSTALLED_MODULE=>{}});
+$comp->install_modules({INSTALLED_MODULE => {},NOT_INSTALLED_MODULE=>{}},$CMD,$MODULES_DIR);
 
 ok(defined(get_command("$UPGRADE INSTALLED_MODULE")), "module upgrade is invoked on installed module");
 ok(!defined(get_command("$INSTALL INSTALLED_MODULE")), "module install is not invoked on installed module");
@@ -111,7 +113,7 @@ ok(defined(get_command("$UPGRADE NOT_INSTALLED_MODULE")), "module upgrade is inv
 ok(defined(get_command("$INSTALL NOT_INSTALLED_MODULE")), "module install is invoked on not installed module");
 ok(!exists($comp->{ERROR}), "No errors found in normal execution");
 
-$comp->install_modules({INSTALLED_MODULE => {},NOT_EXISTING_MODULE=>{}});
+$comp->install_modules({INSTALLED_MODULE => {},NOT_EXISTING_MODULE=>{}},$CMD,$MODULES_DIR);
 
 ok(defined(get_command("$UPGRADE NOT_EXISTING_MODULE")), "module upgrade is invoked on non existing module");
 ok(defined(get_command("$INSTALL NOT_EXISTING_MODULE")), "module install is invoked on non existing module");


### PR DESCRIPTION
* Why the change is necessary.
the previous version of the ncm-puppet was not compliant with puppet v4 and v5. In particular, as things in such version have been heavily reorganized (executable, configuration files, modules, manifests locations have changed, for example) it was necessary to update the schema and the component introducing more flexibility.
 
* What backwards incompatibility it may introduce.
There is no real backward incompatibility. We added new fields in the schema but the default values of such fields are those used for puppet v3 (so, those that were hardcoded in the old version of the component).

