### PR TITLE
ncm-opennebula: RDM datastore support

### DIFF
--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -436,6 +436,34 @@ type opennebula_cluster = {
     "reserved_mem" ? long
 } = dict();
 
+@documentation{
+type for vmgroup roles specific attributes.
+}
+type opennebula_vmgroup_role = {
+    @{The name of the role, it needs to be unique within the VM Group}
+    "name" : string
+    @{Placement policy for the VMs of the role}
+    "policy" ? choice('AFFINED', 'ANTI_AFFINED')
+    @{Defines a set of hosts (by their ID) where the VMs of the role can be executed}
+    "host_affined" ? string[]
+    @{Defines a set of hosts (by their ID) where the VMs of the role cannot be executed}
+    "host_anti_affined" ? string[]
+};
+
+
+@documentation{
+Set OpenNebula vmgroups and their porperties.
+}
+type opennebula_vmgroup = {
+    include opennebula_group
+    "role" ? opennebula_vmgroup_role[]
+    @{List of roles whose VMs has to be placed in the same host}
+    "affined" ? string[]
+    @{List of roles whose VMs cannot be placed in the same host}
+    "anti_affined" ? string[]
+} = dict();
+
+
 type opennebula_remoteconf_ceph = {
     "pool_name" : string
     "host" : string
@@ -775,6 +803,7 @@ type opennebula_untouchables = {
     "groups" ? string[]
     "hosts" ? string[]
     "clusters" ? string[]
+    "vmgroups" ? string[]
 };
 
 
@@ -789,6 +818,7 @@ type component_opennebula = {
     'users' ? opennebula_user{}
     'vnets' ? opennebula_vnet{}
     'clusters' ? opennebula_cluster{}
+    'vmgroups' ? opennebula_vmgroup{}
     'hosts' ? opennebula_host{}
     'rpc' ? opennebula_rpc
     'untouchables' ? opennebula_untouchables

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -138,7 +138,7 @@ type opennebula_auth_mad = {
 type opennebula_tm_mad_conf = {
     "name" : string = "dummy"
     "ln_target" : string = "NONE"
-    "clone_target" : string = "SYSTEM"
+    "clone_target" : choice('SYSTEM', 'NONE', 'SELF') = "SYSTEM"
     "shared" : boolean = true
     "ds_migrate" ? boolean
     "driver" ? choice('raw', 'qcow2')
@@ -565,7 +565,17 @@ type opennebula_oned = {
             "disk_type_shared", "rbd",
         ),
         dict("name", "iscsi_libvirt", "clone_target", "SELF", "ds_migrate", false),
-        dict("name", "dev", "clone_target", "NONE"),
+        dict(
+            "name", "dev",
+            "clone_target", "NONE",
+            "tm_mad_system", "ssh,shared",
+            "ln_target_ssh", "SYSTEM",
+            "clone_target_ssh", "SYSTEM",
+            "disk_type_ssh", "BLOCK",
+            "ln_target_shared", "NONE",
+            "clone_target_shared", "SELF",
+            "disk_type_shared", "BLOCK",
+        ),
         dict("name", "vcenter", "clone_target", "NONE"),
     )
     "ds_mad_conf" : opennebula_ds_mad_conf[] = list(

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -544,7 +544,7 @@ type opennebula_oned = {
         dict("name", "vmfs"),
         dict(
             "name", "ceph",
-            "clone_target","SELF",
+            "clone_target", "SELF",
             "ds_migrate", false,
             "driver", "raw",
             "allow_orphans", "mixed",

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -274,6 +274,14 @@ function is_consistent_datastore = {
             error("system datastores do not support '%s' TM_MAD", ds['tm_mad']);
         };
     };
+    if (ds['ds_mad'] == 'dev') {
+        if (ds['tm_mad'] != 'dev') {
+            error("for a RDM datastore both ds_mad and tm_mad should have value 'dev'");
+        };
+        if(!exists(ds['disk_type'])) {
+            error("Invalid RDM datastore! Expected 'disk_type'");
+        };
+    };
     # Checks for other types can be added here
     true;
 };
@@ -331,15 +339,15 @@ type opennebula_datastore = {
     include opennebula_ceph_datastore
     "bridge_list" ? string[]  # mandatory for ceph ds, lvm ds, ..
     "datastore_capacity_check" : boolean = true
-    "disk_type" ? choice('RBD')
-    "ds_mad" : string = 'ceph' with match (SELF, '^(fs|ceph)$')
+    "disk_type" ? choice('RBD', 'BLOCK', 'CDROM', 'FILE')
+    "ds_mad" : choice('fs', 'ceph', 'dev') = 'ceph'
     @{set system Datastore TM_MAD value.
         shared: The storage area for the system datastore is a shared directory across the hosts.
         vmfs: A specialized version of the shared one to use the vmfs file system.
         ssh: Uses a local storage area from each host for the system datastore.
         ceph: Uses Ceph storage backend.
     }
-    "tm_mad" : string = 'ceph' with match (SELF, '^(shared|ceph|ssh|vmfs)$')
+    "tm_mad" : choice('shared', 'ceph', 'ssh', 'vmfs', 'dev') = 'ceph'
     "type" : string = 'IMAGE_DS' with match (SELF, '^(IMAGE_DS|SYSTEM_DS)$')
     @{datastore labels is a list of strings to group the datastores under a given name and filter them
     in the admin and cloud views. It is also possible to include in the list

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -185,6 +185,34 @@ type opennebula_vmtemplate_pci = {
 };
 
 @documentation{
+Type that sets VM Groups and Roles for a specifc VM.
+VMGroups are placed by dynamically generating the requirement (SCHED_REQUIREMENTS)
+of each VM an re-evaluating these expressions.
+
+Moreover, the following is also considered:
+
+The scheduler will look for a host with enough capacity for an affined set of VMs.
+If there is no such host all the affined VMs will remain pending.
+
+If new VMs are added to an affined role, it will pick one of the hosts where the VMs
+are running. By default, all should be running in the same host but if you manually
+migrate a VM to another host it will be considered feasible for the role.
+
+The scheduler does not have any synchronization point with the state of the VM group,
+it will start scheduling pending VMs as soon as they show up.
+
+Re-scheduling of VMs works as for any other VM, it will look for a different host
+considering the placement constraints.
+
+For more info:
+https://docs.opennebula.org/5.8/advanced_components/application_flow_and_auto-scaling/vmgroups.html
+}
+type opennebula_vmtemplate_vmgroup = {
+    "vmgroup_name" : string
+    "role" : string
+};
+
+@documentation{
 Type that sets placement constraints and preferences for the VM, valid for all hosts
 More info: http://docs.opennebula.org/5.0/operation/references/template.html#placement-section
 }
@@ -246,4 +274,11 @@ type opennebula_vmtemplate = {
     from the guest when its running out of memory, which means a malicious guest allocating
     large amounts of locked memory could cause a denial-of-service attach on the host.}
     "memorybacking" ? string[] with is_consistent_memorybacking(SELF)
+    @{Request existing VM Group and roles.
+    A VM Group defines a set of related VMs, and associated placement constraints for the VMs
+    in the group. A VM Group allows you to place together (or separately) ceartain VMs
+    (or VM classes, roles). VMGroups will help you to optimize the performance
+    (e.g. not placing all the cpu bound VMs in the same host) or improve the fault tolerance
+    (e.g. not placing all your front-ends in the same host) of your multi-VM applications.}
+    "vmgroup" ? opennebula_vmtemplate_vmgroup[]
 } = dict();

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -78,6 +78,15 @@ type opennebula_vmtemplate_vnet = string{} with {
     true;
 };
 
+type opennebula_rdm_disk = string{} with {
+    foreach (k; v; SELF) {
+        if (! is_absolute_file_path(v)) {
+            error(format("entry: %s in the RDM disk map %s is not a valid file path", v, k));
+        };
+    };
+    true;
+};
+
 type opennebula_vmtemplate_datastore = string{} with {
     # check is all entries in the map have a hardrive
     foreach (k; v; SELF) {
@@ -236,6 +245,12 @@ type opennebula_vmtemplate = {
     "vnet" : opennebula_vmtemplate_vnet
     @{Set the OpenNebula opennebula/datastore name for each vdx}
     "datastore" : opennebula_vmtemplate_datastore
+    @{Set raw device mapping (RDM) for a specific virtual disk, for instance:
+        '/system/opennebula/diskrdmpath/vdd/' = '/dev/sdf';
+     will passthrough the block device to the VM as vdd disk. Disk size is ignored in this case.
+     It requires a RDM datastore.
+     See: https://docs.opennebula.org/5.8/deployment/open_cloud_storage_setup/dev_ds.html}
+    "diskrdmpath" ? opennebula_rdm_disk
     @{Set ignoremac tree to avoid to include MAC values within AR/VM templates}
     "ignoremac" ? opennebula_ignoremac
     @{Set how many queues will be used for the communication between CPUs and virtio drivers.

--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -262,6 +262,9 @@ sub set_one_server
     # Create/update the virtual clusters before any resource first
     $self->manage_something($one, "cluster", $tree->{clusters}, $untouchables->{clusters});
 
+    # Add VM groups and roles
+    #$self->manage_something($one, "vmgroup", $tree->{vmgroups}, $untouchables->{vmgroups});
+
     $self->manage_something($one, "vnet", $tree->{vnets}, $untouchables->{vnets});
 
     # For the moment only Ceph and shared datastores are configured

--- a/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Server.pm
@@ -263,7 +263,7 @@ sub set_one_server
     $self->manage_something($one, "cluster", $tree->{clusters}, $untouchables->{clusters});
 
     # Add VM groups and roles
-    #$self->manage_something($one, "vmgroup", $tree->{vmgroups}, $untouchables->{vmgroups});
+    $self->manage_something($one, "vmgroup", $tree->{vmgroups}, $untouchables->{vmgroups});
 
     $self->manage_something($one, "vnet", $tree->{vnets}, $untouchables->{vnets});
 

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -124,7 +124,7 @@ use CAF::FileReader;
 use CAF::Service;
 use Set::Scalar;
 use Config::Tiny;
-use Net::OpenNebula 0.315.0;
+use Net::OpenNebula 0.316.0;
 use Data::Dumper;
 use Readonly;
 use 5.10.1;

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -40,6 +40,8 @@ Features that are implemented at this moment:
 
 =item * Adding/removing OpenNebula virtual clusters
 
+=item * Adding/removing OpenNebula VM groups and roles
+
 =item * Assign OpenNebula resources to virtual clusters
 
 =item * Assign OpenNebula users to primary groups
@@ -122,7 +124,7 @@ use CAF::FileReader;
 use CAF::Service;
 use Set::Scalar;
 use Config::Tiny;
-use Net::OpenNebula 0.314.0;
+use Net::OpenNebula 0.315.0;
 use Data::Dumper;
 use Readonly;
 use 5.10.1;

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -122,7 +122,7 @@ use CAF::FileReader;
 use CAF::Service;
 use Set::Scalar;
 use Config::Tiny;
-use Net::OpenNebula 0.313.0;
+use Net::OpenNebula 0.314.0;
 use Data::Dumper;
 use Readonly;
 use 5.10.1;

--- a/ncm-opennebula/src/main/resources/imagetemplate.tt
+++ b/ncm-opennebula/src/main/resources/imagetemplate.tt
@@ -6,7 +6,11 @@ PERSISTENT = "YES"
 DEV_PREFIX = "vd"
 NAME = "[%- fqdn %]_[% pair.key %]"
 TARGET = "[% pair.key %]"
+[%- IF system.opennebula.diskrdmpath.${pair.key}.defined %]
+PATH = "[% system.opennebula.diskrdmpath.${pair.key} %]"
+[%-  ELSE %]
 SIZE = [% hardware.harddisks.${pair.key}.capacity %]
+[%- END %]
 DESCRIPTION = "QUATTOR image for [% fqdn %]: [% pair.key %]"
 [%- IF system.opennebula.labels.defined %]
 LABELS = "[% system.opennebula.labels.join(',') %]"

--- a/ncm-opennebula/src/main/resources/oned_level1.tt
+++ b/ncm-opennebula/src/main/resources/oned_level1.tt
@@ -1,6 +1,6 @@
 [%- digits = ['port', 'debug_level', 'zone_id', 'cpu_cost', 'memory_cost', 'disk_cost', 'start'] -%]
 [%- booleans = ['shared', 'persistent_only', 'keep_snapshots', 'ds_migrate', 'public'] -%]
-[%- comma_list_attrs = ['imported_vms_actions', 'required_attrs', 'app_actions'] -%]
+[%- comma_list_attrs = ['imported_vms_actions', 'required_attrs', 'app_actions', 'host_affined', 'host_anti_affined'] -%]
 [
 [% FILTER indent -%]
 [%     IF name.defined -%]

--- a/ncm-opennebula/src/main/resources/tests/profiles/datastore_rdm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/datastore_rdm.pan
@@ -1,0 +1,15 @@
+object template datastore_rdm;
+
+include 'components/opennebula/schema';
+
+bind "/metaconfig/contents/datastore/rdm" = opennebula_datastore;
+
+"/metaconfig/module" = "datastore";
+
+prefix "/metaconfig/contents/datastore/rdm";
+"datastore_capacity_check" = false;
+"disk_type" = "BLOCK";
+"tm_mad" = "dev";
+"ds_mad" = "dev";
+"type" = "IMAGE_DS";
+"labels" = list("quattor", "quattor/rdm");

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -68,6 +68,12 @@ prefix "/hardware";
         "model", "Generic SAS disk",
         "part_prefix", ""
     ),
+    "vdc", dict(
+        "capacity", 20480,
+        "interface", "sas",
+        "model", "Generic SAS disk",
+        "part_prefix", ""
+    ),
 );
 "location" = "cubone hyp";
 "model" = "KVM Virtual Machine";
@@ -141,7 +147,12 @@ prefix "/system/opennebula";
 
 "datastore" = dict(
     "vda", "ceph",
-    "vdb", "default");
+    "vdb", "default",
+    "vdc", "rdm");
+
+"diskrdmpath" = dict(
+    "vdc", "/dev/sdc",
+);
 
 "graphics" = "SPICE";
 

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -186,3 +186,7 @@ prefix "/system/opennebula";
     "hugepages",
 );
 
+"vmgroup" = append(dict(
+    "vmgroup_name", "ha_group",
+    "role", "backup"
+));

--- a/ncm-opennebula/src/main/resources/tests/profiles/vmgroup.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vmgroup.pan
@@ -1,0 +1,25 @@
+object template vmgroup;
+
+include 'components/opennebula/schema';
+
+bind "/metaconfig/contents/vmgroup/ha_group" = opennebula_vmgroup;
+
+"/metaconfig/module" = "vmgroup";
+
+prefix "/metaconfig/contents/vmgroup/ha_group";
+"anti_affined" = list('workers', 'backups');
+"affined" = list('db', 'apps');
+"role" = list(
+    dict(
+        "name", "backup",
+        "host_anti_affined", list('1', '2', '3'),
+        "policy", "ANTI_AFFINED",
+    ),
+    dict(
+        "name", "apps",
+        "host_affined", list('4', '5', '6'),
+        "policy", "AFFINED",
+    ),
+);
+"labels" = list("quattor", "quattor/ha_group");
+"description" = "New HA VM group managed by quattor";

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_imagetemplate/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_imagetemplate/simple
@@ -1,4 +1,4 @@
-OpenNebula simple image template test
+nOpenNebula simple image template test
 ---
 multiline
 ---
@@ -12,5 +12,17 @@ multiline
 ^LABELS\s?=\s?".+"$
 ^DRIVER\s?=\s?".+"$
 ^FSTYPE\s?=\s?".+"$
+^QUATTOR\s?=\s?\d?\s*$
+^DATASTORE\s?=\s*".+"\s*$
+^TYPE\s?=\s*".+"\s*$
+^PERSISTENT\s?=\s*".+"\s*$
+^DEV_PREFIX\s?=\s*".+"\s*$
+^NAME\s?=\s*".+"\s*$
+^TARGET\s?=\s*".+"\s*$
+^PATH\s?=\s*".+"\s*$
+^DESCRIPTION\s?=\s*".+"\s*$
+^LABELS\s?=\s*".+"\s*$
+^DRIVER\s?=\s*".+"\s*$
+^FSTYPE\s?=\s*".+"\s*$
 ^QUATTOR\s?=\s?\d?\s*$
 ^DATASTORE\s?=\s*".+"\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
@@ -38,6 +38,9 @@ multiline
 ^\s*CLASS\s?=\s*".+",\s*$
 ^\s*DEVICE\s?=\s*".+",\s*$
 ^\s*VENDOR\s?=\s*".+"\s*$
+^VMGROUP\s?=\s?\[$
+^\s*role\s?=\s*".+",\s*$
+^\s*vmgroup_name\s?=\s*".+"\s*$
 ^LABELS\s?=\s*".+"$
 ^SCHED_DS_RANK\s?=\s?".+"\s*$
 ^SCHED_DS_REQUIREMENTS\s?=\s?".+"\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/datastore_rdm/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/datastore_rdm/simple
@@ -1,0 +1,11 @@
+OpenNebula rdm datastore test
+---
+---
+^NAME\s?=\s?".+"\s*$
+^DATASTORE_CAPACITY_CHECK\s?=\s?".+"\s*$
+^DISK_TYPE\s?=\s?".+"\s*$
+^DS_MAD\s?=\s?".+"\s*$
+^LABELS\s?=\s?".+"$
+^TM_MAD\s?=\s?".+"\s*$
+^TYPE\s?=\s?".+"\s*$
+^QUATTOR\s?=\s?\d+\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/oned/oned_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/oned/oned_template
@@ -221,9 +221,16 @@ multiline
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"NONE",$
+^\s{4}clone_target_shared\s?=\s?"SELF",$
+^\s{4}clone_target_ssh\s?=\s?"SYSTEM",$
+^\s{4}disk_type_shared\s?=\s?"BLOCK",$
+^\s{4}disk_type_ssh\s?=\s?"BLOCK",$
 ^\s{4}ln_target\s?=\s?"NONE",$
+^\s{4}ln_target_shared\s?=\s?"NONE",$
+^\s{4}ln_target_ssh\s?=\s?"SYSTEM",$
 ^\s{4}name\s?=\s?"dev",$
-^\s{4}shared\s?=\s?"yes"$
+^\s{4}shared\s?=\s?"yes",$
+^\s{4}tm_mad_system\s?=\s?"ssh,shared"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"NONE",$

--- a/ncm-opennebula/src/main/resources/tests/regexps/oned/oned_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/oned/oned_template
@@ -8,7 +8,7 @@ multiline
 ^\]$
 ^DATASTORE_CAPACITY_CHECK\s?=\s?"yes"$
 ^DATASTORE_MAD\s?=\s?\[$
-^\s{4}arguments\s?=\s?"-t 15 -d dummy,fs,vmfs,lvm,ceph",$
+^\s{4}arguments\s?=\s?"-t 15 -d dummy,fs,lvm,dev,iscsi_libvirt,vcenter -s shared,ssh,ceph,fs_lvm,qcow2,vcenter",$
 ^\s{4}executable\s?=\s?"one_datastore"$
 ^\]$
 ^DB\s?=\s?\[$
@@ -161,10 +161,14 @@ multiline
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SYSTEM",$
+^\s{4}clone_target_ssh\s?=\s?"SYSTEM",$
+^\s{4}disk_type_ssh\s?=\s?"FILE",$
 ^\s{4}ds_migrate\s?=\s?"yes",$
 ^\s{4}ln_target\s?=\s?"NONE",$
+^\s{4}ln_target_ssh\s?=\s?"SYSTEM",$
 ^\s{4}name\s?=\s?"shared",$
-^\s{4}shared\s?=\s?"yes"$
+^\s{4}shared\s?=\s?"yes",$
+^\s{4}tm_mad_system\s?=\s?"ssh"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SYSTEM",$
@@ -174,6 +178,7 @@ multiline
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SYSTEM",$
+^\s{4}driver\s?=\s?"qcow2",$
 ^\s{4}ln_target\s?=\s?"NONE",$
 ^\s{4}name\s?=\s?"qcow2",$
 ^\s{4}shared\s?=\s?"yes"$
@@ -192,11 +197,20 @@ multiline
 ^\s{4}shared\s?=\s?"yes"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
+^\s{4}allow_orphans\s?=\s?"mixed",$
 ^\s{4}clone_target\s?=\s?"SELF",$
+^\s{4}clone_target_shared\s?=\s?"SELF",$
+^\s{4}clone_target_ssh\s?=\s?"SYSTEM",$
+^\s{4}disk_type_shared\s?=\s?"rbd",$
+^\s{4}disk_type_ssh\s?=\s?"FILE",$
+^\s{4}driver\s?=\s?"raw",$
 ^\s{4}ds_migrate\s?=\s?"no",$
 ^\s{4}ln_target\s?=\s?"NONE",$
+^\s{4}ln_target_shared\s?=\s?"NONE",$
+^\s{4}ln_target_ssh\s?=\s?"SYSTEM",$
 ^\s{4}name\s?=\s?"ceph",$
-^\s{4}shared\s?=\s?"yes"$
+^\s{4}shared\s?=\s?"yes",$
+^\s{4}tm_mad_system\s?=\s?"ssh,shared"$
 ^\]$
 ^TM_MAD_CONF\s?=\s?\[$
 ^\s{4}clone_target\s?=\s?"SELF",$
@@ -226,8 +240,8 @@ multiline
 ^\s{4}arguments\s?=\s?"-t 15 -r 0 kvm",$
 ^\s{4}default\s?=\s?"vmm_exec/vmm_exec_kvm.conf",$
 ^\s{4}executable\s?=\s?"one_vmm_exec",$
-^\s{4}imported_vms_actions\s?=\s?"terminate, terminate-hard, hold, release, suspend, resume, delete, reboot, reboot-hard, resched, unresched, disk-attach, disk-detach, nic-attach, nic-detach, snap-create, snap-delete",$
-^\s{4}keep_snapshots\s?=\s?"no",$
+^\s{4}imported_vms_actions\s?=\s?"terminate, terminate-hard, hold, release, suspend, resume, delete, reboot, reboot-hard, resched, unresched, disk-attach, disk-detach, nic-attach, nic-detach, snapshot-create, snapshot-delete",$
+^\s{4}keep_snapshots\s?=\s?"yes",$
 ^\s{4}sunstone_name\s?=\s?"KVM"$
 ^\]$
 ^VM_RESTRICTED_ATTR\s?=\s?"CONTEXT/FILES"$

--- a/ncm-opennebula/src/main/resources/tests/regexps/vmgroup/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/vmgroup/simple
@@ -1,0 +1,15 @@
+Opennebula vmgroup test
+---
+multiline
+---
+^NAME\s?=\s?".+"$
+^AFFINED\s?=\s?".+"$
+^ANTI_AFFINED\s?=\s?".+"$
+^DESCRIPTION\s?=\s?".+"$
+^LABELS\s?=\s?".+"$
+^ROLE\s?=\s?\[$
+^\s*host_anti_affined\s?=\s*".+",\s*$
+^\s*name\s?=\s*".+",\s*$
+^\s*policy\s?=\s*".+"\s*$
+^\]$
+^QUATTOR\s?=\s?\d+\s*$

--- a/ncm-opennebula/src/main/resources/vmgroup.tt
+++ b/ncm-opennebula/src/main/resources/vmgroup.tt
@@ -6,10 +6,10 @@ NAME = "[% vmgroup.key %]"
 [%            CASE booleans -%]
 [%                pair.key FILTER upper %] = "[% pair.value ? "YES" : "NO" %]"
 [%            CASE 'role' -%]
-[%     FOREACH item IN vmgroup.value.${pair.key} -%]
-[%                pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
-                                      data=item -%]
-[%     END -%]
+[%                FOREACH item IN vmgroup.value.${pair.key} -%]
+[%                    pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
+                          data=item -%]
+[%                END -%]
 [%            CASE role_list -%]
 [%                pair.key FILTER upper %] = "[% pair.value.join(',') %]"
 [%            CASE -%]

--- a/ncm-opennebula/src/main/resources/vmgroup.tt
+++ b/ncm-opennebula/src/main/resources/vmgroup.tt
@@ -1,0 +1,20 @@
+[%- role_list = ['affined', 'anti_affined', 'labels'] -%]
+[% FOR vmgroup IN vmgroup.pairs -%]
+NAME = "[% vmgroup.key %]"
+[%    FOR pair IN vmgroup.value.pairs %]
+[%-       SWITCH pair.key -%]
+[%            CASE booleans -%]
+[%                pair.key FILTER upper %] = "[% pair.value ? "YES" : "NO" %]"
+[%            CASE 'role' -%]
+[%     FOREACH item IN vmgroup.value.${pair.key} -%]
+[%                pair.key FILTER upper %] = [% INCLUDE 'opennebula/oned_level1.tt'
+                                      data=item -%]
+[%     END -%]
+[%            CASE role_list -%]
+[%                pair.key FILTER upper %] = "[% pair.value.join(',') %]"
+[%            CASE -%]
+[%                pair.key FILTER upper %] = "[% pair.value %]"
+[%        END -%]
+[%-    END %]
+[%- END -%]
+QUATTOR = 1

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -81,6 +81,9 @@ PCI = [
 [%-         END %]
 [%-     END %]
 [%- END %]
+[%- FOREACH item IN system.opennebula.vmgroup %]
+VMGROUP = [% INCLUDE 'opennebula/oned_level1.tt' data=item -%]
+[%- END %]
 [%- IF system.opennebula.labels.defined %]
 LABELS = "[% system.opennebula.labels.join(',') %]"
 [%- END %]

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -997,3 +997,65 @@ $cmds{rpc_del_datastore_cluster}{out} = 1;
 $cmds{rpc_del_host_cluster}{params} = [0, 168];
 $cmds{rpc_del_host_cluster}{method} = "one.cluster.delhost";
 $cmds{rpc_del_host_cluster}{out} = 1;
+
+# Manage VM Groups
+
+$data = <<'EOF';
+NAME = "ha_group"
+AFFINED = "db,apps"
+ANTI_AFFINED = "workers,backups"
+DESCRIPTION = "New HA VM group managed by quattor"
+LABELS = "quattor,quattor/ha_group"
+ROLE = [
+    host_anti_affined = "1, 2, 3",
+    name = "backup",
+    policy = "ANTI_AFFINED"
+]
+ROLE = [
+    host_affined = "4, 5, 6",
+    name = "apps",
+    policy = "AFFINED"
+]
+QUATTOR = 1
+EOF
+$cmds{rpc_create_vmgroup}{params} = [$data];
+$cmds{rpc_create_vmgroup}{method} = "one.vmgroup.allocate";
+$cmds{rpc_create_vmgroup}{out} = 2;
+
+$cmds{rpc_delete_vmgroup}{params} = [1];
+$cmds{rpc_delete_vmgroup}{method} = "one.vmgroup.delete";
+$cmds{rpc_delete_vmgroup}{out} = 1;
+
+$cmds{rpc_list_vmgrouppool}{params} = [];
+$cmds{rpc_list_vmgrouppool}{method} = "one.vmgrouppool.info";
+$cmds{rpc_list_vmgrouppool}{out} = <<'EOF';
+<VM_GROUP_POOL><VM_GROUP><ID>1</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>muilt-tierapp</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>0</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><ROLES><ROLE><ID><![CDATA[0]]></ID><NAME><![CDATA[worker]]></NAME><POLICY><![CDATA[ANTI_AFFINED]]></POLICY></ROLE></ROLES><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR></TEMPLATE></VM_GROUP></VM_GROUP_POOL>
+EOF
+
+$cmds{rpc_list_vmgroup}{params} = [1];
+$cmds{rpc_list_vmgroup}{method} = "one.vmgroup.info";
+$cmds{rpc_list_vmgroup}{out} = <<'EOF';
+<VM_GROUP><ID>1</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>muilt-tierapp</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>0</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><ROLES><ROLE><ID><![CDATA[0]]></ID><NAME><![CDATA[worker]]></NAME><POLICY><![CDATA[ANTI_AFFINED]]></POLICY></ROLE></ROLES><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR></TEMPLATE></VM_GROUP>
+EOF
+
+$data = <<'EOF';
+NAME = "ha_group"
+AFFINED = "db,apps"
+ANTI_AFFINED = "workers,backups"
+DESCRIPTION = "New HA VM group managed by quattor"
+LABELS = "quattor,quattor/ha_group"
+ROLE = [
+    host_anti_affined = "1, 2, 3",
+    name = "backup",
+    policy = "ANTI_AFFINED"
+]
+ROLE = [
+    host_affined = "4, 5, 6",
+    name = "apps",
+    policy = "AFFINED"
+]
+QUATTOR = 1
+EOF
+$cmds{rpc_update_vmgroup}{params} = [2, $data, 1];
+$cmds{rpc_update_vmgroup}{method} = "one.vmgroup.update";
+$cmds{rpc_update_vmgroup}{out} = 2;

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -523,6 +523,20 @@ $cmds{rpc_create_newdatastore2}{params} = [$data, -1];
 $cmds{rpc_create_newdatastore2}{method} = "one.datastore.allocate";
 $cmds{rpc_create_newdatastore2}{out} = 103;
 
+$data = <<'EOF';
+NAME = "rdm"
+DATASTORE_CAPACITY_CHECK = "no"
+DISK_TYPE = "BLOCK"
+DS_MAD = "dev"
+LABELS = "quattor,quattor/rdm"
+TM_MAD = "dev"
+TYPE = "IMAGE_DS"
+QUATTOR = 1
+EOF
+$cmds{rpc_create_newdatastore3}{params} = [$data, -1];
+$cmds{rpc_create_newdatastore3}{method} = "one.datastore.allocate";
+$cmds{rpc_create_newdatastore3}{out} = 104;
+
 $cmds{rpc_delete_datastore}{params} = [102];
 $cmds{rpc_delete_datastore}{method} = "one.datastore.delete";
 $cmds{rpc_delete_datastore}{out} = 102;
@@ -530,6 +544,10 @@ $cmds{rpc_delete_datastore}{out} = 102;
 $cmds{rpc_delete_datastore2}{params} = [103];
 $cmds{rpc_delete_datastore2}{method} = "one.datastore.delete";
 $cmds{rpc_delete_datastore2}{out} = 103;
+
+$cmds{rpc_delete_datastore3}{params} = [104];
+$cmds{rpc_delete_datastore3}{method} = "one.datastore.delete";
+$cmds{rpc_delete_datastore3}{out} = 104;
 
 $cmds{rpc_list_datastorespool}{params} = [];
 $cmds{rpc_list_datastorespool}{method} = "one.datastorepool.info";
@@ -553,6 +571,12 @@ $cmds{rpc_list_datastore3}{params} = [0];
 $cmds{rpc_list_datastore3}{method} = "one.datastore.info";
 $cmds{rpc_list_datastore3}{out} = <<'EOF';
 <DATASTORE><ID>0</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>system</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>1</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><DS_MAD><![CDATA[-]]></DS_MAD><TM_MAD><![CDATA[shared]]></TM_MAD><BASE_PATH><![CDATA[/var/lib/one//datastores/0]]></BASE_PATH><TYPE>1</TYPE><DISK_TYPE>0</DISK_TYPE><STATE>0</STATE><CLUSTERS><ID>0</ID></CLUSTERS><TOTAL_MB>5454372</TOTAL_MB><FREE_MB>5445072</FREE_MB><USED_MB>9300</USED_MB><IMAGES/><TEMPLATE><ALLOW_ORPHANS><![CDATA[NO]]></ALLOW_ORPHANS><DS_MIGRATE><![CDATA[YES]]></DS_MIGRATE><SHARED><![CDATA[YES]]></SHARED><TM_MAD><![CDATA[shared]]></TM_MAD><TYPE><![CDATA[SYSTEM_DS]]></TYPE></TEMPLATE></DATASTORE>
+EOF
+
+$cmds{rpc_list_datastore4}{params} = [104];
+$cmds{rpc_list_datastore4}{method} = "one.datastore.info";
+$cmds{rpc_list_datastore4}{out} = <<'EOF';
+<DATASTORE><ID>104</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>rdm</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>1</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><DS_MAD><![CDATA[dev]]></DS_MAD><TM_MAD><![CDATA[dev]]></TM_MAD><BASE_PATH><![CDATA[/var/lib/one//datastores/104]]></BASE_PATH><TYPE>0</TYPE><DISK_TYPE>2</DISK_TYPE><STATE>0</STATE><CLUSTERS><ID>-1</ID></CLUSTERS><TOTAL_MB>1</TOTAL_MB><FREE_MB>1</FREE_MB><USED_MB>0</USED_MB><IMAGES><ID>136</ID></IMAGES><TEMPLATE><ALLOW_ORPHANS><![CDATA[NO]]></ALLOW_ORPHANS><CLONE_TARGET><![CDATA[NONE]]></CLONE_TARGET><DISK_TYPE><![CDATA[BLOCK]]></DISK_TYPE><DS_MAD><![CDATA[dev]]></DS_MAD><LN_TARGET><![CDATA[NONE]]></LN_TARGET><RESTRICTED_DIRS><![CDATA[/]]></RESTRICTED_DIRS><SAFE_DIRS><![CDATA[/var/tmp]]></SAFE_DIRS><TM_MAD><![CDATA[dev]]></TM_MAD><TYPE><![CDATA[IMAGE_DS]]></TYPE></TEMPLATE></DATASTORE>
 EOF
 
 $data = <<'EOF';

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -1026,7 +1026,7 @@ $cmds{rpc_delete_vmgroup}{params} = [1];
 $cmds{rpc_delete_vmgroup}{method} = "one.vmgroup.delete";
 $cmds{rpc_delete_vmgroup}{out} = 1;
 
-$cmds{rpc_list_vmgrouppool}{params} = [];
+$cmds{rpc_list_vmgrouppool}{params} = [-2, -1, -1];
 $cmds{rpc_list_vmgrouppool}{method} = "one.vmgrouppool.info";
 $cmds{rpc_list_vmgrouppool}{out} = <<'EOF';
 <VM_GROUP_POOL><VM_GROUP><ID>1</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>muilt-tierapp</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>0</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><ROLES><ROLE><ID><![CDATA[0]]></ID><NAME><![CDATA[worker]]></NAME><POLICY><![CDATA[ANTI_AFFINED]]></POLICY></ROLE></ROLES><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR></TEMPLATE></VM_GROUP></VM_GROUP_POOL>

--- a/ncm-opennebula/src/test/perl/vmgroup.t
+++ b/ncm-opennebula/src/test/perl/vmgroup.t
@@ -1,0 +1,33 @@
+# -* mode: cperl -*-
+use strict;
+use warnings;
+use Test::More;
+use Test::Quattor qw(vmgroup);
+use CAF::Object;
+
+use OpennebulaMock;
+use NCM::Component::opennebula;
+
+$CAF::Object::NoAction = 1;
+
+my $cmp = NCM::Component::opennebula->new("vmgroup");
+
+my $cfg = get_config_for_profile("vmgroup");
+my $tree = $cfg->getElement("/software/components/opennebula")->getTree();
+my $one = $cmp->make_one($tree->{rpc});
+
+# Test vmgroup
+ok(exists($tree->{vmgroups}), "Found vmgroup data");
+
+rpc_history_reset;
+$cmp->manage_something($one, "vmgroup", $tree->{vmgroups});
+#diag_rpc_history;
+ok(rpc_history_ok(["one.vmgrouppool.info",
+                   "one.vmgrouppool.info",
+                   "one.vmgroup.allocate",
+                   "one.vmgroup.info"]),
+                   "manage_something vmgroup rpc history ok");
+
+ok(!exists($cmp->{ERROR}), "No errors found during vmgroup management execution");
+
+done_testing();

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -166,6 +166,14 @@ prefix "/software/components/opennebula";
             "type", "SYSTEM_DS",
             "clusters", list("default", "red.cluster"),
         ),
+        "rdm", dict(
+            "tm_mad", "dev",
+            "ds_mad", "dev",
+            "type", "IMAGE_DS",
+            "disk_type", "BLOCK",
+            "datastore_capacity_check", false,
+            "labels", list("quattor", "quattor/rdm"),
+        ),
 );
 
 "groups" = dict(

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -57,6 +57,27 @@ prefix "/software/components/opennebula";
         ),
 );
 
+"vmgroups" = dict(
+    "ha_group", dict(
+        "anti_affined", list('workers', 'backups'),
+        "affined", list('db', 'apps'),
+        "role", list(
+            dict(
+                "name", "backup",
+                "host_anti_affined", list('1', '2', '3'),
+                "policy", "ANTI_AFFINED",
+            ),
+            dict(
+                "name", "apps",
+                "host_affined", list('4', '5', '6'),
+                "policy", "AFFINED",
+            ),
+        ),
+    "labels", list("quattor", "quattor/ha_group"),
+    "description", "New HA VM group managed by quattor",
+    ),
+);
+
 "vnets" = dict(
     "altaria.os", dict(
             "bridge", "br100",

--- a/ncm-opennebula/src/test/resources/vmgroup.pan
+++ b/ncm-opennebula/src/test/resources/vmgroup.pan
@@ -1,0 +1,3 @@
+object template vmgroup;
+
+include 'one';


### PR DESCRIPTION
Fix: #1426 

**NOTE:** Requires #1391 which must be reviewed/merged first.
**NOTE:** It requires the new `Net::OpenNebula 0.316.0` or newer to work.

More info about RDM datastores and disks pt with libvirt:
https://docs.opennebula.org/5.8/deployment/open_cloud_storage_setup/dev_ds.html
