### PR TITLE
ncm-filecopy: Make restart failures non-fatal

### DIFF
--- a/ncm-filecopy/src/main/pan/components/filecopy/schema.pan
+++ b/ncm-filecopy/src/main/pan/components/filecopy/schema.pan
@@ -38,6 +38,7 @@ type component_filecopy = {
     include structure_component
     'services' ? structure_filecopy{} with valid_absolute_file_paths(SELF)
     'forceRestart' : boolean = false
+    'ignore_restart_failure' ? boolean
 };
 
 bind '/software/components/filecopy' = component_filecopy;

--- a/ncm-filecopy/src/main/perl/filecopy.pm
+++ b/ncm-filecopy/src/main/perl/filecopy.pm
@@ -149,7 +149,8 @@ sub Configure
                                     stderr => "stdout");
         $cmd->execute();
         if ( $? ) {
-            $self->error("Command failed. Command output: $cmd_output\n");
+            my $method = $confighash->{ignore_restart_failure} ? 'warn' : 'error';
+            $self->{$method}("Command failed. Command output: $cmd_output\n");
         } else {
             $self->debug(1,"Command output: $cmd_output\n");
         }


### PR DESCRIPTION
Currently, if restarting a service fails, that marks the whole component
as failed, preventing other components which depend on filecopy from
running. In practice, that usually causes more damage than the restart
failure, so lower the severity of restart failures to warnings.

I considered making the behavior configurable, but I'm not sure if that
would worth the effort.

Comments are welcome.