### PR TITLE
ncm-ssh: Add schema entry for RevokedKeys option

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -134,6 +134,12 @@ type ssh_daemon_options_type = {
     "Port" ? long
     "PrintLastLog" ? legacy_binary_affirmation_string
     "PrintMotd" ? legacy_binary_affirmation_string
+    "RevokedKeys" ? string with {
+        if(!((SELF == 'none' ) || is_absolute_file_path(SELF))) {
+            error("RevokedKeys must either be a file path or none")
+        };
+        true;
+    }
     "RhostsAuthentication" ? legacy_binary_affirmation_string
     "ServerKeyBits" ? long
     "ShowPatchLevel" ? legacy_binary_affirmation_string


### PR DESCRIPTION
Add schema entry and validation for RevokedKeys option

Adds the RevokedKeys option to allow the banning of ssh keys that have become compromised.
Optional so I don't expect backwards compatibility issues.

I don't think the error call in the validation will ever be reached - in testing is_absolute_file_path() threw the error, but I don't know if that matters.
