### PR TITLE
ncm-grub: remove password from grub.conf if disabled

### DIFF
--- a/ncm-grub/src/main/pan/components/grub/schema.pan
+++ b/ncm-grub/src/main/pan/components/grub/schema.pan
@@ -22,7 +22,7 @@ type type_grub_password = {
       "md5" for an MD5 hashed password. Plaintext is not supported.}
     "option" : string with match (SELF, "^(md5|encrypted)$")
     @{Mutually exclusive with the file option. A crypted password for grub.conf.}
-    "password" ? string
+    "password" ? string(1..)
     @{Mutually exclusive with the password option. The path to a file on the host
       where the password can be read from. May be useful if it is undesirable to put
       (even crypted) profiles into the profile.

--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -165,7 +165,7 @@ sub password
         return SUCCESS;
     } elsif (!$tree->{enabled}) {
         $self->info("removing grub password");
-        $grub_fh->remove_lines(qr/^password\s+/, q(no good line));
+        $grub_fh->remove_lines(qr/^password\s+/, qr/$./);
         return SUCCESS;
     }
 

--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -165,7 +165,7 @@ sub password
         return SUCCESS;
     } elsif (!$tree->{enabled}) {
         $self->info("removing grub password");
-        $grub_fh->remove_lines(qr/^password\s+/, '');
+        $grub_fh->remove_lines(qr/^password\s+/, q(no good line));
         return SUCCESS;
     }
 

--- a/ncm-grub/src/test/perl/methods.t
+++ b/ncm-grub/src/test/perl/methods.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use Test::Quattor qw(password);
+use Test::Quattor qw(nopassword);
 use Test::Quattor::Object;
 use CAF::Object;
 use Test::MockModule;
@@ -60,6 +61,18 @@ title abc
 
 EOF
 
+Readonly my $NEWGRUBCFG_REMOVED_PASSWORD => <<'EOF';
+# some header
+#
+terminal serial console
+serial --unit=0 --speed=5678 --parity=n --word=8
+
+blah blah
+
+title abc
+
+EOF
+
 set_file_contents($GRUBCFGFN, "$GRUBCFG");
 
 my $passwdcfg = get_config_for_profile("password");
@@ -80,6 +93,12 @@ $grubfh = get_file($GRUBCFGFN);
 isa_ok($grubfh, 'CAF::FileEditor', "grub config file is an editor instance");
 
 is("$grubfh", "$NEWGRUBCFG", "grub cfg edited as expected");
+
+# Test removal of password
+set_file_contents($GRUBCFGFN, "$NEWGRUBCFG");
+my $nopasswdcfg = get_config_for_profile("nopassword");
+ok($cmp->password($nopasswdcfg, $grubfh));
+is("$grubfh", $NEWGRUBCFG_REMOVED_PASSWORD);
 
 =head1 grubby
 

--- a/ncm-grub/src/test/perl/methods.t
+++ b/ncm-grub/src/test/perl/methods.t
@@ -2,8 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Quattor qw(password);
-use Test::Quattor qw(nopassword);
+use Test::Quattor qw(password nopassword);
 use Test::Quattor::Object;
 use CAF::Object;
 use Test::MockModule;

--- a/ncm-grub/src/test/resources/nopassword.pan
+++ b/ncm-grub/src/test/resources/nopassword.pan
@@ -1,0 +1,13 @@
+object template nopassword;
+
+include 'base';
+
+
+prefix "/software/components/grub/password";
+"enabled" = false;
+"password" = "";
+"option" = "encrypted";
+
+
+# use defaults from code except speed
+"/hardware/console/serial" = dict("speed", 5678);

--- a/ncm-grub/src/test/resources/nopassword.pan
+++ b/ncm-grub/src/test/resources/nopassword.pan
@@ -5,9 +5,7 @@ include 'base';
 
 prefix "/software/components/grub/password";
 "enabled" = false;
-"password" = "";
 "option" = "encrypted";
-
 
 # use defaults from code except speed
 "/hardware/console/serial" = dict("speed", 5678);


### PR DESCRIPTION
* Why the change is necessary.

Removing a password previously set in grub.conf won't work.

CAF::FileEditor->remove_lines removes lines matching the first
parameter, but not the second parameter. The empty string ''
matches all lines, so it will never remove lines.

Replacing it with 'q(no good line)' as in the ncm-named/*/named.pm
will have the desired effect.

* What backwards incompatibility it may introduce.

If someone was accidentally or deliberately relying on setting the password to 'disabled' in a template, NOT removing the password line from grub.conf, they may be affected by making it work as documented.

If they were using the "enabled=false" line as designed, it wouldn't have worked.