### PR TITLE
ncm-cron: Escape hyphen as we don't want it to be treated as a range

### DIFF
--- a/ncm-cron/src/main/pan/components/cron/schema.pan
+++ b/ncm-cron/src/main/pan/components/cron/schema.pan
@@ -58,7 +58,7 @@ function valid_cron_timing = {
     text_regex = ARGV[3];
 
     # Check that the field contains only valid characters
-    if (!match(timing_value, '^(?:[a-z0-9/*-,]+)$')) error(format('"%s" contains invalid characters', timing_value));
+    if (!match(timing_value, '^(?:[a-z0-9/*\-,]+)$')) error(format('"%s" contains invalid characters', timing_value));
 
     # Find runs of digits and validate them against provided bounds
     foreach(k; v; matches(timing_value, '([0-9]+)')) {

--- a/ncm-cron/src/test/resources/cron_syslog-common.pan
+++ b/ncm-cron/src/test/resources/cron_syslog-common.pan
@@ -62,4 +62,11 @@ include 'components/cron/config';
     "command", "a scary command",
 ));
 
+"/software/components/cron/entries" = append(SELF, dict(
+    "name", "test_range_skip",
+    "user", "skippy",
+    "frequency", "15 0-23/3 * * *",
+    "command", "Fifteen minutes past every third hour",
+));
+
 "/software/components/cron/allow" = list("root");


### PR DESCRIPTION
The `*-,` part was being treated as a range of characters between `*` and `,` which is obviously nonsense.