### PR TITLE
ncm-metaconfig: add mailrc service

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/mailrc/element.tt
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/element.tt
@@ -1,0 +1,15 @@
+[%- FOREACH pair IN data.pairs %]
+[%     IF pair.key == 'account' %]
+[%-         FOREACH account IN pair.value.pairs %]
+account [%      account.key  %] {
+[%              INCLUDE metaconfig/mailrc/element.tt data=account.value %]
+}
+[%-        END %]
+[%     ELSIF pair.value.is_boolean %]
+[%         IF pair.value %]
+set [%         pair.key %]
+[%-        END %]
+[%     ELSE -%]
+set [%     pair.key %]=[% pair.value %]
+[%-    END %]
+[%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/main.tt
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/main.tt
@@ -1,0 +1,2 @@
+[%     INCLUDE metaconfig/mailrc/element.tt data=CCM.contents %]
+

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/pan/config.pan
@@ -1,3 +1,7 @@
 unique template metaconfig/mailrc/config;
 
 include 'metaconfig/mailrc/schema';
+
+bind "/software/components/metaconfig/services/{/etc/mail.rc}/contents" = mailrc_config;
+prefix "/software/components/metaconfig/services/{/etc/mail.rc}";
+"module" = "mailrc/main";

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/pan/config.pan
@@ -1,0 +1,3 @@
+unique template metaconfig/mailrc/config;
+
+include 'metaconfig/mailrc/schema';

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/pan/schema.pan
@@ -1,0 +1,2 @@
+declaration template metaconfig/mailrc/schema;
+

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/pan/schema.pan
@@ -1,2 +1,17 @@
 declaration template metaconfig/mailrc/schema;
 
+include 'pan/types';
+
+type mailrc_element = {
+    'smtp' ? string
+    'from' ? type_email
+    'smtp-use-starttls' ? boolean
+    'smtp-auth-user' ? string
+    'smtp-auth-password' ? string
+    'nss-config-dir' ? string
+};
+
+type mailrc_config = {
+    include mailrc_element
+    'account' ? mailrc_element{}
+};

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/profiles/account_config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/profiles/account_config.pan
@@ -1,0 +1,8 @@
+object template account_config;
+
+include 'metaconfig/mailrc/config';
+
+"/metaconfig/module" = "mailrc/main";
+prefix "/software/components/metaconfig/services/{/etc/mail.rc}/contents/account/gmail";
+"smtp" = 'mailserver.gmail.com';
+"from" = 'root@gmail.com';

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/profiles/config.pan
@@ -1,0 +1,4 @@
+object template config;
+
+include 'metaconfig/mailrc/config';
+

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/profiles/config.pan
@@ -2,3 +2,8 @@ object template config;
 
 include 'metaconfig/mailrc/config';
 
+"/metaconfig/module" = "mailrc/main";
+prefix "/software/components/metaconfig/services/{/etc/mail.rc}/contents";
+"smtp" = 'mailserver.example.com';
+"from" = 'root@example.com';
+

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/account_config
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/account_config
@@ -1,0 +1,9 @@
+account config test for mailrc
+---
+/etc/mail.rc
+multiline
+---
+^account gmail \{$
+^set from=root@gmail.com$
+^set smtp=mailserver.gmail.com$
+^\}$

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/config/base
@@ -1,0 +1,6 @@
+Base test for config
+---
+multiline
+---
+$wontmatch^
+

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/config/base
@@ -1,6 +1,7 @@
-Base test for config
+Base test for mailrc
 ---
+/etc/mail.rc
 multiline
 ---
-$wontmatch^
-
+set from
+set smtp

--- a/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/config/neg
+++ b/ncm-metaconfig/src/main/metaconfig/mailrc/tests/regexps/config/neg
@@ -1,0 +1,7 @@
+Basic negate test
+---
+/etc/mail.rc
+negate
+---
+^account
+^gmail

--- a/ncm-metaconfig/src/test/perl/service-mailrc.t
+++ b/ncm-metaconfig/src/test/perl/service-mailrc.t
@@ -1,0 +1,6 @@
+use Test::More;
+use Test::Quattor::TextRender::Metaconfig;
+my $u = Test::Quattor::TextRender::Metaconfig->new(
+    service => 'mailrc',
+    )->test();
+done_testing;


### PR DESCRIPTION
This service allows you to configure mail.rc or .mailrc files

for an example see https://coderwall.com/p/ez1x2w/send-mail-like-a-boss