### PR TITLE
ncm-metaconfig: service logstash: remove include of non-existing version template

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/logstash/pan/schema.pan
@@ -1,4 +1,3 @@
 declaration template metaconfig/logstash/schema;
 
-include 'metaconfig/logstash/version';
 include format('metaconfig/logstash/schema_%s', METACONFIG_LOGSTASH_VERSION);


### PR DESCRIPTION
Required to make the template-library-core unittests pass