### PR TITLE
ncm-ssh: add HashKnownHosts schema entry

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -160,6 +160,7 @@ type ssh_client_options_type = {
     "EnableSSHKeysign" ? legacy_binary_affirmation_string
     "ForwardAgent" ? legacy_binary_affirmation_string
     "ForwardX11" ? legacy_binary_affirmation_string
+    "HashKnownHosts" ? legacy_binary_affirmation_string
     "GSSAPIDelegateCredentials" ? legacy_binary_affirmation_string
     "Port" ? long
     "PreferredAuthentications" ? ssh_preferred_authentication[]


### PR DESCRIPTION
Add a schema entry for ssh client config option HashKnownHosts

Increasingly important option for security to slow/reduce discovery of additional hosts where a set of compromised credentials may work

Optional so no backwards compatibility problems
