### PR TITLE
ncm-ssh: schema update for changed AuthorizedKeysCommand* 

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema-5.3.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema-5.3.pan
@@ -1,0 +1,12 @@
+# #
+# Software subject to following license(s):
+#   Apache 2 License (http://www.opensource.org/licenses/apache2.0)
+#   Copyright (c) Responsible Organization
+#
+
+declaration template components/ssh/schema-5.3;
+
+type ssh_authkeyscommand_options_type = {
+            "AuthorizedKeysCommand" ? string
+            "AuthorizedKeysCommandRunAs" ? string
+};

--- a/ncm-ssh/src/main/pan/components/ssh/schema-7.4.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema-7.4.pan
@@ -1,0 +1,17 @@
+# #
+# Software subject to following license(s):
+#   Apache 2 License (http://www.opensource.org/licenses/apache2.0)
+#   Copyright (c) Responsible Organization
+#
+
+declaration template components/ssh/schema-7.4;
+
+type ssh_authkeyscommand_options_type = {
+    'AuthorizedKeysCommand' ? string(1..)
+    'AuthorizedKeysCommandUser' ? string(1..)
+} with {
+    if (exists(SELF['AuthorizedKeysCommand']) != exists(SELF['AuthorizedKeysCommandUser'])) {
+        error('Cannot set only one of AuthorizedKeysCommand and AuthorizedKeysCommandUser, set both or neither.');
+    };
+    true;
+};

--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -8,6 +8,10 @@ declaration template components/ssh/schema;
 include 'quattor/types/component';
 include 'pan/types';
 
+variable SSH_SCHEMA_VERSION ?= '5.3';
+
+include 'components/ssh/schema-' + SSH_SCHEMA_VERSION;
+
 type ssh_preferred_authentication = string with match(SELF, '^(gssapi-with-mic|hostbased|publickey' +
     '|keyboard-interactive|password)$');
 
@@ -87,6 +91,7 @@ type ssh_core_options_type = {
 
 type ssh_daemon_options_type = {
     include ssh_core_options_type
+    include ssh_authkeyscommand_options_type
     "AFSTokenPassing" ? legacy_binary_affirmation_string
     @{AcceptEnv, one per line}
     "AcceptEnv" ? string[]
@@ -95,8 +100,6 @@ type ssh_daemon_options_type = {
     "AllowTcpForwarding" ? legacy_binary_affirmation_string
     "AllowUsers" ? string
     "AuthorizedKeysFile" ? string
-    "AuthorizedKeysCommand" ? string
-    "AuthorizedKeysCommandRunAs" ? string
     "Banner" ? string
     "ClientAliveCountMax" ? long
     "ClientAliveInterval" ? long


### PR DESCRIPTION
Splits out the existing AuthorizedKeysCommand schema entries into their own type in a separate file which can then have different versions for different versions of openssh. This type is then included where the original entries were. 

This fixes #1237 