### PR TITLE
ncm-nfs: fix ceph fs type in nfs.pm

### DIFF
--- a/ncm-nfs/src/main/perl/nfs.pm
+++ b/ncm-nfs/src/main/perl/nfs.pm
@@ -315,7 +315,7 @@ sub fstab
         # line does not end in newline (see split above)
         my $fstab = parse_fstab_line($line);
         if ($fstab) {
-            if ( ($fstab->{$FSTAB_FSTYPE} =~ m/^(nfs4?|(pan|ceph)fs)$/) ||
+            if ( ($fstab->{$FSTAB_FSTYPE} =~ m/^(nfs4?|panfs|ceph)$/) ||
                  (($fstab->{$FSTAB_FSTYPE} eq 'none') && ($fstab->{$FSTAB_OPTIONS} eq 'bind')) ) {
                 # It is an ncm-nfs managed entry, save the information.
                 $old{$fstab->{$FSTAB_DEVICE}} = $fstab;

--- a/ncm-nfs/src/test/perl/fstab.t
+++ b/ncm-nfs/src/test/perl/fstab.t
@@ -213,6 +213,7 @@ ok(command_history_ok([
     qr{^mount /mount000$},
     qr{^mount -o remount /mount1$},
     qr{^mount /amount2$},
+    qr{^mount /mount3$},
 ]), "correct mount commands triggered in proper order");
 
 


### PR DESCRIPTION
fix a bug where every run of ncm-nfs would create an additional entry in fstab for ceph mounts because of wrong match regex