### PR TITLE
ncm-openstack: Schema fixes

### DIFF
--- a/ncm-openstack/src/main/pan/components/openstack/glance.pan
+++ b/ncm-openstack/src/main/pan/components/openstack/glance.pan
@@ -5,6 +5,7 @@
 
 declaration template components/openstack/glance;
 
+include 'components/openstack/keystone';
 
 @documentation {
     The Glance configuration options in the "glance_store" Section.

--- a/ncm-openstack/src/main/pan/components/openstack/neutron.pan
+++ b/ncm-openstack/src/main/pan/components/openstack/neutron.pan
@@ -5,6 +5,8 @@
 
 declaration template components/openstack/neutron;
 
+include 'components/openstack/keystone';
+
 @documentation {
     The Neutron configuration options in ml2_conf.ini "ml2" Section.
 }

--- a/ncm-openstack/src/main/pan/components/openstack/nova.pan
+++ b/ncm-openstack/src/main/pan/components/openstack/nova.pan
@@ -5,6 +5,8 @@
 
 declaration template components/openstack/nova;
 
+include 'components/openstack/keystone';
+
 @documentation {
     The Nova configuration options in "api_database" Section.
 }

--- a/ncm-openstack/src/main/pan/components/openstack/schema.pan
+++ b/ncm-openstack/src/main/pan/components/openstack/schema.pan
@@ -13,7 +13,7 @@ include 'components/openstack/horizon';
 Type to define OpenStack services
 Keystone, Nova, Neutron, etc
 }
-type component_openstack = {
+type openstack_component = {
     include structure_component
     'keystone' : openstack_keystone_config
     'nova' ? openstack_nova_config


### PR DESCRIPTION
The Glance, Neutron and Nova schema use the `openstack_keystone_authtoken` type
which is defined in the Keystone schema.

The missing dependency is causing tests on **template-library-core** to fail.

The root type is defined as the reverse of what the built-tools templating generates, so fix that too.

Hopefully shouldn't cause conflicts with #1192.