### PR TITLE
ncm-metaconfig: add mysql conf

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/mysql/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mysql/pan/config.pan
@@ -1,0 +1,12 @@
+unique template metaconfig/mysql/config;
+
+include 'metaconfig/mysql/schema';
+
+bind "/software/components/metaconfig/services/{/etc/my.cnf.d/quattor.cnf}/contents" = type_mysql_cnf;
+
+prefix "/software/components/metaconfig/services/{/etc/my.cnf.d/quattor.cnf}";
+"mode" = 0640;
+"owner" = "root";
+"group" = "mysql";
+"module" = "tiny";
+"daemons/mariadb" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/mysql/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mysql/pan/schema.pan
@@ -6,18 +6,18 @@ type mysql_cnf_size = string with match(SELF, "^[0-9]+(M|K)$");
 type mysql_cnf_boolean = long(0..1);
 
 type mysql_cnf_client = {
-    'password'    ?   string
-    'port'        ?   long = 3306
-    'socket'      ?   string = "/var/lib/mysql/mysql.sock"
+    'password' ? string
+    'port' ? long = 3306
+    'socket' ? string = "/var/lib/mysql/mysql.sock"
 };
 
 type mysql_cnf_mysqld = {
-    'port'        ?   long = 3306
-    'datadir'     ?   string = "/var/lib/mysql"
-    'socket'      ?   string = "/var/lib/mysql/mysql.sock"
-    'user'        ? string = 'mysql'
+    'port' ? long = 3306
+    'datadir' ? string = "/var/lib/mysql"
+    'socket' ? string = "/var/lib/mysql/mysql.sock"
+    'user' ? string = 'mysql'
     'symbolic-links' ? mysql_cnf_boolean
-    'skip-locking'    ? mysql_cnf_boolean
+    'skip-locking' ? mysql_cnf_boolean
     'key_buffer_size' ? mysql_cnf_size
     'max_allowed_packet' ? mysql_cnf_size
     'max_connections' ? long(1..)
@@ -32,12 +32,12 @@ type mysql_cnf_mysqld = {
 
     'skip-networking' ? mysql_cnf_boolean
 
-    'log-bin'     ?   string
+    'log-bin' ? string
 
-    'server-id'   ?   long
+    'server-id' ? long
 
-    'master-host' ?   string
-    'master-user' ?   string
+    'master-host' ? string
+    'master-user' ? string
     'master-password' ? string
     'master-port' ? long
     'log-bin' ? string
@@ -48,10 +48,10 @@ type mysql_cnf_mysqld = {
     'innodb_data_file_path' ? string # eg= ibdata1:2000M;ibdata2:10M:autoextend
     'innodb_log_group_home_dir' ? string # eg = /var/lib/mysql
 
-    'innodb_buffer_pool_size'  ? mysql_cnf_size # eg = 384M
-    'innodb_additional_mem_pool_size'  ? mysql_cnf_size # eg = 20M
-    'innodb_log_file_size'  ? mysql_cnf_size # eg = 100M
-    'innodb_log_buffer_size'  ? mysql_cnf_size # eg = 8M
+    'innodb_buffer_pool_size' ? mysql_cnf_size # eg = 384M
+    'innodb_additional_mem_pool_size' ? mysql_cnf_size # eg = 20M
+    'innodb_log_file_size' ? mysql_cnf_size # eg = 100M
+    'innodb_log_buffer_size' ? mysql_cnf_size # eg = 8M
     'innodb_flush_log_at_trx_commit' ? long # eg = 1
     'innodb_lock_wait_timeout' ? long # eg = 50
 

--- a/ncm-metaconfig/src/main/metaconfig/mysql/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mysql/pan/schema.pan
@@ -1,0 +1,93 @@
+declaration template metaconfig/mysql/schema;
+
+include 'pan/types';
+
+type mysql_cnf_size = string with match(SELF, "^[0-9]+(M|K)$");
+type mysql_cnf_boolean = long(0..1);
+
+type mysql_cnf_client = {
+    'password'    ?   string
+    'port'        ?   long = 3306
+    'socket'      ?   string = "/var/lib/mysql/mysql.sock"
+};
+
+type mysql_cnf_mysqld = {
+    'port'        ?   long = 3306
+    'datadir'     ?   string = "/var/lib/mysql"
+    'socket'      ?   string = "/var/lib/mysql/mysql.sock"
+    'user'        ? string = 'mysql'
+    'symbolic-links' ? mysql_cnf_boolean
+    'skip-locking'    ? mysql_cnf_boolean
+    'key_buffer_size' ? mysql_cnf_size
+    'max_allowed_packet' ? mysql_cnf_size
+    'max_connections' ? long(1..)
+    'table_open_cache' ? long
+    'sort_buffer_size' ? mysql_cnf_size
+    'read_buffer_size' ? mysql_cnf_size
+    'read_rnd_buffer_size' ? mysql_cnf_size
+    'myisam_sort_buffer_size' ? mysql_cnf_size
+    'thread_cache_size' ? long
+    'query_cache_size' ? mysql_cnf_size
+    'thread_concurrency' ? long
+
+    'skip-networking' ? mysql_cnf_boolean
+
+    'log-bin'     ?   string
+
+    'server-id'   ?   long
+
+    'master-host' ?   string
+    'master-user' ?   string
+    'master-password' ? string
+    'master-port' ? long
+    'log-bin' ? string
+
+    'binlog_format' ? string # eg mixed
+
+    'innodb_data_home_dir' ? string # eg = /var/lib/mysql
+    'innodb_data_file_path' ? string # eg= ibdata1:2000M;ibdata2:10M:autoextend
+    'innodb_log_group_home_dir' ? string # eg = /var/lib/mysql
+
+    'innodb_buffer_pool_size'  ? mysql_cnf_size # eg = 384M
+    'innodb_additional_mem_pool_size'  ? mysql_cnf_size # eg = 20M
+    'innodb_log_file_size'  ? mysql_cnf_size # eg = 100M
+    'innodb_log_buffer_size'  ? mysql_cnf_size # eg = 8M
+    'innodb_flush_log_at_trx_commit' ? long # eg = 1
+    'innodb_lock_wait_timeout' ? long # eg = 50
+
+    "ignore_builtin_innodb" ? mysql_cnf_boolean
+    "plugin-load" ? string with match(SELF, '\.so$')
+};
+
+type mysql_cnf_mysqldump = {
+    'quick' ? mysql_cnf_boolean
+    'max_allowed_packet' ? mysql_cnf_size
+    'max_connections' ? long(1..)
+    'user' ? string
+    'password' ? string
+};
+
+type mysql_cnf_mysql = {
+    'no-auto-rehash' ? mysql_cnf_boolean
+    'safe-updates' ? mysql_cnf_boolean
+};
+
+type mysql_cnf_myisamchk = {
+    'key_buffer_size' ? mysql_cnf_size
+    'sort_buffer_size' ? mysql_cnf_size
+    'read_buffer' ? mysql_cnf_size
+    'write_buffer' ? mysql_cnf_size
+};
+type mysql_cnf_mysqlhotcopy = {
+    'interactive-timeout' ? mysql_cnf_boolean
+};
+
+type type_mysql_cnf = {
+    'client' ? mysql_cnf_client
+    'mysqld' ? mysql_cnf_mysqld
+
+    'mysqldump' ? mysql_cnf_mysqldump
+    'mysql' ? mysql_cnf_mysql
+    'myisamchk' ? mysql_cnf_myisamchk
+    'mysqlhotcopy' ? mysql_cnf_mysqlhotcopy
+};

--- a/ncm-metaconfig/src/main/metaconfig/mysql/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mysql/pan/schema.pan
@@ -3,21 +3,20 @@ declaration template metaconfig/mysql/schema;
 include 'pan/types';
 
 type mysql_cnf_size = string with match(SELF, "^[0-9]+(M|K)$");
-type mysql_cnf_boolean = long(0..1);
 
 type mysql_cnf_client = {
     'password' ? string
-    'port' ? long = 3306
-    'socket' ? string = "/var/lib/mysql/mysql.sock"
+    'port' ? type_port = 3306
+    'socket' ? absolute_file_path = "/var/lib/mysql/mysql.sock"
 };
 
 type mysql_cnf_mysqld = {
-    'port' ? long = 3306
-    'datadir' ? string = "/var/lib/mysql"
-    'socket' ? string = "/var/lib/mysql/mysql.sock"
+    'port' ? type_port = 3306
+    'datadir' ? absolute_file_path = "/var/lib/mysql"
+    'socket' ? absolute_file_path = "/var/lib/mysql/mysql.sock"
     'user' ? string = 'mysql'
-    'symbolic-links' ? mysql_cnf_boolean
-    'skip-locking' ? mysql_cnf_boolean
+    'symbolic-links' ? boolean
+    'skip-locking' ? boolean
     'key_buffer_size' ? mysql_cnf_size
     'max_allowed_packet' ? mysql_cnf_size
     'max_connections' ? long(1..)
@@ -30,7 +29,7 @@ type mysql_cnf_mysqld = {
     'query_cache_size' ? mysql_cnf_size
     'thread_concurrency' ? long
 
-    'skip-networking' ? mysql_cnf_boolean
+    'skip-networking' ? boolean
 
     'log-bin' ? string
 
@@ -44,9 +43,9 @@ type mysql_cnf_mysqld = {
 
     'binlog_format' ? string # eg mixed
 
-    'innodb_data_home_dir' ? string # eg = /var/lib/mysql
+    'innodb_data_home_dir' ? absolute_file_path # eg = /var/lib/mysql
     'innodb_data_file_path' ? string # eg= ibdata1:2000M;ibdata2:10M:autoextend
-    'innodb_log_group_home_dir' ? string # eg = /var/lib/mysql
+    'innodb_log_group_home_dir' ? absolute_file_path # eg = /var/lib/mysql
 
     'innodb_buffer_pool_size' ? mysql_cnf_size # eg = 384M
     'innodb_additional_mem_pool_size' ? mysql_cnf_size # eg = 20M
@@ -55,12 +54,12 @@ type mysql_cnf_mysqld = {
     'innodb_flush_log_at_trx_commit' ? long # eg = 1
     'innodb_lock_wait_timeout' ? long # eg = 50
 
-    "ignore_builtin_innodb" ? mysql_cnf_boolean
+    "ignore_builtin_innodb" ? boolean
     "plugin-load" ? string with match(SELF, '\.so$')
 };
 
 type mysql_cnf_mysqldump = {
-    'quick' ? mysql_cnf_boolean
+    'quick' ? boolean
     'max_allowed_packet' ? mysql_cnf_size
     'max_connections' ? long(1..)
     'user' ? string
@@ -68,8 +67,8 @@ type mysql_cnf_mysqldump = {
 };
 
 type mysql_cnf_mysql = {
-    'no-auto-rehash' ? mysql_cnf_boolean
-    'safe-updates' ? mysql_cnf_boolean
+    'no-auto-rehash' ? boolean
+    'safe-updates' ? boolean
 };
 
 type mysql_cnf_myisamchk = {
@@ -79,7 +78,7 @@ type mysql_cnf_myisamchk = {
     'write_buffer' ? mysql_cnf_size
 };
 type mysql_cnf_mysqlhotcopy = {
-    'interactive-timeout' ? mysql_cnf_boolean
+    'interactive-timeout' ? boolean
 };
 
 type type_mysql_cnf = {

--- a/ncm-metaconfig/src/main/metaconfig/mysql/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/mysql/tests/profiles/config.pan
@@ -1,0 +1,8 @@
+object template config;
+
+include 'metaconfig/mysql/config';
+
+prefix "/software/components/metaconfig/services/{/etc/my.cnf.d/quattor.cnf}/contents";
+"mysqldump/user" = "root";
+"mysqldump/password" = "my_database_password";
+"mysqld/max_connections" = 2000;

--- a/ncm-metaconfig/src/main/metaconfig/mysql/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/mysql/tests/regexps/config/base
@@ -1,0 +1,11 @@
+Base test for config
+---
+multiline
+/etc/my.cnf.d/quattor.cnf
+---
+^\[mysqld\]$
+^max_connections\=\d+$
+
+^\[mysqldump\]$
+^password\=.+$
+^user\=.+$

--- a/ncm-metaconfig/src/test/perl/service-mysql.t
+++ b/ncm-metaconfig/src/test/perl/service-mysql.t
@@ -1,0 +1,15 @@
+use Test::Quattor::ProfileCache qw(set_json_typed get_json_typed);
+BEGIN {
+    set_json_typed()
+}
+
+use Test::More;
+use Test::Quattor::TextRender::Metaconfig;
+
+my $u = Test::Quattor::TextRender::Metaconfig->new(
+        service => 'mysql',
+        usett => 0,
+        )->test();
+
+done_testing;
+


### PR DESCRIPTION
I have realised that we are using mysql/mariadb metaconfig setups but our current schema is not available from upstream. We need to change the mysql conf to time to time for our cloud clusters for instance. 

Maybe this could be useful for someone else.
