### PR TITLE
ncm-useraccess: remove bad practice example from documentation

### DIFF
--- a/ncm-useraccess/src/main/perl/useraccess.pod
+++ b/ncm-useraccess/src/main/perl/useraccess.pod
@@ -242,9 +242,6 @@ validation time!
 
 When you lock user accounts, it may not be enough to just lock them
 with C<passwd -l>. Depending on how you configured SSH, a locked user
-may still be able to log-in with his public key. You can run
-C<<ncm-ncd --unconfigure useraccess >> to temporarily lock all accounts,
-before removing the user's entry from CDB. Or remove manually C<< .k*login >>
-and C<< .ssh/authorized_keys >>.
+may still be able to log-in with his public key.
 
 =cut


### PR DESCRIPTION
I believe that what the documentation states about disabling/locking users is bad practice. see #1289 .
