### PR TITLE
ncm-metaconfig: add name config option for beats

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/beats/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/pan/schema.pan
@@ -147,6 +147,7 @@ type beats_service = {
     'output' : beats_output
     'shipper' ? beats_shipper
     'logging' ? beats_logging
+    'name' ? string
 };
 
 @documentation{


### PR DESCRIPTION
By default `name` is not needed, but then it gets the hostname as value, which is likely not what you want. This allows us to set the desired beat name in the configuration.