### PR TITLE
ncm-spma: yum: distro-sync only filtered packages (when filter is defined)

### DIFF
--- a/ncm-spma/src/test/perl/yum-distro-sync.t
+++ b/ncm-spma/src/test/perl/yum-distro-sync.t
@@ -25,9 +25,12 @@ use CAF::Object;
 Readonly::Array my @YDS_ORIG => NCM::Component::spma::yum::YUM_DISTRO_SYNC();
 Readonly::Array my @YDS => @{NCM::Component::spma::yum::_set_yum_config(\@YDS_ORIG)};
 Readonly my $CMD => join(" ", @YDS);
+Readonly my $CMDP => "$CMD a b";
 
 set_desired_err($CMD, "");
 set_desired_output($CMD, "distrosync");
+set_desired_err($CMDP, "");
+set_desired_output($CMDP, "distrosync with packages a b");
 
 my $cmp = NCM::Component::spma::yum->new("spma");
 
@@ -55,11 +58,17 @@ it succeeded or not.
 
 =cut
 
-ok($cmp->distrosync(1), "Basic distroync succeeds");;
+ok($cmp->distrosync(1), "Basic distrosync succeeds");;
 
 $cmd = get_command($CMD);
 ok($cmd, "yum distro-sync was called");
 is($cmd->{method}, "execute", "yum distro-sync was execute'd");
+
+ok($cmp->distrosync(1, ['a', 'b']), "Basic distrosync with packages succeeds");
+$cmd = get_command($CMDP);
+ok($cmd, "yum distro-sync was called with packages");
+is($cmd->{method}, "execute", "yum distro-sync with packages was execute'd");
+
 
 set_desired_err($CMD, "\nError: package");
 

--- a/ncm-spma/src/test/perl/yum-update-pkgs.t
+++ b/ncm-spma/src/test/perl/yum-update-pkgs.t
@@ -124,6 +124,8 @@ ok(!$cmp->{SCHEDULE}->{remove}->{called},
 
 ok(!$cmp->{PACKAGES_TO_REMOVE}->{called}, "No packages to be removed with userpkgs");
 ok($cmp->{DISTROSYNC}->{called}, "Yum distrosync is called");
+diag explain $cmp->{DISTROSYNC}->{args};
+is_deeply($cmp->{DISTROSYNC}->{args}, ['run', undef], "Yum distrosync is called with args");
 
 ok($cmp->{APPLY_TRANSACTION}->{called}, "Transaction application is called");
 is($cmp->{APPLY_TRANSACTION}->{args}->[0], "install\nsolve\n",
@@ -135,13 +137,16 @@ is($cmp->{EXPIRE_YUM_CACHES}->{called}, 1, "Package cache is expired");
 is($cmp->{MAKE_CACHE}->{called}, 1, "Package cache is created");
 
 
+my $filterpkgs = {'name*' => {}};
 is($cmp->update_pkgs("allpkgs", "groups", "run", "allow", "purge",
-                     "e_is_w", "full", "reuse", "filter"), 1,
+                     "e_is_w", "full", "reuse", $filterpkgs), 1,
    "Basic invocation with filter returns success");
 is($cmp->{VERSIONLOCK}->{args}->[0], "allpkgs",
    "Locked package versions with correct arguments with filter");
-is($cmp->{WANTED_PKGS}->{args}->[0], "filter",
+is_deeply($cmp->{WANTED_PKGS}->{args}->[0], $filterpkgs,
    "wanted_pkgs receives the expected arguments with filter");
+diag explain $cmp->{DISTROSYNC}->{args};
+is_deeply($cmp->{DISTROSYNC}->{args}, ['run', ['name']], "Yum distrosync is called with args with filter");
 
 =pod
 

--- a/ncm-spma/src/test/perl/yum-wanted.t
+++ b/ncm-spma/src/test/perl/yum-wanted.t
@@ -72,6 +72,28 @@ my $wanted = {
        },
 };
 
+=head1 valid_packages
+
+=cut
+
+my $vpkgs = $cmp->valid_packages($wanted);
+#diag explain $vpkgs;
+my $names = ['ConsoleKit', 'ConsoleKit-libs', 'glibc', 'kde', 'python', 'tzdata-java'];
+
+is_deeply($vpkgs, $names, "valid_packages returns list of pacakge names");
+
+my $vpkgs_with_data = $cmp->valid_packages($wanted, 1);
+diag explain $vpkgs_with_data;
+is_deeply([map {$_->[0]} @$vpkgs_with_data], $names,
+          "valid_packages with data returns arrayf with names as first element");
+
+my $invalid = {%$wanted, '@something' => {}};
+ok(!defined($cmp->valid_packages($invalid)), "valid_packages returns undef with invalid package (and valid ones)");
+
+=head1 wanted_pkgs
+
+=cut
+
 my $pkgs = $cmp->wanted_pkgs($wanted);
 isa_ok($pkgs, "Set::Scalar", "Received a set, with no errors");
 


### PR DESCRIPTION
This prevents running full distro-sync when filter is in use; which might trigger updates of any number of packages and possible installations of dependencies.