### PR TITLE
ncm-systemd: Add support for Socket in units

### DIFF
--- a/ncm-systemd/src/main/pan/components/systemd/config.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/config.pan
@@ -1,18 +1,3 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
-
-unique template components/${project.artifactId}/config;
-include 'components/${project.artifactId}/schema';
+${componentconfig}
 
 include 'components/${project.artifactId}/functions';
-
-bind '/software/components/${project.artifactId}' = component_${project.artifactId};
-
-'/software/packages' = pkg_repl('ncm-${project.artifactId}','${no-snapshot-version}-${RELEASE}','noarch');
-
-prefix '/software/components/${project.artifactId}';
-'dependencies/pre' ?= list ('spma');
-'active' ?= true;
-'dispatch' ?= true;

--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -45,6 +45,9 @@ type ${project.artifactId}_valid_unit = string;
 # executable paths can have a number of special prefixes
 type ${project.artifactId}_valid_execpath = string with match(SELF, '^([@+!:-]|!!)?/');
 
+# type for a relative directory: no leading / and may not include ".."
+type ${project.artifactId}_relative_directory = string with !match(SELF, '(^/|\.\.)');
+
 # adding new ones
 # go to http://www.freedesktop.org/software/systemd/man/systemd.directives.html
 # and follow the link to the manual
@@ -149,9 +152,9 @@ valid for [Service], [Socket], [Mount], or [Swap] sections
 }
 type ${project.artifactId}_unitfile_config_systemd_exec = {
     'CacheDirectoryMode' ? type_octal_mode
-    'CacheDirectory' ? string[]
+    'CacheDirectory' ? ${project.artifactId}_relative_directory[]
     'ConfigurationDirectoryMode' ? type_octal_mode
-    'ConfigurationDirectory' ? string[]
+    'ConfigurationDirectory' ? ${project.artifactId}_relative_directory[]
     'CPUAffinity' ? long[][] # start with empty list to reset
     'CPUSchedulingPolicy' ? string with match(SELF, '^(other|batch|idle|fifo|rr)$')
     'CPUSchedulingPriority' ? long(1..99) # 99 = highest
@@ -178,19 +181,19 @@ type ${project.artifactId}_unitfile_config_systemd_exec = {
     'LimitSIGPENDING' ? long(-1..) # Specifies the limit on the number of signals that may be queued for the real user ID of the calling process.
     'LimitSTACK' ? long(-1..) # The maximum size of the process stack, in bytes.
     'LogsDirectoryMode' ? type_octal_mode
-    'LogsDirectory' ? string[]
+    'LogsDirectory' ? ${project.artifactId}_relative_directory[]
     'Nice' ? long(-20..19)
     'OOMScoreAdjust' ? long(-1000..1000)
     'PrivateTmp' ? boolean
-    'RootDirectory' ? string
+    'RootDirectory' ? ${project.artifactId}_relative_directory
     'RuntimeDirectoryMode' ? type_octal_mode
     'RuntimeDirectoryPreserve' ? choice('yes', 'no', 'restart')
-    'RuntimeDirectory' ? string[]
+    'RuntimeDirectory' ? ${project.artifactId}_relative_directory[]
     'StandardError' ? ${project.artifactId}_unitfile_config_systemd_exec_stdouterr
     'StandardInput' ? string with match(SELF, '^(null|tty(-(force|fail))?|socket)$')
     'StandardOutput' ? ${project.artifactId}_unitfile_config_systemd_exec_stdouterr
     'StateDirectoryMode' ? type_octal_mode
-    'StateDirectory' ? string[]
+    'StateDirectory' ? ${project.artifactId}_relative_directory[]
     'SupplementaryGroups' ? defined_group[]
     'SyslogFacility' ? syslog_facility
     'SyslogIdentifier' ? string

--- a/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
+++ b/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
@@ -57,6 +57,13 @@ bind "/unitfile" = systemd_unitfile_config[];
         'RuntimeDirectoryMode', '0777',
         'RuntimeDirectoryPreserve', 'restart',
         ),
+    'socket', dict(
+        'ExecStartPre', list('/some/path arg1', '-/some/other/path arg2'),
+        'ListenStream', list('/path/to/pipe'),
+        'SocketUser', 'pipeuser',
+        'SocketGroup', 'pipegroup',
+        'SocketMode', '660',
+        ),
     'install', dict(
         'WantedBy', list('1.service', '2.service'),
         ),

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -24,6 +24,13 @@ contentspath=/unitfile/0
 ^RuntimeDirectoryPreserve=restart$
 ^TTYReset=yes$
 ^TTYVHangup=no$
+^\[Socket\]$
+^ExecStartPre=/some/path arg1$
+^ExecStartPre=-/some/other/path arg2$
+^ListenStream=/path/to/pipe$
+^SocketGroup=pipegroup$
+^SocketMode=660$
+^SocketUser=pipeuser$
 ^\[Unit\]$
 ^After=unit0$
 ^After=unit01$

--- a/ncm-systemd/src/main/resources/unitfile/service-socket.tt
+++ b/ncm-systemd/src/main/resources/unitfile/service-socket.tt
@@ -1,0 +1,5 @@
+[%- # all Limit except NICE (schema doesn't allow NICE)
+    long_infinity = ['LimitAS', 'LimitCORE', 'LimitCPU', 'LimitDATA', 'LimitFSIZE', 'LimitLOCKS', 'LimitMEMLOCK', 'LimitMSGQUEUE', 'LimitNOFILE', 'LimitNPROC', 'LimitRSS', 'LimitRTPRIO', 'LimitRTTIME' 'LimitSIGPENDING', 'LimitSTACK'];
+    list_of_lines = ['CPUAffinity', 'Environment', 'EnvironmentFile', 'ExecStart', 'ExecStartPre', 'ExecStartPost', 'ExecReload', 'ExecStop', 'ExecStopPost', 'ListenStream', 'ListenDatagram', 'ListenSequentialPacket'];
+-%]
+[% INCLUDE 'systemd/unitfile/section.tt' data=data -%]

--- a/ncm-systemd/src/main/resources/unitfile/service.tt
+++ b/ncm-systemd/src/main/resources/unitfile/service.tt
@@ -1,8 +1,1 @@
-[%- # all Limit except NICE (schema doesn't allow NICE)
-    long_infinity = ['LimitAS', 'LimitCORE', 'LimitCPU', 'LimitDATA', 'LimitFSIZE', 'LimitLOCKS', 'LimitMEMLOCK', 'LimitMSGQUEUE', 'LimitNOFILE', 'LimitNPROC', 'LimitRSS', 'LimitRTPRIO', 'LimitRTTIME' 'LimitSIGPENDING', 'LimitSTACK'];
--%]
-[% INCLUDE 'systemd/unitfile/section.tt' section='Service' data=data
-    list_of_lines=['CPUAffinity', 'Environment', 'EnvironmentFile',
-                   'ExecStart', 'ExecStartPre', 'ExecStartPost',
-                   'ExecReload',
-                   'ExecStop', 'ExecStopPost'] -%]
+[% INCLUDE 'systemd/unitfile/service-socket.tt' section='Service' data=data -%]

--- a/ncm-systemd/src/main/resources/unitfile/socket.tt
+++ b/ncm-systemd/src/main/resources/unitfile/socket.tt
@@ -1,0 +1,1 @@
+[% INCLUDE 'systemd/unitfile/service-socket.tt' section='Socket' data=data -%]


### PR DESCRIPTION
This add supports for a `[Socket]` section in a systemd unit.

It builds on top of and requires #1396 

Please have look @stdweird 