### PR TITLE
ncm-systemd: add extra unit options for sandboxing

### DIFF
--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -145,6 +145,10 @@ http://www.freedesktop.org/software/systemd/man/systemd.exec.html
 valid for [Service], [Socket], [Mount], or [Swap] sections
 }
 type ${project.artifactId}_unitfile_config_systemd_exec = {
+    'CacheDirectoryMode' ? type_octal_mode
+    'CacheDirectory' ? string[]
+    'ConfigurationDirectoryMode' ? type_octal_mode
+    'ConfigurationDirectory' ? string[]
     'CPUAffinity' ? long[][] # start with empty list to reset
     'CPUSchedulingPolicy' ? string with match(SELF, '^(other|batch|idle|fifo|rr)$')
     'CPUSchedulingPriority' ? long(1..99) # 99 = highest
@@ -170,13 +174,20 @@ type ${project.artifactId}_unitfile_config_systemd_exec = {
     'LimitRTTIME' ? long(-1..) # Specifies a limit (in microseconds) on the amount of CPU time that a process scheduled under a real-time scheduling policy may consume without making a blocking system call.
     'LimitSIGPENDING' ? long(-1..) # Specifies the limit on the number of signals that may be queued for the real user ID of the calling process.
     'LimitSTACK' ? long(-1..) # The maximum size of the process stack, in bytes.
+    'LogsDirectoryMode' ? type_octal_mode
+    'LogsDirectory' ? string[]
     'Nice' ? long(-20..19)
     'OOMScoreAdjust' ? long(-1000..1000)
     'PrivateTmp' ? boolean
     'RootDirectory' ? string
+    'RuntimeDirectoryMode' ? type_octal_mode
+    'RuntimeDirectoryPreserve' ? choice('yes', 'no', 'restart')
+    'RuntimeDirectory' ? string[]
     'StandardError' ? ${project.artifactId}_unitfile_config_systemd_exec_stdouterr
     'StandardInput' ? string with match(SELF, '^(null|tty(-(force|fail))?|socket)$')
     'StandardOutput' ? ${project.artifactId}_unitfile_config_systemd_exec_stdouterr
+    'StateDirectoryMode' ? type_octal_mode
+    'StateDirectory' ? string[]
     'SupplementaryGroups' ? defined_group[]
     'SyslogFacility' ? syslog_facility
     'SyslogIdentifier' ? string
@@ -186,7 +197,7 @@ type ${project.artifactId}_unitfile_config_systemd_exec = {
     'TTYReset' ? boolean
     'TTYVHangup' ? boolean
     'TTYVTDisallocate' ? boolean
-    'UMask' ? string # octal notation, e.g. 0022
+    'UMask' ? type_octal_mode
     'User' ? defined_user
     'WorkingDirectory' ? string
 };

--- a/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
+++ b/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
@@ -53,6 +53,9 @@ bind "/unitfile" = systemd_unitfile_config[];
         'TTYVHangup', false,
         'LimitSTACK', -1,
         'LimitNPROC', 100,
+        'RuntimeDirectory', list('foo/bar', 'tmp'),
+        'RuntimeDirectoryMode', '0777',
+        'RuntimeDirectoryPreserve', 'restart',
         ),
     'install', dict(
         'WantedBy', list('1.service', '2.service'),

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -19,6 +19,9 @@ contentspath=/unitfile/0
 ^ExecStart=/usr/bin/special$
 ^LimitNPROC=100$
 ^LimitSTACK=infinity$
+^RuntimeDirectory=foo/bar tmp$
+^RuntimeDirectoryMode=0777$
+^RuntimeDirectoryPreserve=restart$
 ^TTYReset=yes$
 ^TTYVHangup=no$
 ^\[Unit\]$

--- a/ncm-systemd/src/main/resources/unitfile/service.tt
+++ b/ncm-systemd/src/main/resources/unitfile/service.tt
@@ -1,5 +1,6 @@
 [%- # all Limit except NICE (schema doesn't allow NICE)
-    long_infinity = ['LimitAS', 'LimitCORE', 'LimitCPU', 'LimitDATA', 'LimitFSIZE', 'LimitLOCKS', 'LimitMEMLOCK', 'LimitMSGQUEUE', 'LimitNOFILE', 'LimitNPROC', 'LimitRSS', 'LimitRTPRIO', 'LimitRTTIME' 'LimitSIGPENDING', 'LimitSTACK'] -%]
+    long_infinity = ['LimitAS', 'LimitCORE', 'LimitCPU', 'LimitDATA', 'LimitFSIZE', 'LimitLOCKS', 'LimitMEMLOCK', 'LimitMSGQUEUE', 'LimitNOFILE', 'LimitNPROC', 'LimitRSS', 'LimitRTPRIO', 'LimitRTTIME' 'LimitSIGPENDING', 'LimitSTACK'];
+-%]
 [% INCLUDE 'systemd/unitfile/section.tt' section='Service' data=data
     list_of_lines=['CPUAffinity', 'Environment', 'EnvironmentFile',
                    'ExecStart', 'ExecStartPre', 'ExecStartPost',


### PR DESCRIPTION
This add a couple of sandboxing options that can be used in systemd unit from https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing

I've only added the ones I need, but the list of potential options is long. Should I add all of them?