### PR TITLE
ncm-nscd: Add support for caching /etc/services and /etc/netgroup

### DIFF
--- a/ncm-nscd/src/main/pan/components/nscd/schema.pan
+++ b/ncm-nscd/src/main/pan/components/nscd/schema.pan
@@ -7,7 +7,7 @@ declaration template components/nscd/schema;
 
 include 'quattor/schema';
 
-type componend_nscd_service_type = {
+type component_nscd_service_type = {
     "enable-cache" ? legacy_binary_affirmation_string
     "positive-time-to-live" ? long
     "negative-time-to-live" ? long
@@ -32,9 +32,9 @@ type component_nscd_type = {
     "paranoia" ? legacy_binary_affirmation_string
     "restart-interval" ? long
 
-    "passwd" ? componend_nscd_service_type
-    "group" ? componend_nscd_service_type
-    "hosts" ? componend_nscd_service_type
+    "passwd" ? component_nscd_service_type
+    "group" ? component_nscd_service_type
+    "hosts" ? component_nscd_service_type
 };
 
 bind "/software/components/nscd" = component_nscd_type;

--- a/ncm-nscd/src/main/pan/components/nscd/schema.pan
+++ b/ncm-nscd/src/main/pan/components/nscd/schema.pan
@@ -35,6 +35,8 @@ type component_nscd_type = {
     "passwd" ? component_nscd_service_type
     "group" ? component_nscd_service_type
     "hosts" ? component_nscd_service_type
+    "services" ? component_nscd_service_type
+    "netgroup" ? component_nscd_service_type
 };
 
 bind "/software/components/nscd" = component_nscd_type;

--- a/ncm-nscd/src/main/perl/nscd.pm
+++ b/ncm-nscd/src/main/perl/nscd.pm
@@ -2,15 +2,7 @@
 # ${developer-info}
 # ${author-info}
 
-#
-# Example NCM Component with NVA API config access
-#
-###############################################################################
-
 package NCM::Component::nscd;
-#
-# a few standard statements, mandatory for all components
-#
 
 use strict;
 use NCM::Component;
@@ -21,167 +13,165 @@ use File::Temp;
 use File::Copy qw(copy);
 
 @ISA = qw(NCM::Component);
-$EC=LC::Exception::Context->new->will_store_all;
-$NCM::Component::NoActionSupported=1;
+$EC = LC::Exception::Context->new->will_store_all;
+$NCM::Component::NoActionSupported = 1;
 
 my $cfgfile='/etc/nscd.conf';
 my $p ='/software/components/nscd';
 
-##########################################################################
-sub Configure($$) {
-##########################################################################
-  my ($self,$config)=@_;
-  my $changes;
-  my $RealNoAction = $NoAction;
-  # need to turn this off while working on the temp file.
-  undef($NoAction);
+sub Configure {
+    my ($self, $config) = @_;
+    my $changes;
+    my $RealNoAction = $NoAction;
+    # need to turn this off while working on the temp file.
+    undef($NoAction);
 
-  my $tmpfile = $cfgfile.".tmp"; # same dir, don't have to worry about a race
-  if( -e $tmpfile) {
-    unlink($tmpfile);
-  }
-
-  if ( -r $cfgfile) {
-    if (!copy($cfgfile, $tmpfile)) {
-      $self->warn("cannot create $tmpfile: $!, giving up");
-      return 0;
+    my $tmpfile = $cfgfile.".tmp"; # same dir, don't have to worry about a race
+    if (-e $tmpfile) {
+        unlink($tmpfile);
     }
-  } else {
-    $self->info("$cfgfile does not exist (yet)");
-  }
 
-  # add ourselves to the top
-  $changes = NCM::Check::lines($tmpfile,
-			       good => '## Warning: file partially controlled by ncm-nscd',
-			       goodre => '^## Warning: file partially controlled.*',
-			       linere => '^## Warning: file partially controlled.*',
-			       add => 'first',
-			       keep => 'first'
-			      );
-  if($changes) {
-    $self->verbose("added NCM marker to top of file");
-  }
-
-  # check global options we know about
-  my @global_opts = (
-		     'logfile',
-		     'debug-level',
-		     'threads',
-		     'max-threads',
-		     'server-user',
-		     'stat-user',
-		     'reload-count',
-		     'paranoia',
-		     'restart-interval'
-		    );
-
-  for my $cfgname (@global_opts) {
-    if ($config->elementExists($p."/".$cfgname )) {
-      my $value=$config->getValue($p."/".$cfgname );
-      $self->debug(5, "global option \"$cfgname\" = \"$value\"");
-
-      $changes=NCM::Check::lines($tmpfile,
-			good => "\t$cfgname\t\t$value",
-			goodre => "^\\s*$cfgname\\s+$value",
-			linere => ".*$cfgname.*",
-			add => 'last',
-			keep => 'first'
-		       );
-      if ($changes) {
-	$self->info("set global option \"$cfgname\" = \"$value\"");
-      } else {
-	$self->verbose("global option \"$cfgname\" = \"$value\" already OK");
-      }
+    if (-r $cfgfile) {
+        if (!copy($cfgfile, $tmpfile)) {
+            $self->warn("cannot create $tmpfile: $!, giving up");
+            return 0;
+        }
     } else {
-      $self->debug(5, "global option \"$cfgname\" not set in profile");
-    }
-  }
-
-  # check per-service options we know about
-  my @services = ('passwd', 'group', 'hosts');
-  my @service_opts = (
-		      'enable-cache',
-		      'positive-time-to-live',
-		      'negative-time-to-live',
-		      'suggested-size',
-		      'check-files',
-		      'persistent',
-		      'shared',
-		      'max-db-size',
-		      'auto-propagate'
-		     );
-
-  for my $service (@services) {
-    for my $cfgname (@service_opts) {
-
-      if ($config->elementExists($p."/".$service."/".$cfgname )) {
-	my $value=$config->getValue($p."/".$service."/".$cfgname );
-	$self->debug(5, "service \"$service\" option \"$cfgname\" = \"$value\"");
-
-	$changes=NCM::Check::lines($tmpfile,
-				   good => "\t$cfgname\t$service\t\t$value",
-				   goodre => "^\\s*$cfgname\\s+$service\\s+$value",
-				   linere => ".*$cfgname\\s+$service.*",
-				   add => 'last',
-				   keep => 'first'
-				  );
-	if ($changes) {
-	  $self->info("set service \"$service\" option \"$cfgname\" = \"$value\"");
-	} else {
-	  $self->verbose("service \"$service\" option \"$cfgname\" = \"$value\" already OK");
-	}
-      } else {
-	$self->debug(5, "service \"$service\" option \"$cfgname\" not set in profile");
-      }
-    }
-  }
-
-
-  # check whether we've changed anything
-  $NoAction = $RealNoAction;
-  $changes = LC::Check::file($cfgfile,
-			       source => $tmpfile,
-			       owner => 'root',
-			       group => 'root',
-			       backup => '.ncmorig',
-			       mode => '0444');
-  if ($changes && !$NoAction) {
-    my $s;
-    # make SELinux happy
-    if (-x '/sbin/restorecon') {
-      $s=`/sbin/restorecon -v $cfgfile 2>&1`;
-      chomp($s);
-      if ($?) {
-	$self->warn("cannot restore SELinux context for $cfgfile:\n$s");
-      } else {
-	$self->info("restored SELinux context for $cfgfile:\n$s");
-      }
+        $self->info("$cfgfile does not exist (yet)");
     }
 
-    $s=`/sbin/service nscd condrestart 2>&1`;
-    chomp($s);
-    if ($? && $s) {
-      # also get bad return code if the service wasn't running, so need to check for actual error msg
-      $self->error("can't restart service, changes not activated:\n$s");
+    # add ourselves to the top
+    $changes = NCM::Check::lines(
+        $tmpfile,
+        good => '## Warning: file partially controlled by ncm-nscd',
+        goodre => '^## Warning: file partially controlled.*',
+        linere => '^## Warning: file partially controlled.*',
+        add => 'first',
+        keep => 'first'
+    );
+    if ($changes) {
+        $self->verbose("added NCM marker to top of file");
+    }
+
+    # check global options we know about
+    my @global_opts = (
+        'logfile',
+        'debug-level',
+        'threads',
+        'max-threads',
+        'server-user',
+        'stat-user',
+        'reload-count',
+        'paranoia',
+        'restart-interval'
+    );
+
+    for my $cfgname (@global_opts) {
+        if ($config->elementExists($p."/".$cfgname )) {
+            my $value=$config->getValue($p."/".$cfgname );
+            $self->debug(5, "global option \"$cfgname\" = \"$value\"");
+
+            $changes=NCM::Check::lines(
+                $tmpfile,
+                good => "\t$cfgname\t\t$value",
+                goodre => "^\\s*$cfgname\\s+$value",
+                linere => ".*$cfgname.*",
+                add => 'last',
+                keep => 'first'
+            );
+            if ($changes) {
+                $self->info("set global option \"$cfgname\" = \"$value\"");
+            } else {
+                $self->verbose("global option \"$cfgname\" = \"$value\" already OK");
+            }
+        } else {
+            $self->debug(5, "global option \"$cfgname\" not set in profile");
+        }
+    }
+
+    # check per-service options we know about
+    my @services = ('passwd', 'group', 'hosts');
+    my @service_opts = (
+        'enable-cache',
+        'positive-time-to-live',
+        'negative-time-to-live',
+        'suggested-size',
+        'check-files',
+        'persistent',
+        'shared',
+        'max-db-size',
+        'auto-propagate'
+    );
+
+
+    for my $service (@services) {
+        for my $cfgname (@service_opts) {
+            if ($config->elementExists($p."/".$service."/".$cfgname )) {
+                my $value=$config->getValue($p."/".$service."/".$cfgname );
+                $self->debug(5, "service \"$service\" option \"$cfgname\" = \"$value\"");
+
+                $changes=NCM::Check::lines(
+                    $tmpfile,
+                    good => "\t$cfgname\t$service\t\t$value",
+                    goodre => "^\\s*$cfgname\\s+$service\\s+$value",
+                    linere => ".*$cfgname\\s+$service.*",
+                    add => 'last',
+                    keep => 'first'
+                );
+                if ($changes) {
+                    $self->info("set service \"$service\" option \"$cfgname\" = \"$value\"");
+                } else {
+                    $self->verbose("service \"$service\" option \"$cfgname\" = \"$value\" already OK");
+                }
+            } else {
+                $self->debug(5, "service \"$service\" option \"$cfgname\" not set in profile");
+            }
+        }
+    }
+
+    # check whether we've changed anything
+    $NoAction = $RealNoAction;
+    $changes = LC::Check::file(
+        $cfgfile,
+        source => $tmpfile,
+        owner => 'root',
+        group => 'root',
+        backup => '.ncmorig',
+        mode => '0444'
+    );
+
+    if ($changes && !$NoAction) {
+        my $s;
+        # make SELinux happy
+        if (-x '/sbin/restorecon') {
+            $s=`/sbin/restorecon -v $cfgfile 2>&1`;
+            chomp($s);
+            if ($?) {
+                $self->warn("cannot restore SELinux context for $cfgfile:\n$s");
+            } else {
+                $self->info("restored SELinux context for $cfgfile:\n$s");
+            }
+        }
+
+        $s=`/sbin/service nscd condrestart 2>&1`;
+        chomp($s);
+        if ($? && $s) {
+            # also get bad return code if the service wasn't running, so need to check for actual error msg
+            $self->error("can't restart service, changes not activated:\n$s");
+        } else {
+            $self->info("service nscd has been condrestart-ed");
+        }
+    } elsif ($changes) {
+        $self->info("some changes, would need to restart nscd");
     } else {
-      $self->info("service nscd has been condrestart-ed");
+        $self->info("no changes.");
     }
-  } elsif ($changes) {
-    $self->info("some changes, would need to restart nscd");
-  } else {
-    $self->info("no changes.");
-  }
 
-  if( -e $tmpfile) {
-    unlink($tmpfile);
-  }
+    if (-e $tmpfile) {
+        unlink($tmpfile);
+    }
 
-  return; # return code is not checked.
-
+    return; # return code is not checked.
 }
 
 1; # Perl module requirement.
-
-### Local Variables: ///
-### mode: perl ///
-### End: ///

--- a/ncm-nscd/src/main/perl/nscd.pm
+++ b/ncm-nscd/src/main/perl/nscd.pm
@@ -117,7 +117,7 @@ sub Configure($$) {
       if ($config->elementExists($p."/".$service."/".$cfgname )) {
 	my $value=$config->getValue($p."/".$service."/".$cfgname );
 	$self->debug(5, "service \"$service\" option \"$cfgname\" = \"$value\"");
-	
+
 	$changes=NCM::Check::lines($tmpfile,
 				   good => "\t$cfgname\t$service\t\t$value",
 				   goodre => "^\\s*$cfgname\\s+$service\\s+$value",

--- a/ncm-nscd/src/main/perl/nscd.pod
+++ b/ncm-nscd/src/main/perl/nscd.pod
@@ -12,7 +12,7 @@ NCM::nscd - NCM component to configure nscd.
 
 =item Configure()
 
-Configures the name service caching daemon (nscd). See the C<nscd.conf(5)> man page 
+Configures the name service caching daemon (nscd). See the C<nscd.conf(5)> man page
 or the CDB schema file for allowed options. Booleans have to be written as
 I<yes> or I<no> in the template, this is the way I<nscd> expects them.
 


### PR DESCRIPTION
Support for these were added to nscd some time ago:
* services by the version shipped with EL6.
* netgroup by the version shipped with EL7.

The version of nscd is checked to determine support for each.
