### PR TITLE
ncm-systemd: Perform actions one unit at a time

### DIFF
--- a/ncm-systemd/src/main/perl/Systemd/Service.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service.pm
@@ -613,8 +613,6 @@ sub change
 
         # TODO: process units wrt dependencies?
         if (@units) {
-            # TODO: trap exitcode and stop any further processing in case of error?
-            # CAF::Process logger is sufficient
             systemctl_command_units($self, $change_state->{$state}, @units);
         }
     }
@@ -632,8 +630,6 @@ sub change
 
             # TODO: process units wrt dependencies?
             if (@units) {
-                # TODO: trap exitcode and stop any further processing in case of error?
-                # CAF::Process logger is sufficient
                 systemctl_command_units($self, $change_activation->{$act}, @units);
             }
         }

--- a/ncm-systemd/src/test/perl/service.t
+++ b/ncm-systemd/src/test/perl/service.t
@@ -436,11 +436,15 @@ is($cmp->{ERROR}, 0, "No error logged while applying the changes");
 ok(command_history_ok([
     # 1st states, unmask first
     "$SYSTEMCTL unmask -- cups.service",
-    "$SYSTEMCTL disable -- cups.service missing_disabled.service",
-    "$SYSTEMCTL enable -- netconsole.service rbdmap.service",
+    "$SYSTEMCTL disable -- cups.service",
+    "$SYSTEMCTL disable -- missing_disabled.service",
+    "$SYSTEMCTL enable -- netconsole.service",
+    "$SYSTEMCTL enable -- rbdmap.service",
     # 2 activity
     "$SYSTEMCTL stop -- missing_disabled.service",
-    "$SYSTEMCTL start -- netconsole.service network.service rbdmap.service",
+    "$SYSTEMCTL start -- netconsole.service",
+    "$SYSTEMCTL start -- network.service",
+    "$SYSTEMCTL start -- rbdmap.service",
 ]), "expected commands for change");
 
 =pod
@@ -462,8 +466,10 @@ is($cmp->{ERROR}, 0, "No error logged while applying the changes during shutdown
 ok(command_history_ok([
     # 1st states, unmask first
     "$SYSTEMCTL unmask -- cups.service",
-    "$SYSTEMCTL disable -- cups.service missing_disabled.service",
-    "$SYSTEMCTL enable -- netconsole.service rbdmap.service",
+    "$SYSTEMCTL disable -- cups.service",
+    "$SYSTEMCTL disable -- missing_disabled.service",
+    "$SYSTEMCTL enable -- netconsole.service",
+    "$SYSTEMCTL enable -- rbdmap.service",
     # 2 activity
 ], [
     "systemctl stop",
@@ -489,11 +495,15 @@ is($cmp->{ERROR}, 4, "4 errors logged while configuring (1 due to configured ali
 ok(command_history_ok([
     # 1st states
     "$SYSTEMCTL unmask -- cups.service",
-    "$SYSTEMCTL disable -- cups.service missing_disabled.service",
-    "$SYSTEMCTL enable -- netconsole.service rbdmap.service",
+    "$SYSTEMCTL disable -- cups.service",
+    "$SYSTEMCTL disable -- missing_disabled.service",
+    "$SYSTEMCTL enable -- netconsole.service",
+    "$SYSTEMCTL enable -- rbdmap.service",
     # 2 activity
     "$SYSTEMCTL stop -- missing_disabled.service",
-    "$SYSTEMCTL start -- netconsole.service network.service rbdmap.service",
+    "$SYSTEMCTL start -- netconsole.service",
+    "$SYSTEMCTL start -- network.service",
+    "$SYSTEMCTL start -- rbdmap.service",
 ]), "expected commands for change");
 
 

--- a/ncm-systemd/src/test/perl/systemctl.t
+++ b/ncm-systemd/src/test/perl/systemctl.t
@@ -240,28 +240,32 @@ Test systemctl_command_units
 
 =cut
 
-my $cmd = "$SYSTEMCTL fake-command -- unit1.type unit2.type";
+my $cmd1 = "$SYSTEMCTL fake-command -- unit1.type";
+my $cmd2 = "$SYSTEMCTL fake-command -- unit2.type";
 my $out = "testok";
-set_command_status($cmd, 0);
-set_desired_output($cmd, $out);
+set_command_status($cmd1, 0);
+set_desired_output($cmd1, $out);
+set_command_status($cmd2, 0);
+set_desired_output($cmd2, $out);
 
 $cmp->{ERROR}= 0;
-my ($ec, $output) = systemctl_command_units($cmp, 'fake-command', 'unit1.type', 'unit2.type');
+my ($success, $failure) = systemctl_command_units($cmp, 'fake-command', 'unit1.type', 'unit2.type');
 
-is($cmp->{ERROR}, 0, "No errors logged during systemctl_command_units $cmd");
-is($ec, 0, "systemctl_command_units finished with exitcode $ec");
-is($output, $out, "systemctl_command_units finished with output $out");
+is($cmp->{ERROR}, 0, "No errors logged during systemctl_command_units");
+is($success, 2, "systemctl_command_units: $success commands succeeded instead of 2");
+is($failure, 0, "systemctl_command_units: $failure commands failed instead of 0");
 
-$cmd .= " unit3.type";
+my $cmd3 = "$SYSTEMCTL fake-command -- unit3.type";
 $out = "FAIL";
-set_command_status($cmd, 5);
-set_desired_output($cmd, $out);
+set_desired_output($cmd2, $out);
+set_command_status($cmd3, 5);
+set_desired_output($cmd3, $out);
 
-($ec, $output) = systemctl_command_units($cmp, 'fake-command', 'unit1.type', 'unit2.type', 'unit3.type');
+($success, $failure) = systemctl_command_units($cmp, 'fake-command', 'unit1.type', 'unit3.type', 'unit2.type');
 
-is($cmp->{ERROR}, 1, "1 error logged during systemctl_command_units $cmd");
-is($ec, 5, "systemctl_command_units finished with exitcode $ec");
-is($output, $out, "systemctl_command_units finished with output $out");
+is($cmp->{ERROR}, 1, "1 errors logged during systemctl_command_units");
+is($success, 2, "systemctl_command_units: $success commands succeeded instead of 2");
+is($failure, 1, "systemctl_command_units: $failure commands failed instead of 1");
 
 =pod
 
@@ -271,7 +275,7 @@ Test systemctl_is_enabled
 
 =cut
 
-$cmd = "$SYSTEMCTL is-enabled -- unit1.type";
+my $cmd = "$SYSTEMCTL is-enabled -- unit1.type";
 $out = "isenabled";
 my $err = "some err data";
 set_command_status($cmd, 0);


### PR DESCRIPTION
If performing an action fails for one unit (e.g., because one tries to
enable a service which is not installed), then systemctl usually returns
a non-descriptive error like "No such file or directory", without any
indications for which unit caused the failure. What's worse, the rest of
the units will not be acted on either, often resulting in much more
breakage than the problematic unit would warrant.

To avoid this, perform actions one unit at a time.
