### PR TITLE
ncm-grub: escape interpretation of value of md5 password as a regex and add sensitive flag to file editor.

### DIFF
--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -200,7 +200,8 @@ sub password
             owner => "root",
             group => "root",
             mode  => oct(400),
-            log   => $self );
+            log   => $self,
+            sensitive => 1 );
 
         $usercfg_fh->add_or_replace_lines(qr/^GRUB2_PASSWORD=/, qr/^GRUB2_PASSWORD=\Q$password\E$/, "GRUB2_PASSWORD=$password\n", SEEK_END);
         $usercfg_fh->close();

--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -202,14 +202,14 @@ sub password
             mode  => oct(400),
             log   => $self );
 
-        $usercfg_fh->add_or_replace_lines(qr/^GRUB2_PASSWORD=/, qr/^GRUB2_PASSWORD=$password$/, "GRUB2_PASSWORD=$password\n", SEEK_END);
+        $usercfg_fh->add_or_replace_lines(qr/^GRUB2_PASSWORD=/, qr/^GRUB2_PASSWORD=\Q$password\E$/, "GRUB2_PASSWORD=$password\n", SEEK_END);
         $usercfg_fh->close();
     } else {
         my $val = $tree->{option} ? "--$tree->{option} " : "";
         $val .= $password;
 
         $grub_fh->add_or_replace_lines(qr/^password\s+/,
-                                  qr/^password $val$/,
+                                  qr/^password \Q$val\E$/,
                                   "password $val\n",
                                   $self->main_section_offset($grub_fh),
                                   SEEK_END);

--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -201,7 +201,8 @@ sub password
             group => "root",
             mode  => oct(400),
             log   => $self,
-            sensitive => 1 );
+            sensitive => 1,
+        );
 
         $usercfg_fh->add_or_replace_lines(qr/^GRUB2_PASSWORD=/, qr/^GRUB2_PASSWORD=\Q$password\E$/, "GRUB2_PASSWORD=$password\n", SEEK_END);
         $usercfg_fh->close();

--- a/ncm-grub/src/test/resources/md5password.pan
+++ b/ncm-grub/src/test/resources/md5password.pan
@@ -1,0 +1,15 @@
+object template md5password;
+
+include 'base';
+
+
+prefix "/software/components/grub/password";
+"enabled" = true;
+# this is technically an incorrect salt due to +, but it's
+# the easiest way to make the regex issue visible
+"password" = "$1$+DS97x/$z0phaR1SK9x7NDzLfGx7S/";
+"option" = "md5";
+
+
+# use defaults from code except speed
+"/hardware/console/serial" = dict("speed", 5678);

--- a/ncm-grub/src/test/resources/md5password.pan
+++ b/ncm-grub/src/test/resources/md5password.pan
@@ -1,7 +1,7 @@
 object template md5password;
 
 include 'base';
-
+include "components/grub/config";
 
 prefix "/software/components/grub/password";
 "enabled" = true;


### PR DESCRIPTION
ncm-grub: escape interpretation of value of md5 password as a regex and add sensitive flag to file editor.

A regular expresion 'qr/^password $val$/' results in the interpretation of the contents of $val as a regular expression if it contains regex characters, which md5 passwords do. This properly escapes it. There should be no backwards incompatibility unless someone was relying on this bug, but I can't think of how that could be used.

We should not show diffs of grub.conf changes since it will expose encrypted password+salt in the logs, so I've added the sensitive flag. If someone was relying on the diff of the grub.conf being available in the logs, or via --noaction, there may be a regression, but this change is necessary so there's no unintended leaks of salt+hash.
