### PR TITLE
ncm-metaconfig: slurm topology schema and tt file

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -604,6 +604,21 @@ type slurm_spank_conf = {
     'includes' ? slurm_spank_includes[]
 };
 
+type slurm_topology_leaf_switch = {
+    'switch': string
+    'nodes': type_fqdn[]
+};
+
+type slurm_topology_spine_switch = {
+    'switch': string
+    'switches': string[]
+};
+
+type slurm_topology_conf = {
+    'leafswitch' : slurm_topology_leaf_switch[]
+    'spineswitch' : slurm_topology_spine_switch[]
+};
+
 type slurm_acct_gather_conf = {
     @{in seconds}
     'EnergyIPMIFrequency' ? long(0..)

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/topology.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/topology.pan
@@ -1,0 +1,13 @@
+unique template metaconfig/slurm/topology;
+
+include 'components/metaconfig/config';
+include 'metaconfig/slurm/schema';
+
+bind "/software/components/metaconfig/services/{/etc/slurm/topology.conf}/contents" = slurm_topology_conf;
+
+prefix "/software/components/metaconfig/services/{/etc/slurm/topology.conf}";
+"owner" = "root";
+"group" = "root";
+"mode" = 0644;
+"module" = "slurm/topology";
+"daemons/slurmd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/topology.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/topology.tt
@@ -1,0 +1,7 @@
+[% FOREACH leafswitch IN CCM.contents.leafswitch %]
+SwitchName=[% leafswitch.switch %] Nodes=[% leafswitch.nodes.join(',') %]
+[% END %]
+
+[% FOREACH spineswitch IN CCM.contents.spineswitch %]
+SwitchName=[% spineswitch.switch %] Switches=[% spineswitch.switches.join(',') %]
+[% END %]


### PR DESCRIPTION
Slurm features support for topologies in the network. This PR provides a schema for a hierarchical 
tree setup.