### PR TITLE
ncm-openstack: documentation fix code block not starting with newline

### DIFF
--- a/ncm-openstack/src/main/perl/OpenStack/Service.pm
+++ b/ncm-openstack/src/main/perl/OpenStack/Service.pm
@@ -266,7 +266,7 @@ sub _set_elpath
 =item _attrs
 
 Add/set/modify more attributes
-Convience method for inheritance
+Convenience method for inheritance
 instead of using SUPER
 
     my $res = $self->SUPER::method(@_);

--- a/ncm-openstack/src/main/perl/OpenStack/Service.pm
+++ b/ncm-openstack/src/main/perl/OpenStack/Service.pm
@@ -266,8 +266,9 @@ sub _set_elpath
 =item _attrs
 
 Add/set/modify more attributes
-Conviennce method for inheritance
+Convience method for inheritance
 instead of using SUPER
+
     my $res = $self->SUPER::method(@_);
 
 =cut


### PR DESCRIPTION
and also fix a small typo.
