### PR TITLE
ncm-systemd: documentation fix: make sure '>' is not interpreted.

### DIFF
--- a/ncm-systemd/src/main/perl/Systemd/Service/Chkconfig.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service/Chkconfig.pm
@@ -172,7 +172,7 @@ C<configured_units> parses the C<tree> hash reference and builds up the
 units to be configured. It returns a hash reference with key the unit name and
 values the details of the unit.
 
-(C<tree> is typically C<$config->getElement('/software/components/chkconfig/service')->getTree>.)
+(C<tree> is typically C<< $config->getElement('/software/components/chkconfig/service')->getTree >>.)
 
 This method converts the legacy states as following
 


### PR DESCRIPTION
```C<text->text>``` fails as the first `>` is interpreted as the end of the block. should be escaped as ```C<< text->text >>```.