### PR TITLE
ncm-altlogrotate: allow yearly rotation

### DIFF
--- a/ncm-altlogrotate/src/main/pan/components/altlogrotate/schema.pan
+++ b/ncm-altlogrotate/src/main/pan/components/altlogrotate/schema.pan
@@ -62,7 +62,7 @@ type structure_altlogrotate_logrot = {
     'taboo_replace' ? boolean
     'tabooext' ? string[]
 
-    'frequency' ? string with match(SELF, '^(daily|weekly|monthly)$')
+    'frequency' ? choice('daily', 'weekly', 'monthly', 'yearly')
 
     'scripts' ? structure_altlogrotate_scripts
 } with {


### PR DESCRIPTION
Some things run once a month or once a week and rotating too frequently takes away the purpose of a log file.