### PR TITLE
ncm-ntpd: Add support for the 'interface' directive

### DIFF
--- a/ncm-ntpd/src/main/pan/components/ntpd/schema.pan
+++ b/ncm-ntpd/src/main/pan/components/ntpd/schema.pan
@@ -96,6 +96,14 @@ type ntpd_system_options = {
     "stats" ? boolean
 };
 
+@documentation{
+    Defines a single rule for the "interface" statement. See the ntp_misc manpage.
+}
+type ntpd_interface_options = {
+    "action" : choice("listen", "ignore", "drop")
+    "match" : string
+};
+
 # logging configuration
 function valid_ntpd_logconfig_list = {
     # Loop over each component.
@@ -211,4 +219,6 @@ type ${project.artifactId}_component = {
     "enablelocalhostdebug" ? boolean = true
     @{if the group is set, files are written with root.group ownership and 0640 permission}
     "group" ? defined_group
+    @{Rules for which interfaces/addresses should the daemon listen on}
+    "interface" ? ntpd_interface_options[]
 };

--- a/ncm-ntpd/src/main/perl/ntpd.pm
+++ b/ncm-ntpd/src/main/perl/ntpd.pm
@@ -264,6 +264,12 @@ sub write_ntpd_config
         print $fh "restrict " . $$client[0] . " mask " . $$client[1] . " nomodify notrap\n";
     }
 
+    if ($cfg->{interface}) {
+        foreach my $rule (@{$cfg->{interface}}) {
+            print $fh "interface " . $rule->{action} . " " . $rule->{match} . "\n";
+        }
+    }
+
     # logfile
     if ($cfg->{logfile}) {
         print $fh "\nlogfile $cfg->{logfile}\n";

--- a/ncm-ntpd/src/test/perl/configure.t
+++ b/ncm-ntpd/src/test/perl/configure.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Quattor qw(no_timeservers only_timeservers only_timeservers_useserverip simple_serverlist disable_options group);
+use Test::Quattor qw(no_timeservers only_timeservers only_timeservers_useserverip simple_serverlist disable_options group interface);
 use NCM::Component::ntpd;
 use CAF::Object;
 use Test::MockModule;
@@ -53,6 +53,15 @@ Test::Quattor::RegexpTest->new(
     text => "$fh",
     )->test();
 
+$cfg = get_config_for_profile('interface');
+is( $cmp->Configure($cfg), 1, "Component runs correctly with interface profile" );
+
+$fh = get_file($NCM::Component::ntpd::NTPDCONF);
+isa_ok($fh, "CAF::FileWriter", "This is a CAF::FileWriter file written");
+Test::Quattor::RegexpTest->new(
+    regexp => 'src/test/resources/regexps/interface',
+    text => "$fh",
+    )->test();
 
 
 my $stfh = get_file($NCM::Component::ntpd::STEPTICKERS);

--- a/ncm-ntpd/src/test/resources/interface.pan
+++ b/ncm-ntpd/src/test/resources/interface.pan
@@ -1,0 +1,9 @@
+object template interface;
+
+include 'only_timeservers_base';
+
+prefix "/software/components/ntpd";
+
+'interface' = append(dict('action', 'listen', 'match', 'eth0'));
+'interface' = append(dict('action', 'ignore', 'match', '192.168.0.0/16'));
+'interface' = append(dict('action', 'drop', 'match', 'ipv6'));

--- a/ncm-ntpd/src/test/resources/regexps/interface
+++ b/ncm-ntpd/src/test/resources/regexps/interface
@@ -1,0 +1,20 @@
+simple_servlist ntpd.conf
+---
+---
+^# This file is under ncm-ntpd control.$
+^restrict default ignore$
+^# Servers$
+^server\s+localhost\s+$
+^restrict\s+localhost mask 255.255.255.255 nomodify notrap noquery$
+^server\s+127.0.0.1\s+$
+^restrict 127.0.0.1 mask 255.255.255.255 nomodify notrap noquery$
+^server\s+localhost\s+$
+^restrict\s+localhost mask 255.255.255.255 nomodify notrap noquery$
+^# add localhost in case of network outages$
+^fudge\s+127.127.1.0 stratum 10$
+^# Allow some debugging via ntpdc, but no modifications$
+^restrict 127.0.0.1 nomodify notrap$
+^restrict ::1 nomodify notrap$
+^interface listen eth0$
+^interface ignore 192\.168\.0\.0/16$
+^interface drop ipv6$


### PR DESCRIPTION
Supersedes #1437 which was messed up by trying to use the webUI to make minor edits.