### PR TITLE
ncm-cron: Implement some validation of cron timing fields

### DIFF
--- a/ncm-cron/src/main/pan/components/cron/schema.pan
+++ b/ncm-cron/src/main/pan/components/cron/schema.pan
@@ -38,13 +38,101 @@ type structure_cron_log = {
     'mode' ? string
 } with structure_cron_log_valid(SELF);
 
+@documentation{
+    Validate contents of cron timing fields (see CRONTAB(5) for details)
+
+    Cron timing fields can contain complex expressions (e.g. "1,5,13-23/2"). Rather than validate these in
+    depth the aim here is to catch things that are obviously wrong, such as:
+        * characters which are not valid in cron fields
+        * out of range numbers (e.g. "35" in the hour field)
+        * names in the wrong field (e.g. "tue" in the day of month field)
+}
+function valid_cron_timing = {
+    if (ARGC != 4) {
+        error(format('%s: expected 4 parameters, received %d', FUNCTION, ARGC));
+    };
+
+    timing_value = to_lowercase(ARGV[0]);
+    lower_bound = ARGV[1];
+    upper_bound = ARGV[2];
+    text_regex = ARGV[3];
+
+    # Check that the field contains only valid characters
+    if (!match(timing_value, '^(?:[a-z0-9/*-,]+)$')) error(format('"%s" contains invalid characters', timing_value));
+
+    # Find runs of digits and validate them against provided bounds
+    foreach(k; v; matches(timing_value, '([0-9]+)')) {
+        i = to_long(v);
+        if (i < lower_bound) error(format('Value %d is below lower bound of %d', i, lower_bound));
+        if (i > upper_bound) error(format('Value %d is above upper bound of %d', i, upper_bound));
+    };
+
+    # Find runs of letters and validate them against provided regex
+    foreach(k; v; matches(timing_value, '([a-z]+)')) {
+        if (!match(v, text_regex)) error(format('"%s" is not a valid value for this field item', v));
+    };
+
+    # Ignore all other characters
+    true;
+};
+
+@documentation{ Convenience wrapper for validating cron minute field }
+function valid_cron_minute = valid_cron_timing(ARGV[0], 0, 59, '^(?![a-z]).+$');
+
+@documentation{ Convenience wrapper for validating cron hour field }
+function valid_cron_hour = valid_cron_timing(ARGV[0], 0, 23, '^(?![a-z]).+$');
+
+@documentation{ Convenience wrapper for validating cron day of month field }
+function valid_cron_day_of_month = valid_cron_timing(ARGV[0], 1, 31, '^(?![a-z]).+$');
+
+@documentation{ Convenience wrapper for validating cron month field }
+function valid_cron_month = valid_cron_timing(ARGV[0], 1, 12, '^(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)$');
+
+@documentation{ Convenience wrapper for validating cron day of week field }
+function valid_cron_day_of_week = valid_cron_timing(ARGV[0], 0, 7, '^(?:mon|tue|wed|thu|fri|sat|sun)$');
+
 type structure_cron_timing = {
-    'minute' ? string
-    'hour' ? string
-    'day' ? string
-    'month' ? string
-    'weekday' ? string
+    @{ minute of hour (0-59) }
+    'minute' ? string with valid_cron_minute(SELF)
+    @{ hour of day (0-23) }
+    'hour' ? string with valid_cron_hour(SELF)
+    @{ day of month (1-31) }
+    'day' ? string with valid_cron_day_of_month(SELF)
+    @{ month of year (1-12 or three-letter abbreviated lowercase name) }
+    'month' ? string with valid_cron_month(SELF)
+    @{ day of week (0-7 or three-letter abbreviated lowercase name) }
+    'weekday' ? string with valid_cron_day_of_week(SELF)
+    @{ Interval (in minutes) over which to randomly smear the start time of the job }
     'smear' ? long(0..1440)
+};
+
+@documentation{
+    Validate contents of cron frequency field
+}
+function valid_cron_frequency = {
+    if (ARGC != 1) {
+        error(format('%s: expected 1 parameter, received %d', FUNCTION, ARGC));
+    };
+
+    frequency = to_lowercase(ARGV[0]);
+
+    if (match(frequency, '^@(?:reboot|yearly|annually|monthly|weekly|daily|midnight|hourly)$')) {
+        return(true);
+    };
+
+    fields = split(' ', frequency);
+
+    if (length(fields) != 5) {
+        error(format('cron frequency "%s" should have 5 fields, it only has %d', frequency, length(fields)));
+    };
+
+    valid_cron_minute(fields[0]);
+    valid_cron_hour(fields[1]);
+    valid_cron_day_of_month(fields[2]);
+    valid_cron_month(fields[3]);
+    valid_cron_day_of_week(fields[4]);
+
+    true;
 };
 
 type structure_cron = {
@@ -59,7 +147,7 @@ type structure_cron = {
       a random value between 0 and 59 inclusive is generated.
       This can be used to avoid too many machines executing the same
       cron at the same time. See also the C<timing> element.}
-    'frequency' ? string
+    'frequency' ? string with valid_cron_frequency(SELF)
     @{If the 'timing' dict is used to specify the time, it can contain any of the
       keys: 'minute', 'hour', 'day', 'month' and 'weekday'. An unspecified key will
       have a value of '*'. A further key of 'smear' can be used to specify (in
@@ -85,12 +173,14 @@ type structure_cron = {
     'syslog' ? structure_cron_syslog
 } with {
     if (exists(SELF['log']) && exists(SELF['syslog'])) {
-        error("At most one of log or syslog can be defined");
+        error("Only one of log or syslog may be defined, not both.");
+    };
+    if (exists(SELF['timing']) && exists(SELF['frequency'])) {
+        error("Only one of timing or frequency may be defined, not both.");
     };
     if (!exists(SELF['timing']) && !exists(SELF['frequency'])) {
-        error("One of timing or frequency must be defined");
+        error("Either timing or frequency must be defined.");
     };
-
     true;
 };
 


### PR DESCRIPTION
Add a function to validate the contents of cron timing fields.

I've got tired of finding cron jobs which are not running due to simple mistakes such as entering day names in the `day` field rather than the `weekday` field due to the almost complete lack of any validation on this component.

This could get pretty complex and most of the public domain regexes I found do a poor job of covering the accepted syntax, so for now we'll just perform some basic sanity checking on numbers and text found in the fields.

While we're touching this, also improve the annotations a bit.
  
  