### PR TITLE
ncm-metaconfig: nginx: support return

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/nginx/location.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/location.tt
@@ -6,5 +6,8 @@ root [% location.root %];
 [%-     IF location.exists("proxy") -%]
 [%          INCLUDE metaconfig/nginx/proxy.tt px=location.proxy %]
 [%      END -%]
+[%-     IF location.exists("return") -%]
+[%          INCLUDE metaconfig/nginx/return.tt data=location.return %]
+[%      END -%]
 [%- END -%]
 }

--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
@@ -91,6 +91,16 @@ type nginx_proxy_location = {
     "read_timeout" ? long(0..)
 };
 
+
+@{nginx return diretcive}
+# url: cannot use type_hostURI, should allow eg $host as host
+type nginx_return = {
+    "code" ? long(0..)
+    "url" ? string with match(SELF, '^\w+://')
+    "text" ? string
+};
+
+
 @{
     Structure of a location entry
 }
@@ -99,8 +109,8 @@ type nginx_location = {
     "name" : string
     "operator" ? string with match(SELF, "^(=|^~|~*)$")
     "proxy" ? nginx_proxy_location
+    "return" ? nginx_return
 };
-
 
 @{
     Description of an nginx error_page line
@@ -110,12 +120,27 @@ type nginx_error_page = {
     "file" : string
 };
 
+@{nginx addr: either a hostport or a port (as string)}
+# ugly port range check before is_hostport (not a test function)
+# cannot use is_port, as it is also not a test function
+type nginx_addr = string with {
+    if (match(SELF, '^\d+$')) {
+        (to_long(SELF) > 0) && (to_long(SELF) < 64 * 1024);
+    } else {
+        is_hostport(SELF);
+    };
+};
+
 type nginx_listen = {
-    "addr" ? type_hostport
+    "addr" ? nginx_addr
     "default" : boolean = false
     "ssl" : boolean = false
 };
 
+
+@{nginx_server_name: either a valid hostname or _ (an invalid domain name which never intersect with any real name)}
+# == test before is_hostname  (is_hostname is not a test function, it can throw errors)
+type nginx_server_name = string with {SELF == '_' || is_hostname(SELF)};
 
 @{
     An nginx server entry.
@@ -123,10 +148,13 @@ type nginx_listen = {
 type nginx_server = {
     "includes" ? string[]
     "listen" : nginx_listen
-    "name" : type_hostname[]
-    "location" : nginx_location[]
+    "name" : nginx_server_name[]
+    "location" ? nginx_location[]
     "error_page" : nginx_error_page[] = list()
     "ssl" ? httpd_ssl
+    "return" ? nginx_return
+} with {
+    exists(SELF['location']) || exists(SELF['return']);
 };
 
 @{ An upstream declaration for reverse proxies

--- a/ncm-metaconfig/src/main/metaconfig/nginx/return.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/return.tt
@@ -1,0 +1,12 @@
+[%  ret = [];
+    IF data.exists('code');
+        ret.push(data.code);
+    END;
+    IF data.exists('url');
+        ret.push(data.url);
+    END;
+    IF data.exists('text');
+        ret.push('[' _ data.text _ ']');
+    END;
+-%]
+return [% ret.join(' ') %];

--- a/ncm-metaconfig/src/main/metaconfig/nginx/server.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/server.tt
@@ -13,3 +13,6 @@ error_page [% e.error_codes.join(" ") %] [% e.file %];
 [%- FOREACH l IN srv.location %]
 [%      INCLUDE metaconfig/nginx/location.tt location=l %]
 [% END -%]
+[%- IF srv.return %]
+[%      INCLUDE metaconfig/nginx/return.tt data=srv.return %]
+[% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/config.pan
@@ -54,4 +54,17 @@ prefix "/software/components/metaconfig/services/{/etc/nginx/nginx.conf}/content
     prepend(l);
 };
 
+"server/1/location" = append(dict(
+    "name", "/",
+    "operator", "=",
+    "return", dict("code", 301, "url", "https://$host/default"),
+    ));
+
 "upstream/secure/host/0" = format("%s:446", SERVER);
+
+# 80 -> 443 redirect
+"server/2" = dict(
+    "listen", dict("addr", "80", "default", true),
+    "name", list("_"),
+    "return", dict("code", 301, "url", "https://$host$request_uri"),
+);

--- a/ncm-metaconfig/src/main/metaconfig/nginx/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/tests/regexps/config/base
@@ -26,7 +26,7 @@ multiline
 ^\s{4}}$
 ^\s{4}upstream secure \{$
 ^\s{8}server myserver.my.domain:446;$
-^\s{4}server \{$ ### COUNT 2
+^\s{4}server \{$ ### COUNT 3
 ^\s{8}listen myhost.my.domain:8443 ssl;$
 ^\s{8}listen myhost.my.domain:443 ssl;$
 ^\s{8}server_name myhost.my.domain;$
@@ -50,7 +50,12 @@ multiline
 ^\s{12}proxy_next_upstream off;$ ### COUNT 7
 ^\s{12}proxy_http_version 1.1;$
 ^\s{12}proxy_read_timeout 86400;$
-^\s{8}\}$ ### COUNT 7
+^\s{8}\}$ ### COUNT 8
 ^\s{8}location ~ repodata \{$
 ^\s{12}proxy_cache off;$ ### COUNT 2
 ^\s{8}location  / \{$
+^\s{8}location = / \{$
+^\s{12}return 301 https://\$host/default;$
+^\s{8}listen 80 default ;$
+^\s{8}server_name _;$
+^\s{8}return 301 https://\$host\$request_uri;$


### PR DESCRIPTION
To be used for eg redirects (http to https; root to default path)