### PR TITLE
ncm-accounts: Add a valid_user type to validate user names

### DIFF
--- a/ncm-accounts/src/main/pan/components/accounts/functions.pan
+++ b/ncm-accounts/src/main/pan/components/accounts/functions.pan
@@ -63,6 +63,9 @@ type defined_user = string with is_user_or_group("user", SELF);
 type defined_group = string with is_user_or_group("group", SELF);
 
 
+type valid_user = string with valid_user_name();
+
+
 # create_group(groupname:string,
 #             params:structure_groupinfo)
 


### PR DESCRIPTION
In some cases, we need to be able to check a username received as
parameter, this allows it by providing a new valid_user type and a
valid_user_name function that checks that the username received
as parameter is a valid one, i.e. comprised only of alphanumeric
characters, plus a few special ones: .+:-

This is required by some changes that we will introduce internally at Morgan Stanley, but as this code could be reused for other templates, we thought it best to submit it to the community.