### PR TITLE
ncm-gpfs: add ib_rdma_monitor_portstate to mmsysmon config

### DIFF
--- a/ncm-gpfs/src/main/pan/components/gpfs/schema.pan
+++ b/ncm-gpfs/src/main/pan/components/gpfs/schema.pan
@@ -37,6 +37,7 @@ type gpfs_sysmon_common = {
 
 type gpfs_sysmon_network = {
     include gpfs_sysmon_common
+    'ib_rdma_monitor_portstate' ? boolean
 };
 
 type gpfs_sysmon = {


### PR DESCRIPTION
option to disable mmhealth ib_rdma_monitor_portstate check