### PR TITLE
ncm-openvpn: Modified to use generic "service" command rather than init.d script

### DIFF
--- a/ncm-openvpn/src/main/perl/openvpn.pm
+++ b/ncm-openvpn/src/main/perl/openvpn.pm
@@ -115,7 +115,7 @@ sub Configure
 
     if ($changed) {
 	$self->verbose("Restarting OpenVPN daemon");
-	CAF::Process->new([qw(/etc/init.d/openvpn restart)],
+	CAF::Process->new([qw(/sbin/service openvpn restart)],
 			  log => $self)->run();
 	return !$?;
     }


### PR DESCRIPTION
Since EL7+ uses systemd, calling /etc/init.d scripts is no longer supported for service control. The generic command 'service' works on either sysvinit or systemd, so is backwards and forwards compatible.
