### PR TITLE
ncm-systemd: add support for resource control in units

### DIFF
--- a/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
+++ b/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
@@ -56,6 +56,9 @@ bind "/unitfile" = systemd_unitfile_config[];
         'RuntimeDirectory', list('foo/bar', 'tmp'),
         'RuntimeDirectoryMode', '0777',
         'RuntimeDirectoryPreserve', 'restart',
+        'MemoryAccounting', true,
+        'MemoryLimit', 1024,
+        'BlockIODeviceWeight', list(list('/var', '100'), list('/tmp', '50')),
         ),
     'socket', dict(
         'ExecStartPre', list('/some/path arg1', '-/some/other/path arg2'),

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -10,6 +10,8 @@ contentspath=/unitfile/0
 ^WantedBy=1.service$
 ^WantedBy=2.service$
 ^\[Service\]$
+^BlockIODeviceWeight=/var 100$
+^BlockIODeviceWeight=/tmp 50$
 ^CPUAffinity=$
 ^CPUAffinity=1 2 3 4$
 ^Environment="VAR1-1=val1-1 val1-1b" "VAR1-2=val1-2" $
@@ -19,6 +21,8 @@ contentspath=/unitfile/0
 ^ExecStart=/usr/bin/special$
 ^LimitNPROC=100$
 ^LimitSTACK=infinity$
+^MemoryAccounting=yes$
+^MemoryLimit=1024$
 ^RuntimeDirectory=foo/bar tmp$
 ^RuntimeDirectoryMode=0777$
 ^RuntimeDirectoryPreserve=restart$

--- a/ncm-systemd/src/main/resources/unitfile/service-socket.tt
+++ b/ncm-systemd/src/main/resources/unitfile/service-socket.tt
@@ -1,5 +1,5 @@
 [%- # all Limit except NICE (schema doesn't allow NICE)
     long_infinity = ['LimitAS', 'LimitCORE', 'LimitCPU', 'LimitDATA', 'LimitFSIZE', 'LimitLOCKS', 'LimitMEMLOCK', 'LimitMSGQUEUE', 'LimitNOFILE', 'LimitNPROC', 'LimitRSS', 'LimitRTPRIO', 'LimitRTTIME' 'LimitSIGPENDING', 'LimitSTACK'];
-    list_of_lines = ['CPUAffinity', 'Environment', 'EnvironmentFile', 'ExecStart', 'ExecStartPre', 'ExecStartPost', 'ExecReload', 'ExecStop', 'ExecStopPost', 'ListenStream', 'ListenDatagram', 'ListenSequentialPacket'];
+    list_of_lines = ['BlockIODeviceWeight', 'BlockIOReadBandwidth', 'BlockIOWriteBandwidth', 'CPUAffinity', 'DeviceAllow', 'Environment', 'EnvironmentFile', 'ExecStart', 'ExecStartPre', 'ExecStartPost', 'ExecReload', 'ExecStop', 'ExecStopPost', 'ListenStream', 'ListenDatagram', 'ListenSequentialPacket'];
 -%]
 [% INCLUDE 'systemd/unitfile/section.tt' data=data -%]


### PR DESCRIPTION
This PR add support for the resource control options in systemd units.

Based on #1484.