### PR TITLE
ncm-metaconfig: zookeeper-server was renamed to zookeeper

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/config.pan
@@ -5,6 +5,6 @@ include 'metaconfig/zookeeper/schema';
 bind "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}/contents" = zookeeper_server_config;
 
 prefix "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}";
-"daemons/zookeeper-server" = "restart";
+"daemons/zookeeper" = "restart";
 "module" = "zookeeper/server";
 "mode" = 0644;

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/config.pan
@@ -2,9 +2,9 @@ unique template metaconfig/zookeeper/config;
 
 include 'metaconfig/zookeeper/schema';
 
-bind "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}/contents" = zookeeper_server_config;
+bind "/software/components/metaconfig/services/{/etc/zookeeper/zoo.cfg}/contents" = zookeeper_server_config;
 
-prefix "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}";
+prefix "/software/components/metaconfig/services/{/etc/zookeeper/zoo.cfg}";
 "daemons/zookeeper" = "restart";
 "module" = "zookeeper/server";
 "mode" = 0644;

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/profiles/server_config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/profiles/server_config.pan
@@ -2,7 +2,7 @@ object template server_config;
 
 include 'metaconfig/zookeeper/config';
 
-prefix "/software/components/metaconfig/services/{/etc/zookeeper/conf/zoo.cfg}/contents";
+prefix "/software/components/metaconfig/services/{/etc/zookeeper/zoo.cfg}/contents";
 "main/dataDir" = "/var/lib/zookeeper";
 "servers" =  list(
     dict("hostname", "host1.domain"),

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/base
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/base
@@ -1,7 +1,7 @@
 Base test for zookeeper main server config
 ---
 multiline
-metaconfigservice=/etc/zookeeper/conf/zoo.cfg
+metaconfigservice=/etc/zookeeper/zoo.cfg
 ---
 ^clientPort=\d+$
 ^dataDir=\S+$

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/values
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/values
@@ -1,7 +1,7 @@
 Values test for zookeeper main server config
 ---
 multiline
-metaconfigservice=/etc/zookeeper/conf/zoo.cfg
+metaconfigservice=/etc/zookeeper/zoo.cfg
 ---
 ^clientPort=2181$
 ^dataDir=/var/lib/zookeeper$


### PR DESCRIPTION
zookeeper-server was something from the old cloudera repo