### PR TITLE
ncm-metaconfig: udev: add more udev rules

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/udev/action_attr.tt
+++ b/ncm-metaconfig/src/main/metaconfig/udev/action_attr.tt
@@ -1,0 +1,5 @@
+[%- FOREACH line IN action_attrs -%] 
+[%      FOREACH attr IN line.attributes -%]
+ACTION=="[% line.action %]", SUBSYSTEM=="[% line.subsystem  %]", ATTR{[% CCM.unescape(attr.key) %]}="[% attr.value %]"
+[%      END -%]
+[%- END -%]

--- a/ncm-metaconfig/src/main/metaconfig/udev/pan/action_attr.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/pan/action_attr.pan
@@ -1,0 +1,14 @@
+unique template metaconfig/udev/action_attr;
+
+include 'metaconfig/udev/schema';
+
+prefix "/software/components/metaconfig/services/{/etc/udev/rules.d/50-attrs.rules}";
+
+"mode" = 0644;
+"owner" = "root";
+"group" = "root";
+"module" = "udev/action_attr";
+
+bind "/software/components/metaconfig/services/{/etc/udev/rules.d/50-attrs.rules}/contents/action_attrs" =
+    udev_action_attrs;
+

--- a/ncm-metaconfig/src/main/metaconfig/udev/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/pan/schema.pan
@@ -15,3 +15,10 @@ type udev_scsi_run = string[];
 type udev_dm_run = string[];
 type udev_nvme_run = string[];
 
+type udev_action_attr = {
+    'action' : string
+    'subsystem' : string
+    'attributes' : string{}
+};
+
+type udev_action_attrs = udev_action_attr[];

--- a/ncm-metaconfig/src/main/metaconfig/udev/tests/profiles/action_attr.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/tests/profiles/action_attr.pan
@@ -1,0 +1,12 @@
+object template action_attr;
+
+include 'metaconfig/udev/action_attr';
+
+prefix "/software/components/metaconfig/services/{/etc/udev/rules.d/50-attrs.rules}/contents";
+prefix "action_attrs/0";
+
+'action' = 'add|change';
+'subsystem' = 'block';
+'attributes/{queue/rotational}' = '0';
+'attributes/justsomekey' = 'ok';
+

--- a/ncm-metaconfig/src/main/metaconfig/udev/tests/regexps/action_attr/base
+++ b/ncm-metaconfig/src/main/metaconfig/udev/tests/regexps/action_attr/base
@@ -1,0 +1,7 @@
+Base test for udev action attrs config
+---
+multiline
+metaconfigservice=/etc/udev/rules.d/50-attrs.rules
+---
+^ACTION=="add|change", SUBSYSTEM=="block", ATTR{justsomekey}="ok"$
+^ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}="0"$


### PR DESCRIPTION
some basic structure to set attributes on (block)devices