### PR TITLE
ncm-network: support device name with suffix

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -288,10 +288,10 @@ type structure_interface = {
         error("ovs_patch_peer is defined but the type of interface is not defined as OVSPatchPort");
     };
     if ( exists(SELF['bond_ifaces']) ) {
-        if ( (!exists(SELF['type']) || SELF['type'] != 'bond_ifaces') ) {
+        if ( (!exists(SELF['type']) || SELF['type'] != 'OVSBond') ) {
             error("bond_ifaces is defined but the type of interface is not defined as OVSBond");
         };
-        foreach (i; iface; bond_ifaces) {
+        foreach (i; iface; SELF['bond_ifaces']) {
             if ( !exists("/system/network/interfaces/" + iface) ) {
                 error("The " + iface + " interface is used by bond_ifaces, but does not exist");
             };

--- a/ncm-network/src/main/pan/components/network/schema.pan
+++ b/ncm-network/src/main/pan/components/network/schema.pan
@@ -4,4 +4,6 @@ include 'quattor/types/component';
 
 type network_component = {
     include structure_component
+    @{experimental: rename (physical) devices}
+    'rename' ? boolean
 };

--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -155,6 +155,7 @@ Readonly my $DEVICE_REGEXP => qr{
          )\d+| # mandatory numbering
          enx[[:xdigit:]]{12} # enx MAC address
     )
+    (?:_(\w+))? # opional suffixes
     (?:\.\d+)? # optional VLAN
     (?::\w+)? # optional alias
     $
@@ -192,7 +193,14 @@ sub is_valid_interface
     # Very primitive, based on regex only
     # Not even the full filename (eg ifcfg) or anything
     if ($filename =~ m/$DEVICE_REGEXP/) {
-        return $1;
+        my $name = $1;
+        my $suffix = $2;
+        if ($suffix && $suffix =~ m/^\d+$/) {
+            $self->verbose("Found digit-only suffix $suffix for device $name ($filename), ",
+                           "adding it to the interface name");
+            $name .= "_$suffix";
+        }
+        return $name;
     } else {
         return;
     };

--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -90,7 +90,8 @@ use CAF::Process;
 use CAF::Service;
 use CAF::FileReader;
 use CAF::FileEditor;
-use CAF::FileWriter 17.2.1;
+use CAF::FileWriter;
+use CAF::Path 17.7.0;
 use NetAddr::IP;
 
 use POSIX qw(WIFEXITED WEXITSTATUS);
@@ -578,7 +579,7 @@ sub runrun
 
 
 # Create a mapping of device names to MAC address
-# Returns hashref with key found device name and value MAC
+# Returns hashref with key found device name and value (lowercase) MAC
 # same MAC can be used by several devices
 sub make_dev2mac
 {
@@ -613,6 +614,7 @@ sub make_dev2mac
     foreach my $tmp_dev (split(/\n/, $out)) {
         $dev2mac{$1} = lc($2) if ($tmp_dev =~ m/$mac_regexp/);
     }
+    $self->verbose("found dev2mac: ", join(', ', map {"$_=$dev2mac{$_}"} sort keys %dev2mac));
     return \%dev2mac;
 }
 
@@ -1152,9 +1154,7 @@ sub make_network_cfg
 # No actual ifdown is executed (see usage of `will` in messages).
 sub make_ifdown
 {
-    my ($self, $exifiles, $ifaces) = @_;
-
-    my $dev2mac = $self->make_dev2mac();
+    my ($self, $exifiles, $ifaces, $dev2mac) = @_;
 
     my %ifdown;
     foreach my $file (sort keys %$exifiles) {
@@ -1239,7 +1239,8 @@ sub make_ifup
         # and have state other than REMOVE
         # e.g. master with NOCHANGES state can be added here
         # when a slave had modifications
-        if ($exifiles->{"$IFCFG_DIR/ifcfg-$iface"} == $REMOVE) {
+        if (exists($exifiles->{"$IFCFG_DIR/ifcfg-$iface"}) &&
+            $exifiles->{"$IFCFG_DIR/ifcfg-$iface"} == $REMOVE) {
             $self->verbose("Not starting $iface scheduled for removal");
         } else {
             if ($ifaces->{$iface}->{master}) {
@@ -1309,7 +1310,7 @@ sub set_hostname
 }
 
 
-# network stop OR ifdown
+# network stop AND/OR ifdown
 # Returns if something was done or not
 sub stop
 {
@@ -1318,20 +1319,26 @@ sub stop
     my @ifaces = sort keys %$ifdown;
 
     my $action;
-    if ($exifiles->{$NETWORKCFG} == $UPDATED) {
-        $self->verbose("$NETWORKCFG UPDATED, stopping network");
-        $action = 1;
-        $nwsrv->stop();
-    } elsif (@ifaces) {
-        my @cmds;
-        foreach my $iface (@ifaces) {
-            # how do we actually know that the device was up?
-            # eg for non-existing device eth4: /sbin/ifdown eth4 --> usage: ifdown <device name>
-            push(@cmds, ["/sbin/ifdown", $iface]);
+    my $nwupdated = $exifiles->{$NETWORKCFG} == $UPDATED;
+
+    if ($nwupdated || @ifaces) {
+        if (@ifaces) {
+            my @cmds;
+            foreach my $iface (@ifaces) {
+                # how do we actually know that the device was up?
+                # eg for non-existing device eth4: /sbin/ifdown eth4 --> usage: ifdown <device name>
+                push(@cmds, ["/sbin/ifdown", $iface]);
+            }
+            $self->verbose("Stopping interfaces ",join(', ', @ifaces));
+            $action = 1;
+            $self->runrun(@cmds);
         }
-        $self->verbose("Stopping interfaces ",join(', ', @ifaces));
-        $action = 1;
-        $self->runrun(@cmds);
+
+        if ($nwupdated) {
+            $self->verbose("$NETWORKCFG UPDATED, stopping network");
+            $action = 1;
+            $nwsrv->stop();
+        }
     } else {
         $self->verbose('Nothing to stop');
         $action = 0;
@@ -1527,6 +1534,103 @@ sub legacy_keeps_state
     };
 }
 
+# Create a mapping of existing physical devices that should be renamed
+# based on the macaddress in the profile.
+# Mapping has current name as key and new name as value.
+# Mapping has to be reversible.
+# Does nothing when mac addresses are not unqiue (and reports error)
+# Returns (possibly empty) hashref
+sub make_rename_map
+{
+    my ($self, $dev2mac, $ifaces) = @_;
+
+    # mapping of iface name and hwaddr for configured devices
+    # force lowercase
+    my $conf = {
+        map {$_ => lc($ifaces->{$_}->{hwaddr})}
+        grep {exists($ifaces->{$_}->{hwaddr})} # no autovivification in $ifaces
+        keys %$ifaces};
+    $self->verbose("configured interfaces: ", join(', ', map {"$_=$conf->{$_}"} sort keys %$conf));
+    my $conf_mac2dev = {map {$conf->{$_} => $_} keys %$conf};
+
+    # Get list of physical device names
+    my $virt = $self->listdir('/sys/devices/virtual/net');
+    if (!defined($virt)) {
+        $self->error("Cannot get list of virtual network devices: $self->{fail}");
+        return;
+    }
+
+    my $is_phys = sub {
+        my ($fn, $dir) = @_;
+        return $self->is_symlink("$dir/$fn") && !(grep {$fn eq $_} @$virt);
+    };
+
+    my $phys = $self->listdir('/sys/class/net', test => $is_phys);
+    if (!defined($phys)) {
+        $self->error("Cannot get list of physical network devices: $self->{fail}");
+        return;
+    }
+
+    # check unique mac addresses
+    my %res;
+
+    if ((scalar keys %$conf_mac2dev) == (scalar keys %$conf)) {
+        foreach my $dev (sort @$phys) {
+            my $mac = $dev2mac->{$dev};
+            if ($mac) {
+                my $cdev = $conf_mac2dev->{$mac};
+                if ($cdev && $dev ne $cdev) {
+                    $self->verbose("Found physical device $dev with same mac address as ",
+                                   "configured device $cdev with different name.");
+                    if (grep {$_ eq $cdev} values %res) {
+                        $self->error("Configured device $cdev already in the rename map ",
+                                     "(while trying to add it for $dev)");
+                    } else {
+                        $res{$dev} = $cdev;
+                    }
+                }
+            } else {
+                # it's ok for IB devices
+                my $method = ($dev =~ m/^ib\d+/) ? 'verbose' : 'warn';
+                $self->$method("Found device $dev without mac address in dev2mac");
+            }
+        }
+    } else {
+        $self->error("Non unique mac addresses configured");
+    }
+
+    $self->verbose("rename map: ", join(', ', map {"$_=$res{$_}"} sort keys %res));
+    return \%res;
+}
+
+# Actually rename the devices
+# uses 'ip link set name'
+#   does a ip link down before renaming
+# map is a hashref old name -> new name
+sub down_rename_devices
+{
+    my ($self, $map) = @_;
+
+    my @devs;
+    my @cmds;
+    foreach my $dev (sort keys %$map) {
+        push(@devs, $dev);
+        push(@cmds, [qw(ip link set), $dev, "down"]);
+        push(@cmds, [qw(ip link set), $dev, "name", $map->{$dev}]);
+    }
+
+    my $action;
+    if (@devs) {
+        $self->verbose("Renaming devices ",join(', ', @devs));
+        $action = 1;
+        $self->runrun(@cmds);
+    } else {
+        $self->verbose("Nothing renamed.");
+    }
+
+    return $action;
+}
+
 
 sub Configure
 {
@@ -1545,6 +1649,7 @@ sub Configure
     my ($exifiles, $exilinks) = $self->gather_existing();
     return if ! defined($exifiles);
 
+    my $comp_tree = $config->getTree($self->prefix());
     my $nwtree = $config->getTree($NETWORK_PATH);
 
     # main network config
@@ -1625,6 +1730,7 @@ sub Configure
         }
     }
 
+    my $dev2mac = $self->make_dev2mac();
 
     # We now have a map with files and values.
     # Changes to the general network config file are handled separately.
@@ -1641,7 +1747,7 @@ sub Configure
     # aliases on bonded vlans ...
     # If you need this, buy more network adapters ;)
 
-    my $ifdown = $self->make_ifdown($exifiles, $ifaces);
+    my $ifdown = $self->make_ifdown($exifiles, $ifaces, $dev2mac);
     if (! defined($ifdown)) {
         # file_dump does not modify the original files.
         # It's safe to exit the component here.
@@ -1674,6 +1780,31 @@ sub Configure
     my $nwsrv = CAF::Service->new(['network'], log => $self);
 
     my $stopstart = $self->stop($exifiles, $ifdown, $nwsrv);
+
+    my $rename;
+    if ($comp_tree->{rename}) {
+        # Rename the (physical) network devices
+        $rename = $self->make_rename_map($dev2mac, $net->{interfaces});
+
+        if (!$rename) {
+            $self->error("Failed to make rename map, nothing to rename");
+        } else {
+            if (%$rename) {
+                # Rename
+                #   either the devices are scheduled for in ifdown or
+                #   scheduled for start in ifup (but not in ifdown),
+                #   or conifgured but somehow we don't care?
+                #   In any case, it's ok to down any device in the rename map
+                $self->down_rename_devices($rename);
+
+                # rerun ethtool
+                # TODO: why do that here? should be done after any restarting of devices or whole network?
+                $self->ethtool_set_options($ifaces);
+            } else {
+                $self->verbose("Nothing to rename");
+            }
+        }
+    }
 
     my $config_changed = $self->deploy_config($exifiles);
 

--- a/ncm-network/src/test/perl/dev2mac.t
+++ b/ncm-network/src/test/perl/dev2mac.t
@@ -16,6 +16,7 @@ set_desired_output('ip addr show', readfile('src/test/resources/output/ipaddrsho
 my $res = $cmp->make_dev2mac();
 is_deeply($res, {'eth0' => '02:00:0a:8d:32:90'}, "dev2mac with el5");
 
+# ipaddrshow has the macaddr of em1 manually convered in uppercase; to test lowercase conversion
 set_desired_output('ip addr show', readfile('src/test/resources/output/ipaddrshow'));
 my $res2 = $cmp->make_dev2mac();
 is_deeply($res2, {

--- a/ncm-network/src/test/perl/rename.t
+++ b/ncm-network/src/test/perl/rename.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+
+BEGIN {
+    *CORE::GLOBAL::sleep = sub {};
+}
+
+use Test::More;
+use Test::Quattor qw(rename);
+use Test::Quattor::Filetools qw(readfile);
+use NCM::Component::network;
+
+use Readonly;
+
+# File must exist
+set_file_contents("/etc/sysconfig/network", '');
+# must also exist (to flag the interface down)
+set_file_contents("/etc/sysconfig/network-scripts/ifcfg-em1", '');
+
+
+my $cfg = get_config_for_profile('rename');
+my $cmp = NCM::Component::network->new('network');
+$cmp->directory('/sys/devices/virtual/net/br100');
+$cmp->directory('/sys/class/net');
+$cmp->symlink('/some/path', '/sys/class/net/em1');
+
+set_desired_output('ip addr show', readfile('src/test/resources/output/ipaddrshowrename'));
+
+my $map = $cmp->make_dev2mac();
+diag "dev2mac map ", explain $map;
+is_deeply($map, {em1 => 'aa:bb:cc:dd:ee:ff'}, "dev2mac map");
+
+# hw cards nic is ok, we only need hwaddr entry
+my $rename = $cmp->make_rename_map($map, $cfg->getTree("/hardware/cards/nic"));
+diag "rename map ", explain $rename;
+is_deeply($rename, {em1 => 'eth0'}, "rename map");
+
+is($cmp->Configure($cfg), 1, "Component runs correctly with a test profile");
+
+ok(command_history_ok([
+    'ip addr show',
+    'ifdown em1',
+    'ifdown eth0',
+    'service network stop',
+    'ip link set em1 down',
+    'ip link set em1 name eth0',
+    'service network start',
+]), "network stop/start called with device renaming");
+
+
+done_testing();

--- a/ncm-network/src/test/perl/rename.t
+++ b/ncm-network/src/test/perl/rename.t
@@ -42,6 +42,7 @@ ok(command_history_ok([
     'ifdown em1',
     'ifdown eth0',
     'service network stop',
+    'ip addr flush dev em1',
     'ip link set em1 down',
     'ip link set em1 name eth0',
     'service network start',

--- a/ncm-network/src/test/perl/valid_interfaces.t
+++ b/ncm-network/src/test/perl/valid_interfaces.t
@@ -21,16 +21,17 @@ my @valid_ifs = qw(eth0 seth1 em2 em2_2
 
 foreach my $valid (@valid_ifs) {
     foreach my $type (qw(ifcfg route)) {
-        is($cmp->is_valid_interface("$basedir/$type-$valid"), $valid,
-           "valid interface $valid from $type");
-        is($cmp->is_valid_interface("$basedir/$type-$valid.123"), $valid,
-           "valid interface $valid from $type with vlan");
-        is($cmp->is_valid_interface("$basedir/$type-$valid:alias"), $valid,
-           "valid interface $valid from $type with alias");
-        is($cmp->is_valid_interface("$basedir/$type-$valid.456:myalias"), $valid,
-           "valid interface $valid from $type with vlan and alias");
-        is($cmp->is_valid_interface("$basedir/$type-${valid}_whatever.456:myalias"), ($valid =~ m/^(.*)_\d+$/ ? $1 : $valid),
-           "valid interface $valid from $type with suffix, vlan and alias");
+        is_deeply($cmp->is_valid_interface("$basedir/$type-$valid"), [$valid, $valid],
+                  "valid interface $valid from $type");
+        is_deeply($cmp->is_valid_interface("$basedir/$type-$valid.123"), [$valid, "$valid.123"],
+                  "valid interface $valid from $type with vlan");
+        is_deeply($cmp->is_valid_interface("$basedir/$type-$valid:alias"), [$valid, "$valid:alias"],
+                  "valid interface $valid from $type with alias");
+        is_deeply($cmp->is_valid_interface("$basedir/$type-$valid.456:myalias"), [$valid, "$valid.456:myalias"],
+                  "valid interface $valid from $type with vlan and alias");
+        is_deeply($cmp->is_valid_interface("$basedir/$type-${valid}_whatever.456:myalias"), 
+                  [$valid =~ m/^(.*)_\d+$/ ? $1 : $valid, "${valid}_whatever.456:myalias"],
+                  "valid interface $valid from $type with suffix, vlan and alias");
     };
 };
 

--- a/ncm-network/src/test/perl/valid_interfaces.t
+++ b/ncm-network/src/test/perl/valid_interfaces.t
@@ -12,7 +12,7 @@ my $cmp = NCM::Component::network->new('network');
 =cut
 
 my $basedir = "/etc/sysconfig/network-scripts/";
-my @valid_ifs = qw(eth0 seth1 em2
+my @valid_ifs = qw(eth0 seth1 em2 em2_2
     bond3 br4 ovirtmgmt5
     vlan6 vxlan6 usb7 ib8 p9p10
     eno11 eno11d123 ens12 ens13f14 ens15d16 ens17f18d19
@@ -29,6 +29,8 @@ foreach my $valid (@valid_ifs) {
            "valid interface $valid from $type with alias");
         is($cmp->is_valid_interface("$basedir/$type-$valid.456:myalias"), $valid,
            "valid interface $valid from $type with vlan and alias");
+        is($cmp->is_valid_interface("$basedir/$type-${valid}_whatever.456:myalias"), ($valid =~ m/^(.*)_\d+$/ ? $1 : $valid),
+           "valid interface $valid from $type with suffix, vlan and alias");
     };
 };
 

--- a/ncm-network/src/test/resources/output/ipaddrshow
+++ b/ncm-network/src/test/resources/output/ipaddrshow
@@ -5,7 +5,7 @@
     inet6 ::1/128 scope host 
        valid_lft forever preferred_lft forever
 2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP qlen 1000
-    link/ether bc:30:5b:a9:3d:2e brd ff:ff:ff:ff:ff:ff
+    link/ether BC:30:5B:A9:3D:2E brd ff:ff:ff:ff:ff:ff
     inet 1.2.3.4/16 brd 1.2.255.255 scope global em1
        valid_lft forever preferred_lft forever
     inet6 fe80::be30:5bff:fea9:3d2e/64 scope link 

--- a/ncm-network/src/test/resources/output/ipaddrshowrename
+++ b/ncm-network/src/test/resources/output/ipaddrshowrename
@@ -1,0 +1,12 @@
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP qlen 1000
+    link/ether aa:bb:cc:dd:ee:ff brd ff:ff:ff:ff:ff:ff
+    inet 1.2.3.4/16 brd 1.2.255.255 scope global em1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::be30:5bff:fea9:3d2e/64 scope link 
+       valid_lft forever preferred_lft forever

--- a/ncm-network/src/test/resources/rename.pan
+++ b/ncm-network/src/test/resources/rename.pan
@@ -1,0 +1,6 @@
+object template rename;
+
+include 'simple_base_profile';
+
+'/software/components/network/rename' = true;
+'/hardware/cards/nic/eth0/hwaddr' = 'aa:bb:cc:dd:ee:ff';


### PR DESCRIPTION
* support device configuration files with a suffix
  (like bond0_slave_1 (from kickstart with bonding or em1_4 from NPar interfaces)
* fix typos in schema wrt OVSBond
* support device renaming
* distinguish valid ifup/ifdown names from interfaces