### PR TITLE
ncm-freeipa: only request new certificate when local one is expired/will expire soon

### DIFF
--- a/ncm-freeipa/src/main/perl/FreeIPA/Cert.pm
+++ b/ncm-freeipa/src/main/perl/FreeIPA/Cert.pm
@@ -56,7 +56,8 @@ sub get_cert
 {
     my ($self, $serial, $crt) = @_;
 
-    my $cert = $self->do_one('cert', 'show', $serial);
+    $serial = hex($serial) if $serial =~ m/^0?x/;
+    my $cert = $self->do_one('cert', 'show', $serial, all => 1);
 
     if ($crt && $cert) {
         # Extract the cert request

--- a/ncm-freeipa/src/main/perl/FreeIPA/Client.pm
+++ b/ncm-freeipa/src/main/perl/FreeIPA/Client.pm
@@ -8,7 +8,7 @@ use parent qw(Net::FreeIPA
               NCM::Component::FreeIPA::Cert
               NCM::Component::FreeIPA::Service);
 
-use Net::FreeIPA 3.0.2;
+use Net::FreeIPA 3.0.3;
 
 use NCM::Component::FreeIPA::Logger;
 

--- a/ncm-freeipa/src/test/perl/freeipa-nss.t
+++ b/ncm-freeipa/src/test/perl/freeipa-nss.t
@@ -128,7 +128,7 @@ set_file_contents('path/to/csr',
 
 ok($n->ipa_request_cert("path/to/csr", "path/to/crt", "g.h.i.j", $ipa), "ipa_request_cert ok");
 ok(POST_history_ok(['cert_request -----BEGIN CERTIFICATE REQUEST-----\nCSRDATA\n-----END CERTIFICATE REQUEST----- principal=host/g.h.i.j@REALM.DOMAIN,vers',
-                   "cert_show 1234 vers"]),
+                   "cert_show 1234 all=1,vers"]),
    "ipa_request_cert IPA POST ok");
 
 =head2 get_priv_keys

--- a/ncm-freeipa/src/test/perl/ipa-cert.t
+++ b/ncm-freeipa/src/test/perl/ipa-cert.t
@@ -50,7 +50,7 @@ ok(POST_history_ok(['cert_request -----BEGIN NEW CERTIFICATE REQUEST-----\nCSRRE
 reset_POST_history;
 is_deeply($c->get_cert(123, '/path/to/cert.crt'),
           {certificate => 'CERTDATA'}, "Get certificate");
-ok(POST_history_ok(['cert_show 123 version']),
+ok(POST_history_ok(['cert_show 123 all=1,version']),
    "get_cert is certificate show made");
 
 my $fh = get_file('/path/to/cert.crt');

--- a/ncm-freeipa/src/test/perl/rpc_data/cert
+++ b/ncm-freeipa/src/test/perl/rpc_data/cert
@@ -1,4 +1,4 @@
 $cmds{request}{cmd}='cert_request -----BEGIN NEW CERTIFICATE REQUEST-----\nCSRREQUEST\n-----END CERTIFICATE REQUEST----- principal=host/myhost.mydomain@EXAMPLE.COM,version.*';
 $cmds{request}{result}={okunittest => 1};
-$cmds{show}{cmd}='cert_show 123 version.*';
+$cmds{show}{cmd}='cert_show 123 all=1,version.*';
 $cmds{show}{result}={certificate => 'CERTDATA'};

--- a/ncm-freeipa/src/test/perl/rpc_data/client
+++ b/ncm-freeipa/src/test/perl/rpc_data/client
@@ -1,6 +1,6 @@
 $cmds{request}{cmd}='cert_request -----BEGIN CERTIFICATE REQUEST-----\nCSRDATA\n-----END CERTIFICATE REQUEST----- principal=host/myhost.example.com@MY.REALM,version.*';
 $cmds{request}{result}={serial_number => 1234};
-$cmds{showcert}{cmd}='cert_show 1234 version.*';
+$cmds{showcert}{cmd}='cert_show 1234 all=1,version.*';
 $cmds{showcert}{result}={serial_number => 1234, certificate => 'CRTDATA'};
 $cmds{showserv1}{cmd}='service_show someservice1/myhost.example.com version.*';
 $cmds{showserv1}{result}={has_keytab => 1};

--- a/ncm-freeipa/src/test/perl/rpc_data/nss
+++ b/ncm-freeipa/src/test/perl/rpc_data/nss
@@ -1,4 +1,4 @@
 $cmds{request}{cmd}='cert_request -----BEGIN CERTIFICATE REQUEST-----\nCSRDATA\n-----END CERTIFICATE REQUEST----- principal=host/g.h.i.j@REALM.DOMAIN,version.*';
 $cmds{request}{result}={serial_number => 1234};
-$cmds{show}{cmd}='cert_show 1234 version.*';
+$cmds{show}{cmd}='cert_show 1234 all=1,version.*';
 $cmds{show}{result}={serial_number => 1234, certificate => 'CERTDATA'};


### PR DESCRIPTION
Fixes a bug where each component run requests a new certificate.
Adds local certificate expiration validation check to determine if a new certificate needs to be retrieved