### PR TITLE
ncm-modprobe: Don't use placeholder CCM::Configuration module

### DIFF
--- a/ncm-modprobe/src/main/perl/modprobe.pm
+++ b/ncm-modprobe/src/main/perl/modprobe.pm
@@ -16,7 +16,6 @@ our @ISA = qw(NCM::Component);
 our $EC  = LC::Exception::Context->new->will_store_all;
 our $NoActionSupported = 1;
 
-use EDG::WP4::CCM::Configuration;
 use CAF::Process;
 use CAF::FileWriter;
 use LC::File qw(directory_contents);


### PR DESCRIPTION
More fallout from quattor/ccm#169.
Blocking for 18.6.