### PR TITLE
ncm-opennebula: include OpenNebula 5.8.x and vmgroups support

### DIFF
--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -436,6 +436,34 @@ type opennebula_cluster = {
     "reserved_mem" ? long
 } = dict();
 
+@documentation{
+type for vmgroup roles specific attributes.
+}
+type opennebula_vmgroup_role = {
+    @{The name of the role, it needs to be unique within the VM Group}
+    "name" : string
+    @{Placement policy for the VMs of the role}
+    "policy" ? choice('AFFINED', 'ANTI_AFFINED')
+    @{Defines a set of hosts (by their ID) where the VMs of the role can be executed}
+    "host_affined" ? string[]
+    @{Defines a set of hosts (by their ID) where the VMs of the role cannot be executed}
+    "host_anti_affined" ? string[]
+};
+
+
+@documentation{
+Set OpenNebula vmgroups and their porperties.
+}
+type opennebula_vmgroup = {
+    include opennebula_group
+    "role" ? opennebula_vmgroup_role[]
+    @{List of roles whose VMs has to be placed in the same host}
+    "affined" ? string[]
+    @{List of roles whose VMs cannot be placed in the same host}
+    "anti_affined" ? string[]
+} = dict();
+
+
 type opennebula_remoteconf_ceph = {
     "pool_name" : string
     "host" : string
@@ -775,6 +803,7 @@ type opennebula_untouchables = {
     "groups" ? string[]
     "hosts" ? string[]
     "clusters" ? string[]
+    "vmgroups" ? string[]
 };
 
 
@@ -789,6 +818,7 @@ type component_opennebula = {
     'users' ? opennebula_user{}
     'vnets' ? opennebula_vnet{}
     'clusters' ? opennebula_cluster{}
+    'vmgroups' ? opennebula_vmgroup{}
     'hosts' ? opennebula_host{}
     'rpc' ? opennebula_rpc
     'untouchables' ? opennebula_untouchables

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -544,7 +544,7 @@ type opennebula_oned = {
         dict("name", "vmfs"),
         dict(
             "name", "ceph",
-            "clone_target","SELF",
+            "clone_target", "SELF",
             "ds_migrate", false,
             "driver", "raw",
             "allow_orphans", "mixed",

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -185,6 +185,34 @@ type opennebula_vmtemplate_pci = {
 };
 
 @documentation{
+Type that sets VM Groups and Roles for a specifc VM.
+VMGroups are placed by dynamically generating the requirement (SCHED_REQUIREMENTS)
+of each VM an re-evaluating these expressions.
+
+Moreover, the following is also considered:
+
+The scheduler will look for a host with enough capacity for an affined set of VMs.
+If there is no such host all the affined VMs will remain pending.
+
+If new VMs are added to an affined role, it will pick one of the hosts where the VMs
+are running. By default, all should be running in the same host but if you manually
+migrate a VM to another host it will be considered feasible for the role.
+
+The scheduler does not have any synchronization point with the state of the VM group,
+it will start scheduling pending VMs as soon as they show up.
+
+Re-scheduling of VMs works as for any other VM, it will look for a different host
+considering the placement constraints.
+
+For more info:
+https://docs.opennebula.org/5.8/advanced_components/application_flow_and_auto-scaling/vmgroups.html
+}
+type opennebula_vmtemplate_vmgroup = {
+    "vmgroup_name" : string
+    "role" : string
+};
+
+@documentation{
 Type that sets placement constraints and preferences for the VM, valid for all hosts
 More info: http://docs.opennebula.org/5.0/operation/references/template.html#placement-section
 }
@@ -246,4 +274,11 @@ type opennebula_vmtemplate = {
     from the guest when its running out of memory, which means a malicious guest allocating
     large amounts of locked memory could cause a denial-of-service attach on the host.}
     "memorybacking" ? string[] with is_consistent_memorybacking(SELF)
+    @{Request existing VM Group and roles.
+    A VM Group defines a set of related VMs, and associated placement constraints for the VMs
+    in the group. A VM Group allows you to place together (or separately) ceartain VMs
+    (or VM classes, roles). VMGroups will help you to optimize the performance
+    (e.g. not placing all the cpu bound VMs in the same host) or improve the fault tolerance
+    (e.g. not placing all your front-ends in the same host) of your multi-VM applications.}
+    "vmgroup" ? opennebula_vmtemplate_vmgroup[]
 } = dict();

--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -262,6 +262,9 @@ sub set_one_server
     # Create/update the virtual clusters before any resource first
     $self->manage_something($one, "cluster", $tree->{clusters}, $untouchables->{clusters});
 
+    # Add VM groups and roles
+    #$self->manage_something($one, "vmgroup", $tree->{vmgroups}, $untouchables->{vmgroups});
+
     $self->manage_something($one, "vnet", $tree->{vnets}, $untouchables->{vnets});
 
     # For the moment only Ceph and shared datastores are configured

--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -263,7 +263,7 @@ sub set_one_server
     $self->manage_something($one, "cluster", $tree->{clusters}, $untouchables->{clusters});
 
     # Add VM groups and roles
-    #$self->manage_something($one, "vmgroup", $tree->{vmgroups}, $untouchables->{vmgroups});
+    $self->manage_something($one, "vmgroup", $tree->{vmgroups}, $untouchables->{vmgroups});
 
     $self->manage_something($one, "vnet", $tree->{vnets}, $untouchables->{vnets});
 

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -124,7 +124,7 @@ use CAF::FileReader;
 use CAF::Service;
 use Set::Scalar;
 use Config::Tiny;
-use Net::OpenNebula 0.315.0;
+use Net::OpenNebula 0.316.0;
 use Data::Dumper;
 use Readonly;
 use 5.10.1;

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -40,6 +40,8 @@ Features that are implemented at this moment:
 
 =item * Adding/removing OpenNebula virtual clusters
 
+=item * Adding/removing OpenNebula VM groups and roles
+
 =item * Assign OpenNebula resources to virtual clusters
 
 =item * Assign OpenNebula users to primary groups
@@ -122,7 +124,7 @@ use CAF::FileReader;
 use CAF::Service;
 use Set::Scalar;
 use Config::Tiny;
-use Net::OpenNebula 0.314.0;
+use Net::OpenNebula 0.315.0;
 use Data::Dumper;
 use Readonly;
 use 5.10.1;

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -122,7 +122,7 @@ use CAF::FileReader;
 use CAF::Service;
 use Set::Scalar;
 use Config::Tiny;
-use Net::OpenNebula 0.313.0;
+use Net::OpenNebula 0.314.0;
 use Data::Dumper;
 use Readonly;
 use 5.10.1;

--- a/ncm-opennebula/src/main/resources/oned_level1.tt
+++ b/ncm-opennebula/src/main/resources/oned_level1.tt
@@ -1,6 +1,6 @@
 [%- digits = ['port', 'debug_level', 'zone_id', 'cpu_cost', 'memory_cost', 'disk_cost', 'start'] -%]
 [%- booleans = ['shared', 'persistent_only', 'keep_snapshots', 'ds_migrate', 'public'] -%]
-[%- comma_list_attrs = ['imported_vms_actions', 'required_attrs', 'app_actions'] -%]
+[%- comma_list_attrs = ['imported_vms_actions', 'required_attrs', 'app_actions', 'host_affined', 'host_anti_affined'] -%]
 [
 [% FILTER indent -%]
 [%     IF name.defined -%]

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -186,3 +186,7 @@ prefix "/system/opennebula";
     "hugepages",
 );
 
+"vmgroup" = append(dict(
+    "vmgroup_name", "ha_group",
+    "role", "backup"
+));

--- a/ncm-opennebula/src/main/resources/tests/profiles/vmgroup.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vmgroup.pan
@@ -1,0 +1,25 @@
+object template vmgroup;
+
+include 'components/opennebula/schema';
+
+bind "/metaconfig/contents/vmgroup/ha_group" = opennebula_vmgroup;
+
+"/metaconfig/module" = "vmgroup";
+
+prefix "/metaconfig/contents/vmgroup/ha_group";
+"anti_affined" = list('workers', 'backups');
+"affined" = list('db', 'apps');
+"role" = list(
+    dict(
+        "name", "backup",
+        "host_anti_affined", list('1', '2', '3'),
+        "policy", "ANTI_AFFINED",
+    ),
+    dict(
+        "name", "apps",
+        "host_affined", list('4', '5', '6'),
+        "policy", "AFFINED",
+    ),
+);
+"labels" = list("quattor", "quattor/ha_group");
+"description" = "New HA VM group managed by quattor";

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
@@ -38,6 +38,9 @@ multiline
 ^\s*CLASS\s?=\s*".+",\s*$
 ^\s*DEVICE\s?=\s*".+",\s*$
 ^\s*VENDOR\s?=\s*".+"\s*$
+^VMGROUP\s?=\s?\[$
+^\s*role\s?=\s*".+",\s*$
+^\s*vmgroup_name\s?=\s*".+"\s*$
 ^LABELS\s?=\s*".+"$
 ^SCHED_DS_RANK\s?=\s?".+"\s*$
 ^SCHED_DS_REQUIREMENTS\s?=\s?".+"\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/oned/oned_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/oned/oned_template
@@ -8,7 +8,7 @@ multiline
 ^\]$
 ^DATASTORE_CAPACITY_CHECK\s?=\s?"yes"$
 ^DATASTORE_MAD\s?=\s?\[$
-^\s{4}arguments\s?=\s?"-t 15 -d dummy,fs,vmfs,lvm,ceph",$
+^\s{4}arguments\s?=\s?"-t 15 -d dummy,fs,lvm,dev,iscsi_libvirt,vcenter -s shared,ssh,ceph,fs_lvm,qcow2,vcenter",$
 ^\s{4}executable\s?=\s?"one_datastore"$
 ^\]$
 ^DB\s?=\s?\[$
@@ -161,10 +161,14 @@ multiline
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SYSTEM",$
+^\s{4}clone_target_ssh\s?=\s?"SYSTEM",$
+^\s{4}disk_type_ssh\s?=\s?"FILE",$
 ^\s{4}ds_migrate\s?=\s?"yes",$
 ^\s{4}ln_target\s?=\s?"NONE",$
+^\s{4}ln_target_ssh\s?=\s?"SYSTEM",$
 ^\s{4}name\s?=\s?"shared",$
-^\s{4}shared\s?=\s?"yes"$
+^\s{4}shared\s?=\s?"yes",$
+^\s{4}tm_mad_system\s?=\s?"ssh"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SYSTEM",$
@@ -174,6 +178,7 @@ multiline
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SYSTEM",$
+^\s{4}driver\s?=\s?"qcow2",$
 ^\s{4}ln_target\s?=\s?"NONE",$
 ^\s{4}name\s?=\s?"qcow2",$
 ^\s{4}shared\s?=\s?"yes"$
@@ -192,11 +197,20 @@ multiline
 ^\s{4}shared\s?=\s?"yes"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
+^\s{4}allow_orphans\s?=\s?"mixed",$
 ^\s{4}clone_target\s?=\s?"SELF",$
+^\s{4}clone_target_shared\s?=\s?"SELF",$
+^\s{4}clone_target_ssh\s?=\s?"SYSTEM",$
+^\s{4}disk_type_shared\s?=\s?"rbd",$
+^\s{4}disk_type_ssh\s?=\s?"FILE",$
+^\s{4}driver\s?=\s?"raw",$
 ^\s{4}ds_migrate\s?=\s?"no",$
 ^\s{4}ln_target\s?=\s?"NONE",$
+^\s{4}ln_target_shared\s?=\s?"NONE",$
+^\s{4}ln_target_ssh\s?=\s?"SYSTEM",$
 ^\s{4}name\s?=\s?"ceph",$
-^\s{4}shared\s?=\s?"yes"$
+^\s{4}shared\s?=\s?"yes",$
+^\s{4}tm_mad_system\s?=\s?"ssh,shared"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SELF",$
@@ -226,8 +240,8 @@ multiline
 ^\s{4}arguments\s?=\s?"-t 15 -r 0 kvm",$
 ^\s{4}default\s?=\s?"vmm_exec/vmm_exec_kvm.conf",$
 ^\s{4}executable\s?=\s?"one_vmm_exec",$
-^\s{4}imported_vms_actions\s?=\s?"terminate, terminate-hard, hold, release, suspend, resume, delete, reboot, reboot-hard, resched, unresched, disk-attach, disk-detach, nic-attach, nic-detach, snap-create, snap-delete",$
-^\s{4}keep_snapshots\s?=\s?"no",$
+^\s{4}imported_vms_actions\s?=\s?"terminate, terminate-hard, hold, release, suspend, resume, delete, reboot, reboot-hard, resched, unresched, disk-attach, disk-detach, nic-attach, nic-detach, snapshot-create, snapshot-delete",$
+^\s{4}keep_snapshots\s?=\s?"yes",$
 ^\s{4}sunstone_name\s?=\s?"KVM"$
 ^\]$
 ^VM_RESTRICTED_ATTR\s?=\s?"CONTEXT/FILES"$

--- a/ncm-opennebula/src/main/resources/tests/regexps/vmgroup/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/vmgroup/simple
@@ -1,0 +1,15 @@
+Opennebula vmgroup test
+---
+multiline
+---
+^NAME\s?=\s?".+"$
+^AFFINED\s?=\s?".+"$
+^ANTI_AFFINED\s?=\s?".+"$
+^DESCRIPTION\s?=\s?".+"$
+^LABELS\s?=\s?".+"$
+^ROLE\s?=\s?\[$
+^\s*host_anti_affined\s?=\s*".+",\s*$
+^\s*name\s?=\s*".+",\s*$
+^\s*policy\s?=\s*".+"\s*$
+^\]$
+^QUATTOR\s?=\s?\d+\s*$

--- a/ncm-opennebula/src/main/resources/vmgroup.tt
+++ b/ncm-opennebula/src/main/resources/vmgroup.tt
@@ -6,10 +6,10 @@ NAME = "[% vmgroup.key %]"
 [%            CASE booleans -%]
 [%                pair.key FILTER upper %] = "[% pair.value ? "YES" : "NO" %]"
 [%            CASE 'role' -%]
-[%     FOREACH item IN vmgroup.value.${pair.key} -%]
-[%                pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
-                                      data=item -%]
-[%     END -%]
+[%                FOREACH item IN vmgroup.value.${pair.key} -%]
+[%                    pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
+                          data=item -%]
+[%                END -%]
 [%            CASE role_list -%]
 [%                pair.key FILTER upper %] = "[% pair.value.join(',') %]"
 [%            CASE -%]

--- a/ncm-opennebula/src/main/resources/vmgroup.tt
+++ b/ncm-opennebula/src/main/resources/vmgroup.tt
@@ -1,0 +1,20 @@
+[%- role_list = ['affined', 'anti_affined', 'labels'] -%]
+[% FOR vmgroup IN vmgroup.pairs -%]
+NAME = "[% vmgroup.key %]"
+[%    FOR pair IN vmgroup.value.pairs %]
+[%-       SWITCH pair.key -%]
+[%            CASE booleans -%]
+[%                pair.key FILTER upper %] = "[% pair.value ? "YES" : "NO" %]"
+[%            CASE 'role' -%]
+[%     FOREACH item IN vmgroup.value.${pair.key} -%]
+[%                pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
+                                      data=item -%]
+[%     END -%]
+[%            CASE role_list -%]
+[%                pair.key FILTER upper %] = "[% pair.value.join(',') %]"
+[%            CASE -%]
+[%                pair.key FILTER upper %] = "[% pair.value %]"
+[%        END -%]
+[%-    END %]
+[%- END -%]
+QUATTOR = 1

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -81,6 +81,9 @@ PCI = [
 [%-         END %]
 [%-     END %]
 [%- END %]
+[%- FOREACH item IN system.opennebula.vmgroup %]
+VMGROUP = [% INCLUDE 'opennebula/oned_level1.tt' data=item -%]
+[%- END %]
 [%- IF system.opennebula.labels.defined %]
 LABELS = "[% system.opennebula.labels.join(',') %]"
 [%- END %]

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -997,3 +997,65 @@ $cmds{rpc_del_datastore_cluster}{out} = 1;
 $cmds{rpc_del_host_cluster}{params} = [0, 168];
 $cmds{rpc_del_host_cluster}{method} = "one.cluster.delhost";
 $cmds{rpc_del_host_cluster}{out} = 1;
+
+# Manage VM Groups
+
+$data = <<'EOF';
+NAME = "ha_group"
+AFFINED = "db,apps"
+ANTI_AFFINED = "workers,backups"
+DESCRIPTION = "New HA VM group managed by quattor"
+LABELS = "quattor,quattor/ha_group"
+ROLE = [
+    host_anti_affined = "1, 2, 3",
+    name = "backup",
+    policy = "ANTI_AFFINED"
+]
+ROLE = [
+    host_affined = "4, 5, 6",
+    name = "apps",
+    policy = "AFFINED"
+]
+QUATTOR = 1
+EOF
+$cmds{rpc_create_vmgroup}{params} = [$data];
+$cmds{rpc_create_vmgroup}{method} = "one.vmgroup.allocate";
+$cmds{rpc_create_vmgroup}{out} = 2;
+
+$cmds{rpc_delete_vmgroup}{params} = [1];
+$cmds{rpc_delete_vmgroup}{method} = "one.vmgroup.delete";
+$cmds{rpc_delete_vmgroup}{out} = 1;
+
+$cmds{rpc_list_vmgrouppool}{params} = [];
+$cmds{rpc_list_vmgrouppool}{method} = "one.vmgrouppool.info";
+$cmds{rpc_list_vmgrouppool}{out} = <<'EOF';
+<VM_GROUP_POOL><VM_GROUP><ID>1</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>muilt-tierapp</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>0</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><ROLES><ROLE><ID><![CDATA[0]]></ID><NAME><![CDATA[worker]]></NAME><POLICY><![CDATA[ANTI_AFFINED]]></POLICY></ROLE></ROLES><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR></TEMPLATE></VM_GROUP></VM_GROUP_POOL>
+EOF
+
+$cmds{rpc_list_vmgroup}{params} = [1];
+$cmds{rpc_list_vmgroup}{method} = "one.vmgroup.info";
+$cmds{rpc_list_vmgroup}{out} = <<'EOF';
+<VM_GROUP><ID>1</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>muilt-tierapp</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>0</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><ROLES><ROLE><ID><![CDATA[0]]></ID><NAME><![CDATA[worker]]></NAME><POLICY><![CDATA[ANTI_AFFINED]]></POLICY></ROLE></ROLES><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR></TEMPLATE></VM_GROUP>
+EOF
+
+$data = <<'EOF';
+NAME = "ha_group"
+AFFINED = "db,apps"
+ANTI_AFFINED = "workers,backups"
+DESCRIPTION = "New HA VM group managed by quattor"
+LABELS = "quattor,quattor/ha_group"
+ROLE = [
+    host_anti_affined = "1, 2, 3",
+    name = "backup",
+    policy = "ANTI_AFFINED"
+]
+ROLE = [
+    host_affined = "4, 5, 6",
+    name = "apps",
+    policy = "AFFINED"
+]
+QUATTOR = 1
+EOF
+$cmds{rpc_update_vmgroup}{params} = [2, $data, 1];
+$cmds{rpc_update_vmgroup}{method} = "one.vmgroup.update";
+$cmds{rpc_update_vmgroup}{out} = 2;

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -1026,7 +1026,7 @@ $cmds{rpc_delete_vmgroup}{params} = [1];
 $cmds{rpc_delete_vmgroup}{method} = "one.vmgroup.delete";
 $cmds{rpc_delete_vmgroup}{out} = 1;
 
-$cmds{rpc_list_vmgrouppool}{params} = [];
+$cmds{rpc_list_vmgrouppool}{params} = [-2, -1, -1];
 $cmds{rpc_list_vmgrouppool}{method} = "one.vmgrouppool.info";
 $cmds{rpc_list_vmgrouppool}{out} = <<'EOF';
 <VM_GROUP_POOL><VM_GROUP><ID>1</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>muilt-tierapp</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>0</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><ROLES><ROLE><ID><![CDATA[0]]></ID><NAME><![CDATA[worker]]></NAME><POLICY><![CDATA[ANTI_AFFINED]]></POLICY></ROLE></ROLES><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR></TEMPLATE></VM_GROUP></VM_GROUP_POOL>

--- a/ncm-opennebula/src/test/perl/vmgroup.t
+++ b/ncm-opennebula/src/test/perl/vmgroup.t
@@ -1,0 +1,33 @@
+# -* mode: cperl -*-
+use strict;
+use warnings;
+use Test::More;
+use Test::Quattor qw(vmgroup);
+use CAF::Object;
+
+use OpennebulaMock;
+use NCM::Component::opennebula;
+
+$CAF::Object::NoAction = 1;
+
+my $cmp = NCM::Component::opennebula->new("vmgroup");
+
+my $cfg = get_config_for_profile("vmgroup");
+my $tree = $cfg->getElement("/software/components/opennebula")->getTree();
+my $one = $cmp->make_one($tree->{rpc});
+
+# Test vmgroup
+ok(exists($tree->{vmgroups}), "Found vmgroup data");
+
+rpc_history_reset;
+$cmp->manage_something($one, "vmgroup", $tree->{vmgroups});
+#diag_rpc_history;
+ok(rpc_history_ok(["one.vmgrouppool.info",
+                   "one.vmgrouppool.info",
+                   "one.vmgroup.allocate",
+                   "one.vmgroup.info"]),
+                   "manage_something vmgroup rpc history ok");
+
+ok(!exists($cmp->{ERROR}), "No errors found during vmgroup management execution");
+
+done_testing();

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -57,6 +57,27 @@ prefix "/software/components/opennebula";
         ),
 );
 
+"vmgroups" = dict(
+    "ha_group", dict(
+        "anti_affined", list('workers', 'backups'),
+        "affined", list('db', 'apps'),
+        "role", list(
+            dict(
+                "name", "backup",
+                "host_anti_affined", list('1', '2', '3'),
+                "policy", "ANTI_AFFINED",
+            ),
+            dict(
+                "name", "apps",
+                "host_affined", list('4', '5', '6'),
+                "policy", "AFFINED",
+            ),
+        ),
+    "labels", list("quattor", "quattor/ha_group"),
+    "description", "New HA VM group managed by quattor",
+    ),
+);
+
 "vnets" = dict(
     "altaria.os", dict(
             "bridge", "br100",

--- a/ncm-opennebula/src/test/resources/vmgroup.pan
+++ b/ncm-opennebula/src/test/resources/vmgroup.pan
@@ -1,0 +1,3 @@
+object template vmgroup;
+
+include 'one';


### PR DESCRIPTION
Fix: #1350 

**NOTE:** Requires #1378 and requires #1371 which should be reviewed/merged first
**NOTE:** It requires the new  Net::OpenNebula 0.316.0 or newer to work.

This PR is backwards compatible with previous ONE versions.
More info about VM groups:
https://docs.opennebula.org/5.8/advanced_components/application_flow_and_auto-scaling/vmgroups.html