### PR TITLE
ncm-ceph: use mds cache memory limit instead of deprecated cache size

### DIFF
--- a/ncm-ceph/src/main/pan/components/ceph/v2/schema-mds.pan
+++ b/ncm-ceph/src/main/pan/components/ceph/v2/schema-mds.pan
@@ -2,7 +2,8 @@ declaration template components/${project.artifactId}/v2/schema-mds;
 
 @documentation{ configuration options for a ceph mds daemon }
 type ceph_mds_config = {
-    'mds_cache_size' ? long = 100000
+    'mds_cache_size' ? long = 100000 # deprecated
+    'mds_cache_memory_limit' ? long
     'mds_max_purge_files' ? long = 64
     'mds_max_purge_ops' ? long = 8192
     'mds_max_purge_ops_per_pg' ? double = 0.5


### PR DESCRIPTION
New for luminous: https://ceph.com/community/new-luminous-cephfs-metadata-server-memory-limits/