### PR TITLE
ncm-metaconfig: add nginx client_max_body_size option

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/nginx/nginx.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/nginx.tt
@@ -23,6 +23,9 @@ gzip [% h.gzip ? "on" : "off" %];
 
 keepalive_timeout [% h.keepalive_timeout %];
 sendfile on;
+[%- IF h.client_max_body_size.defined %]
+client_max_body_size [% h.client_max_body_size %];
+[% END %]
 
 [%-         FOREACH u IN h.upstream.pairs -%]
 [%-             INCLUDE metaconfig/nginx/proxy/upstream.tt name=u.key cfg=u.value %]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
@@ -175,6 +175,13 @@ type nginx_http = {
     "server" : nginx_server[]
     "keepalive_timeout" : long = 65
     "upstream" ? nginx_upstream{}
+    @{Sets the maximum allowed size of the client request body,
+    specified in the "Content-Length" request header field.
+    If the size in a request exceeds the configured value,
+    the 413 (Request Entity Too Large) error is returned to the client.
+    Please be aware that browsers cannot correctly display this error.
+    Setting size to 0 disables checking of client request body size}
+    "client_max_body_size" ? long(0..)
 };
 
 type type_nginx = {

--- a/ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/config.pan
@@ -3,7 +3,7 @@ object template config;
 include 'metaconfig/nginx/config';
 
 variable SERVER = 'myserver.my.domain';
-variable FULL_HOSTNAME = 'myhost.my.domain';;
+variable FULL_HOSTNAME = 'myhost.my.domain';
 
 prefix "/software/components/metaconfig/services/{/etc/nginx/nginx.conf}/contents/http/0";
 
@@ -68,3 +68,5 @@ prefix "/software/components/metaconfig/services/{/etc/nginx/nginx.conf}/content
     "name", list("_"),
     "return", dict("code", 301, "url", "https://$host$request_uri"),
 );
+# Disable max body size limit
+"client_max_body_size" = 0;


### PR DESCRIPTION
Required by some services. By default nginx restricts the POST header body size to a few kilobytes.
