### PR TITLE
ncm-sudo: Test names of alias list entries, rather than list itself

### DIFF
--- a/ncm-sudo/src/main/pan/components/sudo/validation.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/validation.pan
@@ -12,7 +12,7 @@ declaration template components/sudo/validation;
   the name of the alias list.};
 function sudo_check_aliases_list = {
     if (exists(ARGV[0][ARGV[1]])) {
-        foreach(idx; aliasname; ARGV[0][ARGV[1]]) {
+        foreach(aliasname; aliaslist; ARGV[0][ARGV[1]]) {
             if (!match (aliasname, "^[A-Z][A-Z0-9_]*$")) error(
                 "Wrong alias name: " + aliasname +
                 "\nAn alias name must be made of " +


### PR DESCRIPTION
Aliases are dictionaries of lists with the alias name as the key, but the validation code was treating them as a lists of alias names, so bad times ensued.

Fixes compilation problems with example template library.