### PR TITLE
ncm-cron: fix test of /system/archetype/os

### DIFF
--- a/ncm-cron/src/main/pan/components/cron/config.pan
+++ b/ncm-cron/src/main/pan/components/cron/config.pan
@@ -1,8 +1,8 @@
 ${componentconfig}
 
 'securitypath' ?= {
-    if (exists('/system/archetype/os') &&
-            value('/system/archetype/os') == 'solaris') {
+    if (exists('/system/archetype/os/name') &&
+        value('/system/archetype/os/name') == 'solaris') {
         '/etc/cron.d';
     } else {
         '/etc';


### PR DESCRIPTION
- /system/archetype/os is now a dict instead of a string

**Required for Aquilon support** (see https://github.com/quattor/template-library-core/pull/177).

Fixes #1281
