### PR TITLE
ncm-systemd: Do not try to restart sevices which cannot

### DIFF
--- a/ncm-systemd/src/main/perl/Systemd/Service/Unit.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service/Unit.pm
@@ -443,8 +443,17 @@ sub configured_units
                 next;
             } elsif ($changed) {
                 if ($detail->{startstop}) {
-                    $self->verbose("Going to issue conditional restart for $detail->{name} due to changed unitfile");
-                    push(@tryrestart, $detail->{name});
+                    $ufile->{config}->reset;
+                    my $utree = $ufile->{config}->getTree;
+                    # This is incomplete, because the RefuseManual* options may come from
+                    # unit fragments not managed via templates. But $unit_cache does not seem
+                    # to be initialized here, so we cannot check "systemctl show" data easily.
+                    if ($utree->{unit}->{RefuseManualStop} || $utree->{unit}->{RefuseManualStart}) {
+                        $self->verbose("$detail->{name} is configured to disallow manual restart, skip");
+                    } else {
+                        $self->verbose("Going to issue conditional restart for $detail->{name} due to changed unitfile");
+                        push(@tryrestart, $detail->{name});
+                    }
                 } else {
                     $self->verbose("Changed unitfile for $detail->{name} ",
                                    "but conditional service restart disabled via startstop configuration");

--- a/ncm-systemd/src/test/perl/service-unit.t
+++ b/ncm-systemd/src/test/perl/service-unit.t
@@ -654,6 +654,16 @@ is_deeply($cos->{'othername2.service'}, {
         possible_missing => 0,
 }, "configured_units set correct name and type for othername2.service");
 
+is_deeply($cos->{'test_4_no_restart.service'}, {
+        name => "test_4_no_restart.service",
+        state => $STATE_ENABLED,
+        targets => ["multi-user.target"],
+        startstop => 1,
+        type => $TYPE_SERVICE,
+        shortname => "test_4_no_restart",
+        possible_missing => 0,
+}, "configured_units set correct name and type for test_4_no_restart.service");
+
 is_deeply($cos->{'test_off.service'}, {
         name => "test_off.service",
         state => $STATE_MASKED,
@@ -679,6 +689,7 @@ is_deeply($cos->{'test_del.service'}, {
 is_deeply(\@uf_write, [
               ['othername2.service', 1, '.old', {service => {some1 => "data1"}}, {a1 => 'b1'}],
               ['test3_only.service', 0, '.old', {service => {some => "data"}}, {a => 'b'}],
+              ['test_4_no_restart.service', 1, '.old', {service => {some1 => "data1"}, unit => {RefuseManualStart => 1}}, {a1 => 'b1'}],
           ], "configured unitfiles initialized as expected");
 
 # the entries in uf_write show that these have a file/ subtree
@@ -689,6 +700,7 @@ ok(! defined($cos->{$uf_write[0]->[1]}),
 ok(command_history_ok(
        ["$SYSTEMCTL try-restart -- othername2.service"],
        ['test3'], # not modified, no try-restart
+       ['test_4_no_restart'], # try-restart suppressed
    ), "expected commands for changed unitfile");
 
 =pod

--- a/ncm-systemd/src/test/perl/service.t
+++ b/ncm-systemd/src/test/perl/service.t
@@ -138,6 +138,15 @@ is_deeply($gathered_configured_units, {
         shortname => "othername2",
         possible_missing => 0,
     },
+    'test_4_no_restart.service' => {
+        name => "test_4_no_restart.service",
+        state => $STATE_ENABLED,
+        targets => ["multi-user.target"],
+        startstop => 1,
+        type => $TYPE_SERVICE,
+        shortname => "test_4_no_restart",
+        possible_missing => 0,
+    },
     'test_off.service' => { # from ncm-systemd
         name => "test_off.service",
         state => $STATE_MASKED,
@@ -162,6 +171,7 @@ is_deeply($gathered_configured_units, {
 is_deeply(\@uf_write, [
               ['othername2.service', 1, '.old', {service => {some1 => "data1"}}, {a1 => 'b1'}],
               ['test3_only.service', 0, '.old', {service => {some => "data"}}, {a => 'b'}],
+              ['test_4_no_restart.service', 1, '.old', {service => {some1 => "data1"}, unit => {RefuseManualStart => 1}}, {a1 => 'b1'}],
           ], "configured unitfiles initialized as expected");
 
 # the entries in uf_write show that these have a file/ subtree

--- a/ncm-systemd/src/test/resources/service-unit_simple_services.pan
+++ b/ncm-systemd/src/test/resources/service-unit_simple_services.pan
@@ -5,19 +5,45 @@ prefix "/software/components/systemd/unit";
 "{test2_on}" = dict("state", "enabled", "targets", list("rescue", "multi-user"), "startstop", true);
 "{test2_add}" = dict("state", "disabled", "targets", list("multi-user"), "startstop", true, "type", "target");
 "{test2_on_rename}" = dict(
-    "state", "enabled", "targets", list("multi-user"), "startstop", true, "name", "othername2",
-    "file", dict("only", false, "replace", true, "custom", dict("a1", "b1"), "config", dict("service", dict("some1", "data1"))),
-    );
+    "state", "enabled",
+    "targets", list("multi-user"),
+    "startstop", true,
+    "name", "othername2",
+    "file", dict(
+        "only", false,
+        "replace", true,
+        "custom", dict("a1", "b1"),
+        "config", dict("service", dict("some1", "data1")),
+    ),
+);
 
 # redefine old ones / these have the same name
 "{test_off}" = dict("state", "masked", "targets", list("rescue"), "startstop", true);
 "{test_del}" = dict("state", "enabled", "targets", list("rescue"), "startstop", false);
 
 "{test3_only}" = dict(
-    "state", "enabled", "targets", list("multi-user"), "startstop", true,
-    "file", dict("only", true, "replace", false, "custom", dict("a", "b"), "config", dict("service", dict("some", "data"))),
-    );
+    "state", "enabled",
+    "targets", list("multi-user"),
+    "startstop", true,
+    "file", dict(
+        "only", true,
+        "replace", false,
+        "custom", dict("a", "b"),
+        "config", dict("service", dict("some", "data")),
+    ),
+);
 "{test4_no_restart}" = dict(
-    "state", "enabled", "targets", list("multi-user"), "startstop", true, "name", "test_4_no_restart",
-    "file", dict("only", false, "replace", true, "custom", dict("a1", "b1"), "config", dict("service", dict("some1", "data1"), "unit", dict("RefuseManualStart", true))),
-    );
+    "state", "enabled",
+    "targets", list("multi-user"),
+    "startstop", true,
+    "name", "test_4_no_restart",
+    "file", dict(
+        "only", false,
+        "replace", true,
+        "custom", dict("a1", "b1"),
+        "config", dict(
+            "service", dict("some1", "data1"),
+            "unit", dict("RefuseManualStart", true)
+        ),
+    ),
+);

--- a/ncm-systemd/src/test/resources/service-unit_simple_services.pan
+++ b/ncm-systemd/src/test/resources/service-unit_simple_services.pan
@@ -17,3 +17,7 @@ prefix "/software/components/systemd/unit";
     "state", "enabled", "targets", list("multi-user"), "startstop", true,
     "file", dict("only", true, "replace", false, "custom", dict("a", "b"), "config", dict("service", dict("some", "data"))),
     );
+"{test4_no_restart}" = dict(
+    "state", "enabled", "targets", list("multi-user"), "startstop", true, "name", "test_4_no_restart",
+    "file", dict("only", false, "replace", true, "custom", dict("a1", "b1"), "config", dict("service", dict("some1", "data1"), "unit", dict("RefuseManualStart", true))),
+    );


### PR DESCRIPTION
Attempt to address issue #1395, but only if the RefuseManual* directives
are defined in the profiles. If those directives are coming from unit
fragments which are not managed by Quattor, then restart is still
attempted, and the component will fail.