### PR TITLE
ncm-metaconfig: slurm setting escape fix

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/config.pan
@@ -21,4 +21,5 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}";
 "group" = "root";
 "mode" = 0644;
 "module" = "slurm/config";
+"convert/unescapekey" = true;
 "daemons" = if(length(SLURM_DAEMONS) > 0) SLURM_DAEMONS else null;

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -86,7 +86,7 @@ type slurm_scheduler_parameters = {
     'bf_yield_interval' ? long(0..)
     'bf_yield_sleep' ? long(0..)
     'build_queue_timeout' ? long(0..)
-    'default_queue_depth' ? long(0..)
+    'default_5fqueue_5fdepth' ? long(0..)   # escaped version, otherwise unescaping produces some weird unicode
     'defer' ? boolean
     'delay_boot' ? long(0..)
     'default_gbytes' ? boolean

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -95,7 +95,7 @@ type slurm_scheduler_parameters = {
     'enable_user_top' ? boolean
     'Ignore_NUMA' ? boolean
     'inventory_interval' ? long(0..)
-    'kill_invalid_depend' ? boolean
+    'kill_5finvalid_5fdepend' ? boolean
     'max_array_tasks' ? long(0..)   # should be smaller than MaxArraySize
     'max_depend_depth' ? long(0..)
     'max_rpc_cnt' ? long(0..)

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
@@ -107,7 +107,7 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 #SchedulerTimeSlice = 30;
 "SchedulerType" = "backfill";
 "SchedulerParameters" = dict(
-    "default_queue_depth", 128,
+    "default_5fqueue_5fdepth", 128,
     "bf_max_job_test", 1024,
     "bf_continue", true,
     "bf_window", 4320,


### PR DESCRIPTION
We need to have the escaped version here, since the contents will be unescaped when deploying the conf file.