### PR TITLE
ncm-metaconfig: the content should not only be a dict

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -3,7 +3,7 @@ ${componentschema}
 include 'quattor/types/component';
 include 'quattor/functions/validation';
 
-type ${project.artifactId}_extension = extensible {};
+type ${project.artifactId}_extension = resource;
 
 @documentation{
     Convert value of certain types (e.g. boolean to string yes/no)


### PR DESCRIPTION
- When producing JSON, a list should also be accepted as
  valid. Before the change, only JSON objects could be
  used as content.
- This should remain fully backwards compatible