### PR TITLE
ncm-cron: Support magic AUTO value in minutes field of frequency

### DIFF
--- a/ncm-cron/src/main/pan/components/cron/schema.pan
+++ b/ncm-cron/src/main/pan/components/cron/schema.pan
@@ -114,7 +114,7 @@ function valid_cron_frequency = {
         error(format('%s: expected 1 parameter, received %d', FUNCTION, ARGC));
     };
 
-    frequency = to_lowercase(ARGV[0]);
+    frequency = ARGV[0];
 
     if (match(frequency, '^@(?:reboot|yearly|annually|monthly|weekly|daily|midnight|hourly)$')) {
         return(true);
@@ -126,7 +126,7 @@ function valid_cron_frequency = {
         error(format('cron frequency "%s" should have 5 fields, it only has %d', frequency, length(fields)));
     };
 
-    valid_cron_minute(fields[0]);
+    match(fields[0], '^AUTO$') || valid_cron_minute(fields[0]);
     valid_cron_hour(fields[1]);
     valid_cron_day_of_month(fields[2]);
     valid_cron_month(fields[3]);

--- a/ncm-cron/src/main/perl/cron.pm
+++ b/ncm-cron/src/main/perl/cron.pm
@@ -249,7 +249,7 @@ sub Configure
         # Frequency of the cron entry.  May contain AUTO for the
         # minutes field : in this case, substitute AUTO with a random
         # value. This only works in the minutes field of the
-        # frequence.  We support two formats here: the traditional
+        # frequency.  We support two formats here: the traditional
         # "frequency" field and also a more complex "timing" structure
         # (which allows more smear)
         my $frequency = "";
@@ -303,7 +303,7 @@ sub Configure
             $frequency = $entry->{frequency};
 
             # Substitute AUTO with a random value. This only works in
-            # the minutes field of the frequence.
+            # the minutes field of the frequency.
             $frequency =~ s/AUTO/int(rand(60))/eg;
         }
 

--- a/ncm-cron/src/test/resources/cron_syslog-common.pan
+++ b/ncm-cron/src/test/resources/cron_syslog-common.pan
@@ -55,4 +55,11 @@ include 'components/cron/config';
     "command", "some command",
 ));
 
+"/software/components/cron/entries" = append(SELF, dict(
+    "name", "test_magic_auto_value",
+    "user", "magic",
+    "frequency", "AUTO 7 * * *",
+    "command", "a scary command",
+));
+
 "/software/components/cron/allow" = list("root");


### PR DESCRIPTION
Resolves issue reported in quattor/release#314 caused by #1222.

Should really be replaced by use of `smear` in `timing` structure, but there is too much code in the wild using `AUTO` to remove support for it right now. #1227 opened to track this in the longer term.