### PR TITLE
ncm-metaconfig: keepalived - support unicast peers, virtual routes and interface tracking

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/keepalived/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/pan/schema.pan
@@ -25,6 +25,7 @@ type keepalived_service_vrrpscript = {
 type keepalived_service_vip = {
     'ipaddress' : string
     'interface' : string
+    'broadcast' : string
 };
 
 @documentation {
@@ -34,7 +35,7 @@ type keepalived_service_vrrpinstance_config = {
     'virtual_router_id' : long
     'advert_int' : long = 1
     'priority' : long = 100
-    'state' : string
+    'state' : choice("MASTER", "BACKUP")
     'interface' : string
 };
 
@@ -46,6 +47,10 @@ type keepalived_service_vrrpinstance = {
     'config' : keepalived_service_vrrpinstance_config
     'virtual_ipaddresses' : keepalived_service_vip[]
     'track_scripts' : string[]
+    'unicast_peer' ? type_ip[]
+    'unicast_src_ip' ? type_ip
+    'virtual_routes' ? string[]
+    'track_interface' ? string[]
 };
 
 @documentation {

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/tests/profiles/config.pan
@@ -3,31 +3,32 @@ object template config;
 include 'metaconfig/keepalived/config';
 
 prefix '/software/components/metaconfig/services/{/etc/keepalived/keepalived.conf}';
-'contents/global_defs/router_id'='vm1';
-'contents/vrrp_scripts'=append(
+'contents/global_defs/router_id' = 'vm1';
+'contents/vrrp_scripts' = append(
     dict(
-        'name' , 'haproxy',
-        'script' , '"killall -0 haproxy"',
-        'interval' , 2,
-        'weight' , 2
+        'name', 'haproxy',
+        'script', '"killall -0 haproxy"',
+        'interval', 2,
+        'weight', 2
     )
 );
-'contents/vrrp_instances'=append(
+'contents/vrrp_instances' = append(
     dict(
-        'name' , 'Testing',
-        'config' , dict(
-            'virtual_router_id' , 52,
-            'advert_int' , 1,
-            'priority' , 100,
-            'state' , 'BACKUP',
-            'interface' , 'eth0',
+        'name', 'Testing',
+        'config', dict(
+            'virtual_router_id', 52,
+            'advert_int', 1,
+            'priority', 100,
+            'state', 'BACKUP',
+            'interface', 'eth0',
         ),
-        'virtual_ipaddresses' , list(
+        'virtual_ipaddresses', list(
             dict(
-                'ipaddress' , '192.168.1.20',
-                'interface' , 'eth0',
+                'ipaddress', '192.168.1.20',
+                'interface', 'eth0',
+                'broadcast', '192.168.0.255',
             ),
         ),
-        'track_scripts' , list('haproxy'),
+        'track_scripts', list('haproxy'),
     )
 );

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/tests/regexps/config/base
@@ -18,7 +18,7 @@ unordered
 ^\s{4}state\s+BACKUP\s*$
 ^\s{4}interface\s+eth0\s*$
 ^\s{4}virtual_ipaddress\s+\{\s*$
-^\s{8}192\.168\.1\.20\s+dev\s+eth0\s*$
+^\s{8}192\.168\.1\.20\s+dev\s+eth0\s+brd\s+192\.168\.0\.255\s*$
 ^\s{4}\}\s*$
 ^\s{4}track_script\s\{\s*$
 ^\s{8}haproxy\s*$

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/virtual_ipaddress.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/virtual_ipaddress.tt
@@ -1,3 +1,3 @@
 [% FOREACH vip IN vrrp_instance.virtual_ipaddresses -%]
-[%     vip.ipaddress %] dev [% vip.interface %]
+[%     vip.ipaddress %] dev [% vip.interface %] brd [% vip.broadcast %]
 [% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_instance.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_instance.tt
@@ -7,3 +7,25 @@ virtual_ipaddress {
 track_script {
 [% INCLUDE 'metaconfig/keepalived/track_script.tt' FILTER indent -%]
 }
+[% IF vrrp_instance.virtual_routes.defined %]
+virtual_routes {
+[% FOREACH route IN vrrp_instance.virtual_routes -%]
+    [% route %]
+[% END %]
+}
+[% END %]
+[% IF vrrp_instance.track_interface.defined %]
+track_interface {
+[% FOREACH intf IN vrrp_instance.track_interface -%]
+    [% intf %]
+[% END %]
+}
+[% END %]
+[% IF vrrp_instance.unicast_src_ip.defined %]
+unicast_src_ip [% vrrp_instance.unicast_src_ip %]
+unicast_peer {
+[% FOREACH peer IN vrrp_instance.unicast_peer -%]
+    [% peer %]
+[% END %]
+}
+[% END %]

--- a/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_script.tt
+++ b/ncm-metaconfig/src/main/metaconfig/keepalived/vrrp_script.tt
@@ -1,3 +1,5 @@
 [% FOREACH option IN vrrp_script.pairs -%]
+[% IF option.key != 'name' -%]
 [%     option.key %] [% option.value %]
+[% END -%]
 [% END -%]


### PR DESCRIPTION
add keepalived support for unicast peers in schema en TT file.
