### PR TITLE
ncm-metaconfig: nginx add more ssl configuration options

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/nginx/nginx.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/nginx.tt
@@ -8,6 +8,9 @@ events {
     use epoll;
 }
 
+[% FOREACH header IN add_header %]
+add_header [% header %];
+[% END %]
 [% FOREACH h IN http %]
 http {
 [%      FILTER indent %]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/nginx.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/nginx.tt
@@ -7,7 +7,6 @@ events {
     worker_connections [% global.worker_connections %];
     use epoll;
 }
-
 [% FOREACH header IN add_header %]
 add_header [% header %];
 [% END %]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
@@ -19,6 +19,7 @@ type cipherstring = choice("TLSv1", "ECDHE-ECDSA-CHACHA20-POLY1305", "ECDHE-RSA-
     "AES256-GCM-SHA384", "AES128-SHA256", "AES256-SHA256", "AES128-SHA", "AES256-SHA", "DES-CBC3-SHA", "!RC4",
     "!LOW", "!aNULL", "!eNULL", "!MD5", "!EXP", "!3DES", "!IDEA", "!SEED", "!CAMELLIA", "!DSS");
 
+
 type basic_ssl = {
     "options" ? string[]
     "requiressl" ? boolean
@@ -34,7 +35,7 @@ type httpd_ssl = {
     "active" : boolean = true
     "ciphersuite" : cipherstring[] = list("TLSv1")
     "protocol" : sslprotocol[] = list("TLSv1", "TLSv1.1", "TLSv1.2")
-    "prefer_server_ciphers" ? choice("on", "off")
+    "prefer_server_ciphers" ? boolean
     "certificate" : string
     "key" : string
     @{ca sets ssl_client_certificate which specifies a file with trusted
@@ -43,10 +44,10 @@ type httpd_ssl = {
     "ca" ? string
     "certificate_chain_file" ? string
     "revocation_file" ? string
-    "stapling" ? choice("on", "off")
-    "stapling_verify" ? choice("on", "off")
+    "stapling" ? boolean
+    "stapling_verify" ? boolean
     "trusted_certificate" ? string
-    "session_tickets" ? choice("on", "off")
+    "session_tickets" ? boolean
     "session_timeout" ? string
     "session_cache" ? string
 };
@@ -152,6 +153,7 @@ type nginx_listen = {
     "addr" ? nginx_addr
     "default" : boolean = false
     "ssl" : boolean = false
+    "http2" ? boolean = false
 };
 
 

--- a/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/pan/schema.pan
@@ -19,7 +19,6 @@ type cipherstring = choice("TLSv1", "ECDHE-ECDSA-CHACHA20-POLY1305", "ECDHE-RSA-
     "AES256-GCM-SHA384", "AES128-SHA256", "AES256-SHA256", "AES128-SHA", "AES256-SHA", "DES-CBC3-SHA", "!RC4",
     "!LOW", "!aNULL", "!eNULL", "!MD5", "!EXP", "!3DES", "!IDEA", "!SEED", "!CAMELLIA", "!DSS");
 
-
 type basic_ssl = {
     "options" ? string[]
     "requiressl" ? boolean
@@ -107,6 +106,8 @@ type nginx_proxy_location = {
     server does not transmit anything within this time,
     the connection is closed}
     "read_timeout" ? long(0..)
+    "ssl_certificate" ? absolute_file_path
+    "ssl_certificate_key" ? absolute_file_path
 };
 
 

--- a/ncm-metaconfig/src/main/metaconfig/nginx/proxy.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/proxy.tt
@@ -18,3 +18,9 @@ proxy_http_version [% px.http_version %];
 [%- IF px.exists("read_timeout") %]
 proxy_read_timeout [% px.read_timeout %];
 [%- END -%]
+[%- IF px.exists("ssl_certificate") %]
+proxy_ssl_certificate [% px.ssl_certificate %];
+[%- END -%]
+[%- IF px.exists("ssl_certificate_key") %]
+proxy_ssl_certificate_key [% px.ssl_certificate_key %];
+[%- END -%]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/server.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/server.tt
@@ -1,5 +1,6 @@
 listen [% srv.listen.addr %][% " default" IF srv.listen.default -%]
- [% "ssl" IF srv.listen.ssl %];
+ [% "ssl" IF srv.listen.ssl -%]
+ [% "http2" IF srv.listen.http2 %];
 [% FOREACH i IN srv.includes %]
 include [% i %];
 [% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/server.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/server.tt
@@ -4,6 +4,9 @@ listen [% srv.listen.addr %][% " default" IF srv.listen.default -%]
 include [% i %];
 [% END -%]
 server_name [% srv.name.join(" ") %];
+[% FOREACH header IN srv.add_header %]
+add_header [% header %];
+[% END %]
 [% FOREACH e IN srv.error_page -%]
 error_page [% e.error_codes.join(" ") %] [% e.file %];
 [% END -%]

--- a/ncm-metaconfig/src/main/metaconfig/nginx/ssl.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/ssl.tt
@@ -20,21 +20,20 @@ ssl_ciphers [% ssl.ciphersuite.join(":") %];
 ssl_session_timeout [% ssl.session_timeout %];
 [%  END -%]
 [% IF ssl.session_tickets.defined -%]
-ssl_session_tickets [% ssl.session_tickets %];
+ssl_session_tickets [% ssl.session_tickets ? "on" : "off" %];
 [%  END -%]
 [% IF ssl.session_cache.defined -%]
 ssl_session_cache [% ssl.session_cache %];
 [%  END -%]
 [% IF ssl.prefer_server_ciphers.defined -%]
-ssl_prefer_server_ciphers [% ssl.prefer_server_ciphers %];
+ssl_prefer_server_ciphers [% ssl.prefer_server_ciphers ? "on" : "off" %];
 [%  END -%]
 [% IF ssl.stapling.defined -%]
-ssl_stapling [% ssl.stapling %];
+ssl_stapling [% ssl.stapling ? "on" : "off" %];
 [%  END -%]
 [% IF ssl.stapling_verify.defined -%]
-ssl_stapling_verify [% ssl.stapling_verify %];
+ssl_stapling_verify [% ssl.stapling_verify ? "on" : "off" %];
 [%  END -%]
 [% IF ssl.trusted_certificate.defined -%]
 ssl_trusted_certificate [% ssl.trusted_certificate %];
 [%  END -%]
-

--- a/ncm-metaconfig/src/main/metaconfig/nginx/ssl.tt
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/ssl.tt
@@ -16,3 +16,25 @@ ssl_client_certificate [% ssl.ca %];
 ssl_certificate_key [% ssl.key %];
 # Watch out!! This list is separated by colons!!
 ssl_ciphers [% ssl.ciphersuite.join(":") %];
+[% IF ssl.session_timeout.defined -%]
+ssl_session_timeout [% ssl.session_timeout %];
+[%  END -%]
+[% IF ssl.session_tickets.defined -%]
+ssl_session_tickets [% ssl.session_tickets %];
+[%  END -%]
+[% IF ssl.session_cache.defined -%]
+ssl_session_cache [% ssl.session_cache %];
+[%  END -%]
+[% IF ssl.prefer_server_ciphers.defined -%]
+ssl_prefer_server_ciphers [% ssl.prefer_server_ciphers %];
+[%  END -%]
+[% IF ssl.stapling.defined -%]
+ssl_stapling [% ssl.stapling %];
+[%  END -%]
+[% IF ssl.stapling_verify.defined -%]
+ssl_stapling_verify [% ssl.stapling_verify %];
+[%  END -%]
+[% IF ssl.trusted_certificate.defined -%]
+ssl_trusted_certificate [% ssl.trusted_certificate %];
+[%  END -%]
+

--- a/ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/basic_ssl.pan
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/tests/profiles/basic_ssl.pan
@@ -6,3 +6,4 @@ structure template basic_ssl;
 "certificate" = "/etc/mycert";
 "key" = "/etc/mykey";
 "ca" = "/etc/myca";
+"prefer_server_ciphers" = true;

--- a/ncm-metaconfig/src/main/metaconfig/nginx/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/nginx/tests/regexps/config/base
@@ -18,7 +18,7 @@ multiline
 ^\s{20}'\$status \$body_bytes_sent "\$http_referer" '$
 ^\s{20}'"\$http_user_agent" "\$http_x_forwarded_for"';$
 ^\s{4}access_log /var/log/nginx/access.log main;$
-^\s{4}gzip on;$
+^\s{4}gzip off;$
 ^\s{4}keepalive_timeout 65;$
 ^\s{4}sendfile on;$
 ^\s{4}upstream restricted-packages \{$
@@ -27,12 +27,12 @@ multiline
 ^\s{4}upstream secure \{$
 ^\s{8}server myserver.my.domain:446;$
 ^\s{4}server \{$ ### COUNT 3
-^\s{8}listen myhost.my.domain:8443 ssl;$
-^\s{8}listen myhost.my.domain:443 ssl;$
+^\s{8}listen myhost.my.domain:8443 ssl\s;$
+^\s{8}listen myhost.my.domain:443 ssl\s;$
 ^\s{8}server_name myhost.my.domain;$
 ^\s{8}ssl_verify_client off;$
 ^\s{8}# Watch out!! This list is separated by whitespace!!$
-^\s{8}ssl_protocols TLSv1;$
+^\s{8}ssl_protocols TLSv1 TLSv1.1 TLSv1.2;$
 ^\s{8}ssl_certificate /etc/mycert;$
 ^\s{8}ssl_client_certificate /etc/myca;$
 ^\s{8}ssl_certificate_key /etc/mykey;$
@@ -56,6 +56,6 @@ multiline
 ^\s{8}location  / \{$
 ^\s{8}location = / \{$
 ^\s{12}return 301 https://\$host/default;$
-^\s{8}listen 80 default ;$
+^\s{8}listen 80 default\s{2};$
 ^\s{8}server_name _;$
 ^\s{8}return 301 https://\$host\$request_uri;$


### PR DESCRIPTION
- added a bunch of settings to be able to better configure SSL on nginx.
- changed the ciphersuite options so it is possible to follow https://mozilla.github.io/server-side-tls/ssl-config-generator/
- changed the default of gzip to false. As I understand it, if misconfigured it leaves you open to BREACH.