### PR TITLE
ncm-sysconfig: Automatically quote values containing whitespace

### DIFF
--- a/ncm-sysconfig/src/main/perl/sysconfig.pm
+++ b/ncm-sysconfig/src/main/perl/sysconfig.pm
@@ -20,7 +20,6 @@ our $NoActionSupported = 1;
 
 use Readonly;
 
-Readonly my $QUOTE => "\"";
 Readonly my $SYSCONFIGDIR => "/etc/sysconfig"; # The base directory for sysconfig files.
 
 sub filelist_read
@@ -87,7 +86,21 @@ sub Configure
             # Loop over the pairs adding the information to the file.
             for my $key (sort keys %$pairs) {
                 if ($key ne 'prologue' && $key ne 'epilogue') {
-                    $contents .= "$key=$pairs->{$key}\n";
+                    my $value = $pairs->{$key};
+                    # Remove any leading or trailing whitespace from the value
+                    $value =~ s/^\s+|\s+$//g;
+                    # Quote values containing whitespace.
+                    # Only if they have not already been quoted and do not look like an array.
+                    # If a value contains quotes, use a different quotation mark.
+                    # Values without whitespace should not be modified.
+                    if ($value !~ m/^".*"$/ && $value !~ m/^'.*'$/ && $value !~ m/^\(.*\)$/ && $value =~ m/\s/) {
+                        if ($value =~ m/"/) {
+                            $value = "'$value'";
+                        } else {
+                            $value = "\"$value\"";
+                        }
+                    }
+                    $contents .= "$key=$value\n";
                 }
             }
 

--- a/ncm-sysconfig/src/test/perl/configure.t
+++ b/ncm-sysconfig/src/test/perl/configure.t
@@ -24,6 +24,16 @@ is(get_file_contents('/etc/sysconfig/ncm-sysconfig'), "/etc/sysconfig/examplefil
 is(get_file_contents('/etc/sysconfig/delete_me'), undef, "Has the previously managed file been deleted?");
 
 isa_ok(get_file('/etc/sysconfig/examplefile'), "CAF::FileWriter", "Is the file-handle for the example file the correct class?");
-is(get_file_contents('/etc/sysconfig/examplefile'), "key1=testvalue\nkey2=valuetest\n", "Does the example file have the correct contents?");
+my $example_contents = <<'EOF';
+OPTS="$OPTS -a /proc/acpi/ac_adapter/*/state"
+array=(this is a bash array)
+boot=/dev/sda
+internal1="quoting 'inside' a line"
+internal2='quoting "inside" a line'
+key1=testvalue
+key2=valuetest
+words='lots of words'
+EOF
+is(get_file_contents('/etc/sysconfig/examplefile'), $example_contents, "Does the example file have the correct contents?");
 
 done_testing();

--- a/ncm-sysconfig/src/test/resources/configure.pan
+++ b/ncm-sysconfig/src/test/resources/configure.pan
@@ -6,3 +6,10 @@ prefix '/software/components/sysconfig';
 
 'files/examplefile/key1' = 'testvalue';
 'files/examplefile/key2' = 'valuetest';
+
+'files/examplefile/boot' = "/dev/sda";
+'files/examplefile/OPTS' = '"$OPTS -a /proc/acpi/ac_adapter/*/state"';
+'files/examplefile/words' = "'lots of words'";
+'files/examplefile/internal1' = "quoting 'inside' a line";
+'files/examplefile/internal2' = 'quoting "inside" a line';
+'files/examplefile/array' = '(this is a bash array)';


### PR DESCRIPTION
Fixes #1191.

If the user has already included quotes in the value, this is detected and worked around.