### PR TITLE
pom: Remove references to decomissioned stratuslab-srv01

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,18 +13,6 @@
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
-  <distributionManagement>
-    <repository>
-      <id>quattor.releases</id>
-      <name>Releases</name>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases/</url>
-    </repository>
-    <snapshotRepository>
-      <id>quattor.snapshots</id>
-      <name>Snapshots</name>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
   <scm>
     <connection>scm:git:git://github.com/quattor/configuration-modules-git.git</connection>
     <developerConnection>scm:git:git@github.com:quattor/configuration-modules-core.git</developerConnection>


### PR DESCRIPTION
Builds try to connect to it and hang for a long time before the connection times out.
