### PR TITLE
ncm-systemd: Do not start/stop services during boot and shutdown

### DIFF
--- a/ncm-systemd/src/test/perl/cmddata.pm
+++ b/ncm-systemd/src/test/perl/cmddata.pm
@@ -35,6 +35,7 @@ sub _evalfn {
 
 my @files = qw(service-systemctl_list service-systemctl_show
                service-systemctl_daemon_reload
+               service-systemctl_is_active_multi_user_target
                service_systemctl_list_show_gen_full_el7_ceph021
                service-legacy);
 foreach my $file (@files) {

--- a/ncm-systemd/src/test/perl/cmddata/service-systemctl_is_active_multi_user_target
+++ b/ncm-systemd/src/test/perl/cmddata/service-systemctl_is_active_multi_user_target
@@ -1,0 +1,7 @@
+$cmds{systemctl_is_active_multi_user_target}{cmd}="/usr/bin/systemctl is-active -- multi-user.target";
+$cmds{systemctl_is_active_multi_user_target}{ec}=0;
+$cmds{systemctl_is_active_multi_user_target}{out}= 'active';
+
+$cmds{systemctl_is_active_multi_user_target_shutdown}{cmd}="/usr/bin/systemctl is-active -- multi-user.target";
+$cmds{systemctl_is_active_multi_user_target_shutdown}{ec}=3;
+$cmds{systemctl_is_active_multi_user_target_shutdown}{out}= 'inactive';

--- a/ncm-systemd/src/test/perl/component.t
+++ b/ncm-systemd/src/test/perl/component.t
@@ -19,6 +19,7 @@ Test the C<Configure> method of the component.
 
 set_output("runlevel_5");
 set_output("chkconfig_list_test");
+set_output("systemctl_is_active_multi_user_target");
 
 my $cfg = get_config_for_profile('component');
 my $cmp = NCM::Component::systemd->new('systemd');

--- a/ncm-systemd/src/test/perl/service-component-chkconfig.t
+++ b/ncm-systemd/src/test/perl/service-component-chkconfig.t
@@ -24,6 +24,7 @@ Test the C<Configure> method of the component.
 
 set_output("runlevel_5");
 set_output("chkconfig_list_test");
+set_output("systemctl_is_active_multi_user_target");
 
 my $cfg = get_config_for_profile('service-component-chkconfig');
 my $cmp = NCM::Component::Systemd::Service::Component::chkconfig->new('systemd-component-chkconfig');

--- a/ncm-systemd/src/test/perl/service.t
+++ b/ncm-systemd/src/test/perl/service.t
@@ -427,6 +427,7 @@ Test change
 
 $cmp->{ERROR} = 0;
 command_history_reset();
+set_output("systemctl_is_active_multi_user_target");
 
 $svc->change($states, $acts);
 
@@ -444,6 +445,33 @@ ok(command_history_ok([
 
 =pod
 
+=head2 change during shutdown
+
+Test change during shutdown
+
+=cut
+
+$cmp->{ERROR} = 0;
+command_history_reset();
+set_output("systemctl_is_active_multi_user_target_shutdown");
+
+$svc->change($states, $acts);
+
+is($cmp->{ERROR}, 0, "No error logged while applying the changes during shutdown");
+
+ok(command_history_ok([
+    # 1st states, unmask first
+    "$SYSTEMCTL unmask -- cups.service",
+    "$SYSTEMCTL disable -- cups.service missing_disabled.service",
+    "$SYSTEMCTL enable -- netconsole.service rbdmap.service",
+    # 2 activity
+], [
+    "systemctl stop",
+    "systemctl start",
+]), "no stop/start commands during shutdown");
+
+=pod
+
 =head2 configure
 
 Test configure
@@ -452,6 +480,7 @@ Test configure
 
 $cmp->{ERROR} = 0;
 command_history_reset();
+set_output("systemctl_is_active_multi_user_target");
 
 $svc->configure($cfg);
 


### PR DESCRIPTION
If ncm-systemd is called during boot or shut-down, then it should avoid
starting/stopping services itself, as that could interfere with the
standard ordering of events. E.g., on shut-down, it could start services
again which were just stopped.
