### PR TITLE
ncm-metaconfig: aii_command unittest: make the test more robust

### DIFF
--- a/ncm-metaconfig/src/test/perl/aii_command.t
+++ b/ncm-metaconfig/src/test/perl/aii_command.t
@@ -33,6 +33,6 @@ isa_ok($fh, "CAF::FileWriter");
 $fh = get_file("/foo/bar");
 ok(!defined($fh), "Nothing created at regular file location");
 
-ok(command_history_ok(undef, ['foo']), "serivce foo not restarted");
+ok(command_history_ok(undef, ['service foo']), "serivce foo not restarted");
 
 done_testing();

--- a/ncm-metaconfig/src/test/perl/configure.t
+++ b/ncm-metaconfig/src/test/perl/configure.t
@@ -25,6 +25,7 @@ my $fh = get_file("/foo/bar");
 ok($fh, "A file was actually created");
 isa_ok($fh, "CAF::FileWriter");
 
+# if default sysv init service changes, also modify the aii_command negative test
 ok(command_history_ok(['service foo restart']), "serivce foo restarted");
 
 done_testing();


### PR DESCRIPTION
Fixes failure of nightly builds with a user named `foo1234`