### PR TITLE
Revert "ncm-cron: fix test of /system/archetype/os"

### DIFF
--- a/ncm-cron/src/main/pan/components/cron/config.pan
+++ b/ncm-cron/src/main/pan/components/cron/config.pan
@@ -1,8 +1,8 @@
 ${componentconfig}
 
 'securitypath' ?= {
-    if (exists('/system/archetype/os/name') &&
-        value('/system/archetype/os/name') == 'solaris') {
+    if (exists('/system/archetype/os') &&
+            value('/system/archetype/os') == 'solaris') {
         '/etc/cron.d';
     } else {
         '/etc';


### PR DESCRIPTION
The schema change which triggered this was wrong and will be reverted in quattor/template-library-core#181.

Reverts #1282.