### PR TITLE
ncm-opennebula: add virtio queues support

### DIFF
--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -210,6 +210,9 @@ type opennebula_vmtemplate = {
     "datastore" : opennebula_vmtemplate_datastore
     @{Set ignoremac tree to avoid to include MAC values within AR/VM templates}
     "ignoremac" ? opennebula_ignoremac
+    @{Set how many queues will be used for the communication between CPUs and virtio drivers.
+    see: https://docs.opennebula.org/5.6/deployment/open_cloud_host_setup/kvm_driver.html}
+    "virtio_queues" ? long(0..)
     @{Set graphics to export VM graphical display (VNC is used by default)}
     "graphics" : string = 'VNC' with match (SELF, '^(VNC|SDL|SPICE)$')
     @{Select the cache mechanism for your disks. (by default is set to none)}

--- a/ncm-opennebula/src/main/resources/network_level1.tt
+++ b/ncm-opennebula/src/main/resources/network_level1.tt
@@ -19,3 +19,6 @@ IP = "[% interfaces.${interface}.ip %]",
 [%     IF !ignoremac  -%]
 MAC = "[% hardware.cards.nic.${data.key}.hwaddr %]",
 [%     END -%]
+[%     IF system.opennebula.virtio_queues -%]
+VIRTIO_QUEUES = "[% system.opennebula.virtio_queues %]",
+[%     END -%]

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -145,6 +145,8 @@ prefix "/system/opennebula";
 
 "graphics" = "SPICE";
 
+"virtio_queues" = 4;
+
 "diskcache" = "default";
 
 "diskdriver" = "raw";

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
@@ -4,6 +4,7 @@ multiline
 ---
 ^NIC\s?=\s?\[$
 ^\s*IP\s?=\s*".+",\s*$
+^\s*VIRTIO_QUEUES\s?=\s*".+",\s*$
 ^\s*MODEL\s?=\s*".+",\s*$
 ^\s*NETWORK\s?=\s*".+",\s*$
 ^\s*NETWORK_UNAME\s?=\s*".+"\s*$

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -803,24 +803,28 @@ $data = <<'EOF';
 
 NIC = [
     IP = "10.141.8.30",
+    VIRTIO_QUEUES = "4",
     MODEL = "virtio",
     NETWORK = "altaria.os",
     NETWORK_UNAME = "oneadmin"
 ]
 NIC = [
     IP = "172.24.8.30",
+    VIRTIO_QUEUES = "4",
     MODEL = "virtio",
     NETWORK = "altaria.vsc",
     NETWORK_UNAME = "oneadmin"
 ]
 NIC = [
     IP = "172.24.8.31",
+    VIRTIO_QUEUES = "4",
     MODEL = "virtio",
     NETWORK = "altaria.vsc",
     NETWORK_UNAME = "oneadmin"
 ]
 NIC = [
     IP = "172.24.8.32",
+    VIRTIO_QUEUES = "4",
     MODEL = "virtio",
     NETWORK = "altaria.vsc",
     NETWORK_UNAME = "oneadmin"

--- a/ncm-opennebula/src/test/resources/vm.pan
+++ b/ncm-opennebula/src/test/resources/vm.pan
@@ -125,6 +125,8 @@ prefix "/system/opennebula";
 
 "graphics" = "SPICE";
 
+"virtio_queues" = 4;
+
 "diskcache" = "default";
 
 "diskdriver" = "raw";


### PR DESCRIPTION
Include virtio network queues support in libvirt

Fix: #1371 
See also: https://docs.opennebula.org/5.6/deployment/open_cloud_host_setup/kvm_driver.html
