### PR TITLE
ncm-network: allow default broadcast

### DIFF
--- a/ncm-network/src/test/resources/simple_nobroadcast.pan
+++ b/ncm-network/src/test/resources/simple_nobroadcast.pan
@@ -1,0 +1,5 @@
+object template simple_nobroadcast;
+
+include 'simple_base_profile';
+
+"/system/network/interfaces/eth0/broadcast" = null;


### PR DESCRIPTION
Improves upon fix to #1305 
Also provides a path without network restart to remove any configured broadcast that are equal to the computed default (via `ipcalc --broadcast ipaddr netmask`)