### PR TITLE
ncm-authconfig: fix documentation

### DIFF
--- a/ncm-authconfig/src/main/perl/authconfig.pm
+++ b/ncm-authconfig/src/main/perl/authconfig.pm
@@ -88,6 +88,7 @@ It will also enable/disable NSCD support on the client.
     "enable" = false;
     "lhs" = "lefthanded";
     "rhs" = "righthanded";
+
 =cut
 
 use parent qw(NCM::Component);


### PR DESCRIPTION
pod `=cut` needs a blank line before (and after). Otherwise this results in podlint errors and most of the code beeing generated as documentation.