### PR TITLE
ncm-opennebula: fix malformed pod syntax

### DIFF
--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -34,8 +34,8 @@ support to C<NCM::Component::OpenNebula>.
 
 =item restart_opennebula_service
 
-Restarts C<OpenNebula> service after any
-configuration change.
+Restarts C<OpenNebula> service after any configuration change.
+
 =cut
 
 sub restart_opennebula_service {


### PR DESCRIPTION
newline before pod directive is required.