### PR TITLE
ncm-metaconfig generic templates

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/generic/multiline.tt
+++ b/ncm-metaconfig/src/main/metaconfig/generic/multiline.tt
@@ -1,0 +1,1 @@
+[%- CCM.contents.join("\n") %]

--- a/ncm-metaconfig/src/main/metaconfig/generic/pan/multiline.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/pan/multiline.pan
@@ -1,0 +1,6 @@
+structure template metaconfig/generic/multiline;
+
+"mode" = 0644;
+"owner" = "root";
+"group" = "root";
+"module" = "generic/multiline";

--- a/ncm-metaconfig/src/main/metaconfig/generic/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/pan/schema.pan
@@ -1,0 +1,5 @@
+declaration template metaconfig/generic/schema;
+
+@{for completeness, but no reason to use it}
+
+type metaconfig_generic_string = string;

--- a/ncm-metaconfig/src/main/metaconfig/generic/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/pan/schema.pan
@@ -1,5 +1,7 @@
 declaration template metaconfig/generic/schema;
 
-@{for completeness, but no reason to use it}
-
+@{for completeness, but no reason to use it. you can pass any scalar you want}
 type metaconfig_generic_string = string;
+
+@{for completeness, but no reason to use it. you can pass any list you}
+type metaconfig_generic_multiline = string[];

--- a/ncm-metaconfig/src/main/metaconfig/generic/pan/string.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/pan/string.pan
@@ -1,0 +1,6 @@
+structure template metaconfig/generic/string;
+
+"mode" = 0644;
+"owner" = "root";
+"group" = "root";
+"module" = "generic/string";

--- a/ncm-metaconfig/src/main/metaconfig/generic/string.tt
+++ b/ncm-metaconfig/src/main/metaconfig/generic/string.tt
@@ -1,0 +1,1 @@
+[%- CCM.contents -%]

--- a/ncm-metaconfig/src/main/metaconfig/generic/tests/profiles/multiline.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/tests/profiles/multiline.pan
@@ -1,0 +1,10 @@
+object template multiline;
+
+include 'metaconfig/generic/schema';
+
+# explicit bind with metaconfig_generic_multiline here so it is tested
+bind "/software/components/metaconfig/services/{/a/b/c}/contents" = metaconfig_generic_multiline;
+
+"/software/components/metaconfig/services/{/a/b/c}" = create('metaconfig/generic/multiline',
+    "contents", list("first", "second", "third"),
+    );

--- a/ncm-metaconfig/src/main/metaconfig/generic/tests/profiles/string.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/tests/profiles/string.pan
@@ -1,0 +1,10 @@
+object template string;
+
+include 'metaconfig/generic/schema';
+
+# explicit bind with metaconfig_generic_string here so it is tested
+bind "/software/components/metaconfig/services/{/a/b/c}/contents" = metaconfig_generic_string;
+
+"/software/components/metaconfig/services/{/a/b/c}" = create('metaconfig/generic/string',
+    "contents", "a very long string\nwith\nnarbitrarysomething\nno eol newline in value",
+    );

--- a/ncm-metaconfig/src/main/metaconfig/generic/tests/regexps/multiline
+++ b/ncm-metaconfig/src/main/metaconfig/generic/tests/regexps/multiline
@@ -1,0 +1,8 @@
+Test multiline string
+---
+/a/b/c
+quote
+---
+first
+second
+third

--- a/ncm-metaconfig/src/main/metaconfig/generic/tests/regexps/string
+++ b/ncm-metaconfig/src/main/metaconfig/generic/tests/regexps/string
@@ -1,0 +1,9 @@
+Test generic string (no EOL newline here!)
+---
+/a/b/c
+quote
+---
+a very long string
+with
+narbitrarysomething
+no eol newline in value

--- a/ncm-metaconfig/src/test/perl/service-generic.t
+++ b/ncm-metaconfig/src/test/perl/service-generic.t
@@ -1,0 +1,8 @@
+use Test::More;
+use Test::Quattor::TextRender::Metaconfig;
+
+my $u = Test::Quattor::TextRender::Metaconfig->new(
+        service => 'generic',
+        )->test();
+
+done_testing;


### PR DESCRIPTION
support writing simple string literal and multine text with metaconfig
Requires #1387