### PR TITLE
Remove lint from shared AII components (ncm-freeipa & ncm-opennebula)

### DIFF
--- a/ncm-freeipa/src/main/pan/components/freeipa/schema.pan
+++ b/ncm-freeipa/src/main/pan/components/freeipa/schema.pan
@@ -26,7 +26,7 @@ type component_${project.artifactId}_user = {
     @{first name}
     'givenname' : string
     @{group name (must be a configured group to retrieve the gid)}
-    'group' ? string with exists('/software/components/${project.artifactId}/server/groups/'+SELF)
+    'group' ? string with exists('/software/components/${project.artifactId}/server/groups/' + SELF)
     @{homedirectory}
     'homedirectory' ? string
     @{gecos}

--- a/ncm-freeipa/src/main/pan/quattor/aii/freeipa/default.pan
+++ b/ncm-freeipa/src/main/pan/quattor/aii/freeipa/default.pan
@@ -9,16 +9,16 @@ include 'quattor/aii/freeipa/schema';
 variable FREEIPA_AII_REMOVE ?= false;
 variable FREEIPA_AII_DISABLE ?= true;
 
-"/system/aii/hooks/post_reboot/" = append(dict(
+"/system/aii/hooks/post_reboot" = append(dict(
     'module', FREEIPA_AII_MODULE_NAME,
-     ));
+));
 
 bind "/system/aii/hooks" = dict with validate_aii_freeipa_hooks('post_reboot');
 
-"/system/aii/hooks/remove/" = append(dict(
+"/system/aii/hooks/remove" = append(dict(
     'module', FREEIPA_AII_MODULE_NAME,
     'remove', FREEIPA_AII_REMOVE,
     'disable', FREEIPA_AII_DISABLE,
-    ));
+));
 
 bind "/system/aii/hooks" = dict with validate_aii_freeipa_hooks('remove');

--- a/ncm-freeipa/src/main/pan/quattor/aii/freeipa/schema.pan
+++ b/ncm-freeipa/src/main/pan/quattor/aii/freeipa/schema.pan
@@ -24,7 +24,7 @@ function validate_aii_freeipa_hooks = {
     hook = SELF[ARGV[0]];
     found = false;
     ind = 0;
-    foreach (i;v;hook) {
+    foreach (i; v; hook) {
         if (exists(v['module']) && v['module'] == FREEIPA_AII_MODULE_NAME) {
             if (found) {
                 error(format("%s: second freeipa %s hook found", FUNCTION, name));

--- a/ncm-freeipa/src/test/perl/net_freeipa.pm
+++ b/ncm-freeipa/src/test/perl/net_freeipa.pm
@@ -13,6 +13,6 @@ $json->mock('decode_json', {
     $self>{rc} = $RC;
 });
 
-our 
+our
 
 1;

--- a/ncm-freeipa/src/test/perl/rpc_data/host
+++ b/ncm-freeipa/src/test/perl/rpc_data/host
@@ -9,7 +9,7 @@ $cmds{host_disable}{result}={okunittest => 1};
 
 $cmds{host_remove}{cmd}="1 host_del host.domain updatedns=1,.*";
 $cmds{host_remove}{result}={okunittest => 1};
-    
+
 $cmds{host_passwd}{cmd}="1 host_mod host.domain random=1,.*";
 $cmds{host_passwd}{result}={randompassword => 'supersecret'};
 

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -720,7 +720,7 @@ type component_opennebula = {
     'vnm_conf' ? opennebula_vnm_conf
     @{set ssh host multiplex options}
     'ssh_multiplex' : boolean = true
-    @{in some cases (such a Sunstone standalone configuration with apache), 
+    @{in some cases (such a Sunstone standalone configuration with apache),
     some OpenNebula configuration files should be accessible by a different group (as apache).
     This variable sets the group name to change these files permissions.}
     'cfg_group' ? string

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/default.pan
@@ -4,7 +4,7 @@ include 'quattor/aii/opennebula/schema';
 include 'quattor/aii/opennebula/functions';
 
 # do not overwrite/remove templates by default
-variable OPENNEBULA_AII_FORCE ?= null; 
+variable OPENNEBULA_AII_FORCE ?= null;
 variable OPENNEBULA_AII_ONHOLD ?= null;
 variable OPENNEBULA_AII_FORCE_REMOVE ?= false;
 

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/functions.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/functions.pan
@@ -8,7 +8,7 @@ Based on OpenNebula opennebula_ipv42mac function:
 
 https://github.com/OpenNebula/one/blob/master/share/router/vmcontext.rb
 
-Syntax: 
+Syntax:
 mac_prefix:string ipv4:string
 
 mac_prefix hex:hex value used also by oned.conf (02:00 by default)
@@ -39,7 +39,7 @@ function opennebula_ipv42mac = {
 This function replaces nic hwaddr using OpenNebula MAC function
 Use the same MAC_PREFIX for OpenNebula component (oned.conf) and AII
 
-Syntax: 
+Syntax:
 mac_prefix:string
 
 mac_prefix hex:hex value used by oned.conf
@@ -66,10 +66,10 @@ function opennebula_replace_vm_mac = {
                     if (exists(interv['ip'])) {
                         mac = opennebula_ipv42mac(ARGV[0], interv['ip']);
                         SELF[eth]['hwaddr'] = mac;
-                    }; 
+                    };
                     if (exists(interv['bridge']) &&
                         exists("/system/network/interfaces/" + interv['bridge'] + "/ip")) {
-                        mac = opennebula_ipv42mac(ARGV[0], 
+                        mac = opennebula_ipv42mac(ARGV[0],
                             value("/system/network/interfaces/" + interv['bridge'] + "/ip"));
                         SELF[eth]['hwaddr'] = mac;
                     };

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -4,7 +4,7 @@ include 'pan/types';
 
 final variable OPENNEBULA_AII_MODULE_NAME ?= 'NCM::Component::opennebula';
 
-@documentation{ 
+@documentation{
 Function to validate all aii_opennebula hooks
 }
 function validate_aii_opennebula_hooks = {
@@ -109,7 +109,7 @@ function is_consistent_memorybacking = {
     true;
 };
 
-@documentation{ 
+@documentation{
 Type that checks if the network interface is available from the quattor tree
 }
 type valid_interface_ignoremac = string with {
@@ -119,7 +119,7 @@ type valid_interface_ignoremac = string with {
     true;
 };
 
-@documentation{ 
+@documentation{
 Type that sets which net interfaces/MACs
 will not include MAC values within ONE templates
 }
@@ -217,10 +217,10 @@ type opennebula_vmtemplate = {
     @{Set pci list values to enable PCI Passthrough.
     PCI passthrough section is also generated based on /hardware/cards/<card_type>/<interface>/pci values.}
     "pci" ? opennebula_vmtemplate_pci[]
-    @{labels is a list of strings to group the VMs under a given name and filter them 
-    in the admin and cloud views. It is also possible to include in the list 
+    @{labels is a list of strings to group the VMs under a given name and filter them
+    in the admin and cloud views. It is also possible to include in the list
     sub-labels using a common slash: list("Name", "Name/SubName")
-    This feature is available since OpenNebula 5.x, below this version the change 
+    This feature is available since OpenNebula 5.x, below this version the change
     does not take effect.}
     "labels" ? string[]
     "placements" ? opennebula_placements

--- a/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
@@ -16,8 +16,8 @@ Readonly my $BOOT_V5 => [qw(nic0 disk0)];
 
 =head1 NAME
 
-C<NCM::Component::OpenNebula::AII> adds C<AII> hook 
-to generate the required resources and templates 
+C<NCM::Component::OpenNebula::AII> adds C<AII> hook
+to generate the required resources and templates
 to instantiate/create/remove VMs within an C<OpenNebula> infrastructure.
 
 =head2 AII

--- a/ncm-opennebula/src/main/perl/OpenNebula/Account.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Account.pm
@@ -7,7 +7,7 @@ Readonly my $CORE_AUTH_DRIVER => "core";
 
 =head1 NAME
 
-C<NCM::Component::OpenNebula::Account> adds and modifies C<OpenNebula> user 
+C<NCM::Component::OpenNebula::Account> adds and modifies C<OpenNebula> user
 and groups accounts.
 
 =head2 Public methods

--- a/ncm-opennebula/src/main/perl/OpenNebula/Ceph.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Ceph.pm
@@ -107,7 +107,7 @@ sub detect_ceph_datastores
 {
     my ($self, $one) = @_;
     my @datastores = $one->get_datastores();
-    
+
     foreach my $datastore (@datastores) {
         if ($datastore->{data}->{TM_MAD}->[0] eq "ceph") {
             $self->verbose("Detected Ceph datastore: ", $datastore->name);

--- a/ncm-opennebula/src/main/perl/OpenNebula/Commands.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Commands.pm
@@ -8,7 +8,7 @@ use CAF::Process;
 use File::Basename;
 use Readonly;
 
-Readonly::Array our @SSH_MULTIPLEX_OPTS => qw(-o ControlMaster=auto 
+Readonly::Array our @SSH_MULTIPLEX_OPTS => qw(-o ControlMaster=auto
     -o ControlPersist=600 -o ControlPath=/tmp/ssh_mux_%h_%p_%r);
 Readonly::Array our @SSH_COMMAND => qw(/usr/bin/ssh);
 Readonly::Array my @VIRSH_COMMAND => qw(sudo /usr/bin/virsh);
@@ -29,7 +29,7 @@ C<NCM::Component::OpenNebula::Commands> Configuration module for ONE
 Configuration module for OpenNebula. Executes the required ssh commands
 to enable the hosts to be used by the cloud server.
 
-This component needs a 'oneadmin' user. 
+This component needs a 'oneadmin' user.
 The user should be able to run these commands with sudo without password:
 
 =over
@@ -131,7 +131,7 @@ Checks for shell escapes.
 sub has_shell_escapes {
     my ($self, $cmd) = @_;
     if (grep(m{[;&>|"']}, @$cmd) ) {
-        $self->error("Invalid shell escapes found in ", 
+        $self->error("Invalid shell escapes found in ",
             join(" ", @$cmd));
         return 0;
     }
@@ -146,8 +146,8 @@ Executes a command as C<oneadmin> user.
 
 sub run_command_as_oneadmin {
     my ($self, $command, $secret) = @_;
-    
-    $self->has_shell_escapes($command) or return; 
+
+    $self->has_shell_escapes($command) or return;
     $command = [join(' ',@$command)];
     return $self->run_command([@SU_ONEADMIN_COMMAND, @$command], $secret);
 }
@@ -171,7 +171,7 @@ Accepts and adds unknown keys if wanted.
 =cut
 
 sub ssh_known_keys {
-    my ($self, $host, $key_accept, $homedir) = @_; 
+    my ($self, $host, $key_accept, $homedir) = @_;
     if ($key_accept eq 'first'){
         # If not in known_host, scan key and add; else do nothing
         my $cmd = [@SSH_KEYGEN_COMMAND, '-F', $host];
@@ -190,7 +190,7 @@ sub ssh_known_keys {
         # SSH into machine with -o StrictHostKeyChecking=no
         # dummy ssh does the trick
         $self->run_command_as_oneadmin_with_ssh(['uname'], $host, ['-o', 'StrictHostKeyChecking=no']);
-    }   
+    }
 }
 
 =item can_connect_to_host

--- a/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
@@ -56,9 +56,9 @@ sub manage_hosts
 
     foreach my $host (@$hosts) {
         my %host_options = (
-            'name'    => $host, 
-            'im_mad'  => $type, 
-            'vmm_mad' => $type, 
+            'name'    => $host,
+            'im_mad'  => $type,
+            'vmm_mad' => $type,
             'vnm_mad' => $vnm_mad
         );
         # to keep the record of our cloud infrastructure

--- a/ncm-opennebula/src/main/perl/OpenNebula/Image.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Image.pm
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-C<NCM::Component::OpenNebula::Image> adds C<OpenNebula> C<VM> images 
+C<NCM::Component::OpenNebula::Image> adds C<OpenNebula> C<VM> images
 support to C<NCM::Component::OpenNebula>.
 
 =head2 Public methods
@@ -42,8 +42,8 @@ sub get_images
 
 =item remove_or_create_vm_images
 
-Creates new C<VM> images and it detects if the image is 
-already available or not. 
+Creates new C<VM> images and it detects if the image is
+already available or not.
 Also it removes images if the remove flag is set.
 
 =cut

--- a/ncm-opennebula/src/main/perl/OpenNebula/Network.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Network.pm
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-C<NCM::Component::OpenNebula::Network> adds C<OpenNebula> C<VirtualNetwork> 
+C<NCM::Component::OpenNebula::Network> adds C<OpenNebula> C<VirtualNetwork>
 configuration support to L<NCM::Component::opennebula>.
 
 =head2 Public methods

--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -24,7 +24,7 @@ Readonly::Array our @SERVERADMIN_AUTH_FILE => qw(sunstone_auth oneflow_auth
 
 =head1 NAME
 
-C<NCM::Component::OpenNebula::Server> adds C<OpenNebula> service configuration 
+C<NCM::Component::OpenNebula::Server> adds C<OpenNebula> service configuration
 support to C<NCM::Component::OpenNebula>.
 
 =head2 Public methods

--- a/ncm-opennebula/src/main/perl/OpenNebula/VM.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/VM.pm
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-C<NCM::Component::OpenNebula::VM> adds C<OpenNebula> C<VMs> 
+C<NCM::Component::OpenNebula::VM> adds C<OpenNebula> C<VMs>
 manage support to C<NCM::Component::OpenNebula>.
 
 =head2 Public methods

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -126,7 +126,7 @@ Readonly our $ONED_CONF_FILE => "/etc/one/oned.conf";
 Readonly our $SUNSTONE_CONF_FILE => "/etc/one/sunstone-server.conf";
 Readonly our $ONEFLOW_CONF_FILE => "/etc/one/oneflow-server.conf";
 
-# Required by process_template to detect 
+# Required by process_template to detect
 # if it should return a text template or
 # CAF::FileWriter instance
 Readonly::Array my @FILEWRITER_TEMPLATES => qw(oned one_auth kvmrc vnm_conf sunstone remoteconf_ceph oneflow);
@@ -140,7 +140,7 @@ Sets C<OpenNebula> C<RPC> endpoint info to connect to ONE API.
 
 =cut
 
-sub make_one 
+sub make_one
 {
     my ($self, $rpc) = @_;
 
@@ -207,7 +207,7 @@ Creates/updates ONE resources based on resource type.
 sub create_or_update_something
 {
     my ($self, $one, $type, $data, %protected) = @_;
-    
+
     my $template = $self->process_template($data, $type);
     my ($name, $new);
     if (!$template) {

--- a/ncm-opennebula/src/main/resources/imagetemplate.tt
+++ b/ncm-opennebula/src/main/resources/imagetemplate.tt
@@ -1,4 +1,4 @@
-[%- tmphost = [ system.network.hostname, system.network.domainname ]; 
+[%- tmphost = [ system.network.hostname, system.network.domainname ];
     fqdn = tmphost.join('.') -%]
 [%- FOR pair IN hardware.harddisks.pairs %]
 TYPE = "DATABLOCK"

--- a/ncm-opennebula/src/main/resources/network_ar.tt
+++ b/ncm-opennebula/src/main/resources/network_ar.tt
@@ -1,11 +1,11 @@
-[%- tmphost = [ system.network.hostname, system.network.domainname ]; 
+[%- tmphost = [ system.network.hostname, system.network.domainname ];
     fqdn = tmphost.join('.') -%]
 [% # We only include net interfaces that are mapped to VNETs-%]
 [%- FOR pair IN system.opennebula.vnet.pairs %]
 AR = [
 [%      FILTER indent -%]
 TYPE = "IP4",
-[%    INCLUDE 'opennebula/network_level1.tt' 
+[%    INCLUDE 'opennebula/network_level1.tt'
                data=pair -%]
 QUATTOR = "1",
 HOSTNAME = "[% fqdn %]",

--- a/ncm-opennebula/src/main/resources/oned.tt
+++ b/ncm-opennebula/src/main/resources/oned.tt
@@ -1,31 +1,31 @@
-[%- oned_section = ['db', 'log', 'federation', 'datastore_mad', 'tm_mad', 'hm_mad', 
-                    'auth_mad', 'default_cost', 'vnc_ports', 'vlan_ids', 'vxlan_ids', 
+[%- oned_section = ['db', 'log', 'federation', 'datastore_mad', 'tm_mad', 'hm_mad',
+                    'auth_mad', 'default_cost', 'vnc_ports', 'vlan_ids', 'vxlan_ids',
                     'market_mad'] -%]
 [%- booleans = ['datastore_capacity_check'] -%]
-[%- digits = ['monitoring_interval', 'monitoring_threads', 
-              'port', 'vnc_base_port', 'network_size', 'session_expiration_time', 
+[%- digits = ['monitoring_interval', 'monitoring_threads',
+              'port', 'vnc_base_port', 'network_size', 'session_expiration_time',
               'default_umask'] -%]
-[%- oned_attr_list = ['vm_restricted_attr', 'inherit_datastore_attr', 'inherit_vnet_attr', 
+[%- oned_attr_list = ['vm_restricted_attr', 'inherit_datastore_attr', 'inherit_vnet_attr',
                       'image_restricted_attr', 'vnet_restricted_attr', 'inherit_image_attr'] -%]
 [%- mad_conf_section = ['tm_mad_conf', 'ds_mad_conf', 'market_mad_conf'] -%]
 [%- FOR pair IN oned.pairs -%]
 [%-    SWITCH pair.key -%]
-[%         CASE oned_section -%]              
-[%             pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt' 
+[%         CASE oned_section -%]
+[%             pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
                                       data=oned.${pair.key} -%]
 [%         CASE 'im_mad' -%]
 [%-            FOREACH item IN oned.${pair.key}.pairs -%]
-[%                 pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt' 
+[%                 pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
                                           data=item.value name=item.key -%]
 [%             END -%]
 [%         CASE 'vm_mad' -%]
 [%-            FOREACH item IN oned.${pair.key}.pairs -%]
-[%                 pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt' 
+[%                 pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
                                           data=item.value name=item.key type=item.key -%]
 [%             END -%]
 [%         CASE mad_conf_section -%]
 [%-            FOREACH item IN oned.${pair.key} -%]
-[%                 pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt' 
+[%                 pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
                                           data=item -%]
 [%             END -%]
 [%         CASE oned_attr_list -%]

--- a/ncm-opennebula/src/main/resources/sunstone.tt
+++ b/ncm-opennebula/src/main/resources/sunstone.tt
@@ -4,7 +4,7 @@
 [%         CASE 'instance_types' -%]
 :[%            pair.key %]:
 [%             FOREACH item IN sunstone.${pair.key} -%]
-[%                 INCLUDE 'opennebula/sunstone_level1.tt' 
+[%                 INCLUDE 'opennebula/sunstone_level1.tt'
                                           data=item -%]
 [%             END -%]
 [%         CASE 'routes' -%]

--- a/ncm-opennebula/src/main/resources/tests/profiles/datastore_ceph.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/datastore_ceph.pan
@@ -8,7 +8,7 @@ bind "/metaconfig/contents/datastore/ceph" = opennebula_datastore;
 
 prefix "/metaconfig/contents/datastore/ceph";
 "bridge_list" = list("hyp004.cubone.os");
-"ceph_host" = list("ceph001.cubone.os","ceph002.cubone.os","ceph003.cubone.os");
+"ceph_host" = list("ceph001.cubone.os", "ceph002.cubone.os", "ceph003.cubone.os");
 "ceph_secret" = "35b161e7-a3bc-440f-b007-cb98ac042646";
 "ceph_user" = "libvirt";
 "ceph_user_key" = "dummydummycephuserkey";

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -1,4 +1,4 @@
-[%- tmphost = [ system.network.hostname, system.network.domainname ]; 
+[%- tmphost = [ system.network.hostname, system.network.domainname ];
     fqdn = tmphost.join('.') -%]
 [%- vcpus = 0 -%]
 [%- sockets = 0 -%]
@@ -16,7 +16,7 @@
 [%- FOR pair IN system.opennebula.vnet.pairs %]
 NIC = [
 [%  FILTER indent -%]
-[%    INCLUDE 'opennebula/network_level1.tt' 
+[%    INCLUDE 'opennebula/network_level1.tt'
                data = pair ignoremac = 1 -%]
 MODEL = "virtio",
 NETWORK = "[% system.opennebula.vnet.${pair.key} %]",

--- a/ncm-opennebula/src/main/resources/vnet.tt
+++ b/ncm-opennebula/src/main/resources/vnet.tt
@@ -7,7 +7,7 @@ NAME = "[% pool.key %]"
 [%            CASE booleans -%]
 [%                pair.key FILTER upper %] = "[% pair.value ? "YES" : "NO" %]"
 [%            CASE ar_section -%]
-[%                pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt' 
+[%                pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
                                       data=pair.value -%]
 [%            CASE 'labels' -%]
 [%                pair.key FILTER upper %] = "[% pair.value.join(',') %]"

--- a/ncm-opennebula/src/test/perl/OpennebulaMock.pm
+++ b/ncm-opennebula/src/test/perl/OpennebulaMock.pm
@@ -14,7 +14,7 @@ our @EXPORT = qw(rpc_history_reset rpc_history_ok diag_rpc_history);
 
 
 BEGIN {
-  *CORE::GLOBAL::getpwnam = sub { 
+  *CORE::GLOBAL::getpwnam = sub {
         my @ids = qw(1 2 3 4);
         return @ids;
     };
@@ -67,11 +67,11 @@ sub rpc_history_ok {
         return 0 if !defined($index) or $index <= $lastidx;
         $lastidx = $index;
     };
-    # in principle, when you get here, all is ok.                                                                                                                                        
-    # but at least 1 command should be found, so lastidx should be > -1                                                                                                                  
+    # in principle, when you get here, all is ok.
+    # but at least 1 command should be found, so lastidx should be > -1
 
     return $lastidx > -1;
-    
+
 }
 
 sub mock_rpc {
@@ -101,7 +101,7 @@ sub mock_rpc {
             } else {
                 note("is xml ", $data->{out});
                 return XMLin($data->{out}, forcearray => 1);
-            } 
+            }
         }
     }
 };

--- a/ncm-opennebula/src/test/perl/aii-basic.t
+++ b/ncm-opennebula/src/test/perl/aii-basic.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 # -*- mode: cperl -*-
 # ${license-info}
 # ${developer-info}

--- a/ncm-opennebula/src/test/perl/aii_images.t
+++ b/ncm-opennebula/src/test/perl/aii_images.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 # -*- mode: cperl -*-
 # ${license-info}
 # ${developer-info}

--- a/ncm-opennebula/src/test/perl/aii_kickstart.t
+++ b/ncm-opennebula/src/test/perl/aii_kickstart.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 # -*- mode: cperl -*-
 # ${license-info}
 # ${developer-info}

--- a/ncm-opennebula/src/test/perl/aii_network_ar.t
+++ b/ncm-opennebula/src/test/perl/aii_network_ar.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 # -*- mode: cperl -*-
 # ${license-info}
 # ${developer-info}

--- a/ncm-opennebula/src/test/perl/aii_vmtemplate.t
+++ b/ncm-opennebula/src/test/perl/aii_vmtemplate.t
@@ -1,4 +1,4 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 # -*- mode: cperl -*-
 # ${license-info}
 # ${developer-info}

--- a/ncm-opennebula/src/test/perl/commandsMock.pm
+++ b/ncm-opennebula/src/test/perl/commandsMock.pm
@@ -17,7 +17,7 @@ sub mock_run_command {
         note("This is my shortname:", $short);
         note("ssh internal command: ", $cmd);
         note("ssh dictionary command: ", $data->{command});
-        
+
         if ($sameparams) {
             note("ssh command found: ", $data->{out});
             return $data->{out};


### PR DESCRIPTION
Resolve white-space and other simple issues to prevent these from being propagated to **template-library-core** during the release process.

Also strips trailing white-space from the Perl code, because while we're at it... why not.