### PR TITLE
ncm-network: Add support for CAF::Service actions after changes

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -84,8 +84,6 @@ type ${project.artifactId}_textrender_convert = {
     true;
 };
 
-type caf_service_action = string with match(SELF, '^(restart|condrestart|reload|stop_sleep_start)$');
-
 type ${project.artifactId}_actions = {
     @{Always run, happens before possible modifications.
       A failure will cancel any file modification, unless the command is prefixed with -.}

--- a/ncm-network/src/main/pan/components/network/schema.pan
+++ b/ncm-network/src/main/pan/components/network/schema.pan
@@ -6,4 +6,10 @@ type network_component = {
     include structure_component
     @{experimental: rename (physical) devices}
     'rename' ? boolean
+
+    @{
+        A dict mapping daemon name to CAF::Service action to take if the network configuration changes.
+        e.g. 'daemons/firewalld' = 'reload';
+    }
+    'daemons' ? caf_service_action{}
 };

--- a/ncm-network/src/test/perl/actions.t
+++ b/ncm-network/src/test/perl/actions.t
@@ -1,0 +1,43 @@
+# -*- mode: cperl -*-
+use strict;
+use warnings;
+
+BEGIN {
+    *CORE::GLOBAL::sleep = sub {};
+}
+
+use Test::More;
+use Test::Quattor qw(actions);
+use Test::MockModule;
+
+use NCM::Component::network;
+
+
+my $mock = Test::MockModule->new('CAF::Service');
+
+our ($restart, $reload, $stop_sleep_start) = qw(0 0 0);
+
+$mock->mock('restart', sub {
+    my $self = shift;
+    $restart += scalar @{$self->{services}};
+});
+$mock->mock('reload', sub {
+    my $self = shift;
+    $reload += scalar @{$self->{services}};
+});
+$mock->mock('stop_sleep_start', sub {
+    my $self = shift;
+    $stop_sleep_start += scalar @{$self->{services}};
+});
+
+
+my $cfg = get_config_for_profile('actions');
+my $cmp = NCM::Component::network->new('network');
+
+is($cmp->Configure($cfg), 1, "Component runs correctly with daemon actions set");
+
+is($restart, 1, "$restart/1 restarts triggered");
+is($reload, 2, "$reload/2 reloads triggered");
+is($stop_sleep_start, 3, "$stop_sleep_start/3 stop_sleep_starts triggered");
+
+done_testing();

--- a/ncm-network/src/test/resources/actions.pan
+++ b/ncm-network/src/test/resources/actions.pan
@@ -1,0 +1,14 @@
+object template actions;
+
+include 'simple_base_profile';
+
+prefix "/software/components/network/daemons";
+
+"test_restart_1" = 'restart';
+
+"test_reload_1" = 'reload';
+"test_reload_2" = 'reload';
+
+"test_stop_sleep_start_1" = 'stop_sleep_start';
+"test_stop_sleep_start_2" = 'stop_sleep_start';
+"test_stop_sleep_start_3" = 'stop_sleep_start';


### PR DESCRIPTION
Largely transcribed from ncm-metaconfig.

Requires #1335.
Resolves #1071.