### PR TITLE
ncm-symlink minor PAN template fixes

### DIFF
--- a/ncm-symlink/src/main/pan/components/symlink/config.pan
+++ b/ncm-symlink/src/main/pan/components/symlink/config.pan
@@ -1,3 +1,3 @@
 ${componentconfig}
 'options/exists' ?= false;
-'options/replace/none' ?= "yes";
+'options/replace' ?= dict('none', "yes");

--- a/ncm-symlink/src/main/pan/components/symlink/schema.pan
+++ b/ncm-symlink/src/main/pan/components/symlink/schema.pan
@@ -16,7 +16,7 @@ type structure_symlink_replace_option_entry = {
 
 type structure_symlink_entry = {
     @{symbolic link name (path).}
-    "name" : string
+    "name" : absolute_file_path
     @{The target path can be built using a command output with the command string
     (can include valid command options) to execute between a pair of '@@' or a
     contextual variable (variables are defined in "/software/components/symlinks/context").


### PR DESCRIPTION
ncm-symlink: tweak default replace options

    The "all" and "none" replace options are mutually exclusive. The prefix
    syntax meant there was no way for site-config to set replace/all without
    modifying this file to comment out the replace/none line in config.pan.
    By moving the setting one level higher in the tree, replace/none will
    only be set if site-config has not created the replace sub-tree.

ncm-symlink: update schema to use absolute_file_path type

    Specifying a symlink name with a trailing slash leads to a runtime
    error. Instead use the schema to catch and prevent these errors at
    compile time.
