### PR TITLE
metaconfig: Update xinetd schema to include "port"

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/xinetd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/pan/schema.pan
@@ -1,8 +1,10 @@
 declaration template metaconfig/xinetd/schema;
 
-type xinetd_options_type = string with match(SELF,"^(RPC|INTERNAL|TCPMUX|TCPMUXPLUS|UNLISTED)$");
+type xinetd_options_type = string with match(SELF, "^(RPC|INTERNAL|TCPMUX|TCPMUXPLUS|UNLISTED)$");
 
-type xinetd_options_flags = string with match(SELF,"^(INTERCEPT|NORETRY|IDONLY|NAMEINARGS|NODELAY|KEEPALIVE|NOLIBWRAP|SENSOR|IPv4|IPv6|LABELED|REUSE)$");
+type xinetd_options_flags = string with match(
+    SELF, "^(INTERCEPT|NORETRY|IDONLY|NAMEINARGS|NODELAY|KEEPALIVE|NOLIBWRAP|SENSOR|IPv4|IPv6|LABELED|REUSE)$"
+);
 
 type xinetd_options_ips = string; # TODO, write proper check for all possible combinations
 
@@ -18,10 +20,10 @@ type xinetd_options = {
     "cps" ? long[]
     "port" ? long(0..)
 
-    "socket_type" : string with match(SELF,'^(stream|dgram|raw|seqpacket)$')
+    "socket_type" : string with match(SELF, '^(stream|dgram|raw|seqpacket)$')
     "user" : string = 'root'
     "server" ? string
-    "protocol" ? string with match(SELF,'^(udp|tcp)$') # actually, anything in /etc/protocols
+    "protocol" ? string with match(SELF, '^(udp|tcp)$') # actually, anything in /etc/protocols
     "server_args" ? string
     "group" ? string
     "instances" ? string with match(SELF, '^(UNLIMITED|\d+)$')

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/pan/schema.pan
@@ -15,7 +15,8 @@ type xinetd_options = {
     "type" ? xinetd_options_type[]
     "flags" ? xinetd_options_flags[]
     "only_from" ? xinetd_options_ips[]
-    "cps" : long[] = list(100, 2)
+    "cps" ? long[]
+    "port" ? long(0..)
 
     "socket_type" : string with match(SELF,'^(stream|dgram|raw|seqpacket)$')
     "user" : string = 'root'
@@ -23,8 +24,8 @@ type xinetd_options = {
     "protocol" ? string with match(SELF,'^(udp|tcp)$') # actually, anything in /etc/protocols
     "server_args" ? string
     "group" ? string
-    "instances" ? long(0..) # if not defined, it's UNLIMITED
-    "per_source" : long = 11
+    "instances" ? string with match(SELF, '^(UNLIMITED|\d+)$')
+    "per_source" ? long
 };
 
 type xinetd_conf = {

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/rsync/base
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/rsync/base
@@ -5,9 +5,7 @@ metaconfigservice=/etc/xinetd.d/rsync
 ---
 ^service\srsync$
 ^\{$
-^\s{4}cps\s=\s100 2$
 ^\s{4}disable\s=\sno$
-^\s{4}per_source\s=\s11$
 ^\s{4}server\s=\s/usr/bin/rsync$
 ^\s{4}server_args\s=\s--daemon$
 ^\s{4}socket_type\s=\sstream$

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/tftp/base
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/tftp/base
@@ -5,10 +5,8 @@ metaconfigservice=/etc/xinetd.d/tftp
 ---
 ^service\stftp$
 ^\{$
-^\s{4}cps\s=\s100 2$
 ^\s{4}disable\s=\sno$
 ^\s{4}flags\s=\sIPv4$
-^\s{4}per_source\s=\s11$
 ^\s{4}protocol\s=\sudp$
 ^\s{4}server\s=\s/usr/sbin/in.tftpd$
 ^\s{4}socket_type\s=\sdgram$

--- a/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/time-stream/base
+++ b/ncm-metaconfig/src/main/metaconfig/xinetd/tests/regexps/time-stream/base
@@ -5,9 +5,7 @@ metaconfigservice=/etc/xinetd.d/time-stream
 ---
 ^service\stime$
 ^\{$
-^\s{4}cps\s=\s100 2$
 ^\s{4}disable\s=\sno$
-^\s{4}per_source\s=\s11$
 ^\s{4}socket_type\s=\sstream$
 ^\s{4}user\s=\sroot$
 ^\s{4}wait\s=\sno$


### PR DESCRIPTION
port is a valid xinetd option according to `xinetd.conf(5)`.

Also remove default values for `cps` and `per_source`.