### PR TITLE
ncm-opennebula: fix add several ip/ars to same vnet

### DIFF
--- a/ncm-opennebula/src/main/perl/OpenNebula/Network.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Network.pm
@@ -49,15 +49,17 @@ sub get_vnetars
     my ($self, $config) = @_;
     my $all_ars = $self->process_template_aii($config, "network_ar");
     my %res;
+    my $vnetid = 0;
 
     my @tmp = split(qr{^NETWORK\s+=\s+(?:"|')(\S+)(?:"|')\s*$}m, $all_ars);
 
     while (my ($ar, $network) = splice(@tmp, 0, 2)) {
         if ($network && $ar) {
             $self->verbose("Detected network AR: $ar within network $network");
-            $res{$network}{ar} = $ar;
-            $res{$network}{network} = $network;
+            $res{$vnetid}{ar} = $ar;
+            $res{$vnetid}{network} = $network;
             $self->debug(3, "This is the network AR template for $network: $ar");
+            $vnetid = $vnetid + 1;
         } else {
             # No ARs found for this VM
             $self->error("No network ARs $ar and/or network info $network.");
@@ -76,8 +78,9 @@ sub remove_and_create_vn_ars
 {
     my ($self, $one, $arsref, $remove) = @_;
 
-    foreach my $vnet (sort keys %$arsref) {
-        my $ardata = $arsref->{$vnet};
+    foreach my $vnetid (sort keys %$arsref) {
+        my $ardata = $arsref->{$vnetid};
+        my $vnet = $ardata->{network};
         $self->debug(2, "Testing vnet network AR: $vnet");
 
         my %ar_opts = ('template' => $ardata->{ar});

--- a/ncm-opennebula/src/test/perl/aii_network_ar.t
+++ b/ncm-opennebula/src/test/perl/aii_network_ar.t
@@ -29,11 +29,13 @@ my %networks = $aii->get_vnetars($cfg);
 my $networka = "altaria.os";
 my $networkb = "altaria.vsc";
 
-ok(exists($networks{$networka}), "vnet a exists");
-ok(exists($networks{$networkb}), "vnet b exists");
+# Check all the new ARs per network
+for (my $arid=0; $arid <=3; $arid++) {
+    ok(exists($networks{$arid}{network}), "vnet AR id $arid exists in $networks{$arid}{network}");
+};
 
-is($networks{$networka}{network}, "altaria.os", "vneta name is altaria.os");
-is($networks{$networkb}{network}, "altaria.vsc", "vnetb name is altaria.vsc");
+is($networks{0}{network}, "altaria.os", "vneta name is altaria.os");
+is($networks{1}{network}, "altaria.vsc", "vnetb name is altaria.vsc");
 
 my $one = $aii->read_one_aii_conf();
 


### PR DESCRIPTION
This is a bit silly issue (not sure why we didn't find this issue before...) 
It was not possible to add several ARs or IPs to the same virtual network from the AII when the VM is instantiated. This should fix that problem.
