### PR TITLE
ncm-authconfig: sssd: remove unsupported force_timeout domain option

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd.pan
@@ -117,7 +117,12 @@ type authconfig_sssd_domain  = {
     "max_id" : long = 0
     "enumerate" : boolean = false
     "timeout" : long = 10
-    "force_timeout" : long = 60
+    "force_timeout" ? long with {
+        deprecated(0,
+            "Warning: sssd/force_timeout was removed from sssd 1.14.2 and will be removed in a future Quattor release."
+        );
+        true;
+    }
     "entry_cache_timeout" : long = 5400
     "entry_cache_user_timeout" ? long
     "entry_cache_group_timeout" ? long


### PR DESCRIPTION
Fixes (harmless) error message in sssd logs
