### PR TITLE
ncm-metaconfig: add support for slurm 20.11

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/slurm/gres.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/gres.tt
@@ -4,5 +4,5 @@
 [%  FOREACH node IN CCM.contents.Nodes %]
 NodeName=[% node.NodeName.join(',') %] [% -%]
 [%- node.delete('NodeName'); 
-    INCLUDE 'metaconfig/slurm/params.tt' data=node join=' ' -%]
+    INCLUDE 'metaconfig/slurm/params.tt' data=node boolvalue=1 join=' ' -%]
 [%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/slurm/gres.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/gres.tt
@@ -1,0 +1,8 @@
+[%  FOREACH pair IN CCM.contents.Default %]
+[%     pair.key %]=[% pair.value -%]
+[%- END %]
+[%  FOREACH node IN CCM.contents.Nodes %]
+NodeName=[% node.NodeName.join(',') %] [% -%]
+[%- node.delete('NodeName'); 
+    INCLUDE 'metaconfig/slurm/params.tt' data=node join=' ' -%]
+[%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/slurm/job_container.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/job_container.tt
@@ -1,0 +1,8 @@
+[%  FOREACH pair IN CCM.contents.Default %]
+[%     pair.key %]=[% pair.value -%]
+[%- END %]
+[%  FOREACH node IN CCM.contents.Nodes %]
+NodeName=[% node.NodeName.join(',') %] [% -%]
+[%- node.delete('NodeName'); 
+    INCLUDE 'metaconfig/slurm/params.tt' data=node boolvalue=1 join=' ' -%]
+[%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/slurm/job_container.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/job_container.tt
@@ -1,8 +1,0 @@
-[%  FOREACH pair IN CCM.contents.Default %]
-[%     pair.key %]=[% pair.value -%]
-[%- END %]
-[%  FOREACH node IN CCM.contents.Nodes %]
-NodeName=[% node.NodeName.join(',') %] [% -%]
-[%- node.delete('NodeName'); 
-    INCLUDE 'metaconfig/slurm/params.tt' data=node boolvalue=1 join=' ' -%]
-[%- END %]

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/config.pan
@@ -21,4 +21,5 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}";
 "group" = "root";
 "mode" = 0644;
 "module" = "slurm/config";
+"convert/unescapekey" = true;
 "daemons" = if(length(SLURM_DAEMONS) > 0) SLURM_DAEMONS else null;

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/dbd.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/dbd.pan
@@ -6,8 +6,8 @@ include 'metaconfig/slurm/schema';
 bind "/software/components/metaconfig/services/{/etc/slurm/slurmdbd.conf}/contents" = slurm_dbd_conf;
 
 prefix "/software/components/metaconfig/services/{/etc/slurm/slurmdbd.conf}";
-"owner" = "root";
-"group" = "root";
-"mode" = 0644;
+"owner" = "slurm";
+"group" = "slurm";
+"mode" = 0600;
 "module" = "slurm/dbd";
 "daemons/slurmdbd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/gres.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/gres.pan
@@ -1,0 +1,13 @@
+unique template metaconfig/slurm/gres;
+
+include 'components/metaconfig/config';
+include 'metaconfig/slurm/schema';
+
+bind "/software/components/metaconfig/services/{/etc/slurm/gres.conf}/contents" = slurm_gres_conf;
+
+prefix "/software/components/metaconfig/services/{/etc/slurm/gres.conf}";
+"owner" = "root";
+"group" = "root";
+"mode" = 0644;
+"module" = "slurm/gres";
+"daemons/slurmd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/job_container.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/job_container.pan
@@ -1,0 +1,14 @@
+unique template metaconfig/slurm/job_container;
+
+include 'components/metaconfig/config';
+include 'metaconfig/slurm/schema';
+
+bind "/software/components/metaconfig/services/{/etc/slurm/job_container.conf}/contents" = slurm_job_container_conf;
+
+prefix "/software/components/metaconfig/services/{/etc/slurm/job_container.conf}";
+"owner" = "root";
+"group" = "root";
+"mode" = 0644;
+"module" = "slurm/job_container";
+"convert/truefalse" = true;
+"daemons/slurmd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/job_container.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/job_container.pan
@@ -9,6 +9,6 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/job_container.conf}
 "owner" = "root";
 "group" = "root";
 "mode" = 0644;
-"module" = "slurm/job_container";
+"module" = "slurm/gres";
 "convert/truefalse" = true;
 "daemons/slurmd" = "restart";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -243,7 +243,7 @@ type slurm_conf_control = {
     'GroupUpdateForce' ? boolean # 0/1
     'GroupUpdateTime' ? long(0..)
     'JobCheckpointDir' ? absolute_file_path
-    'JobContainerType' ? choice('cncu', 'none')
+    'JobContainerType' ? choice('cncu', 'tmpfs', 'none')
     'JobCredentialPrivateKey' ? absolute_file_path
     'JobCredentialPublicCertificate' ? absolute_file_path
     'JobFileAppend' ? boolean # 0/1
@@ -713,4 +713,20 @@ type slurm_dbd_conf = {
     'TCPTimeout' ? long(0..)
     'TrackWCKey' ? boolean
     'TrackSlurmctldDown' ? boolean
+};
+
+type slurm_job_container_per_node_conf = {
+    'AutoBasePath' ? boolean
+    'Basepath' ? absolute_file_path
+    'InitScript' ? absolute_file_path
+};
+
+type slurm_job_container_node_conf = {
+    include slurm_job_container_per_node_conf
+    'NodeName' : string[]
+};
+
+type slurm_job_container_conf = {
+    'Default' ? slurm_job_container_per_node_conf
+    'Nodes' ? slurm_job_container_node_conf[]
 };

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -86,7 +86,7 @@ type slurm_scheduler_parameters = {
     'bf_yield_interval' ? long(0..)
     'bf_yield_sleep' ? long(0..)
     'build_queue_timeout' ? long(0..)
-    'default_queue_depth' ? long(0..)
+    'default_5fqueue_5fdepth' ? long(0..)   # escaped version, otherwise unescaping produces some weird unicode
     'defer' ? boolean
     'delay_boot' ? long(0..)
     'default_gbytes' ? boolean

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -86,7 +86,7 @@ type slurm_scheduler_parameters = {
     'bf_yield_interval' ? long(0..)
     'bf_yield_sleep' ? long(0..)
     'build_queue_timeout' ? long(0..)
-    'default_5fqueue_5fdepth' ? long(0..)   # escaped version, otherwise unescaping produces some weird unicode
+    '{default_queue_depth}' ? long(0..)
     'defer' ? boolean
     'delay_boot' ? long(0..)
     'default_gbytes' ? boolean
@@ -95,7 +95,7 @@ type slurm_scheduler_parameters = {
     'enable_user_top' ? boolean
     'Ignore_NUMA' ? boolean
     'inventory_interval' ? long(0..)
-    'kill_5finvalid_5fdepend' ? boolean
+    '{kill_invalid_depend}' ? boolean
     'max_array_tasks' ? long(0..)   # should be smaller than MaxArraySize
     'max_depend_depth' ? long(0..)
     'max_rpc_cnt' ? long(0..)

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -730,3 +730,24 @@ type slurm_job_container_conf = {
     'Default' ? slurm_job_container_per_node_conf
     'Nodes' ? slurm_job_container_node_conf[]
 };
+
+type slurm_gres_autodetect_conf = {
+    'AutoDetect' ? choice('nvml', 'rsmi', 'off')
+};
+
+type slurm_gres_per_node_conf = {
+    include slurm_gres_autodetect_conf
+    'NodeName' : string[]
+    'Cores' ? long[]
+    'Count' ? long(0..)
+    'File' ? absolute_file_path
+    'Flags' ? choice('CountOnly')[]
+    'Links' ? long(0..)[]
+    'Name' ? choice('gpu', 'mps', 'nic', 'mic')
+    'Type' ? string
+};
+
+type slurm_gres_conf = {
+    'Default' ? slurm_gres_autodetect_conf
+    'Nodes' ? slurm_gres_per_node_conf[]
+};

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -668,6 +668,8 @@ type slurm_dbd_conf = {
     'ArchiveSuspend' ? boolean
     'ArchiveTXN' ? boolean
     'ArchiveUsage' ? boolean
+    'AuthAltParameters' ? slurm_authalt_params
+    'AuthAltTypes' ? choice('jwt')
     'AuthInfo' ? string
     'AuthType' ? choice('none', 'munge')
     'CommitDelay' ? long(1..)

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -95,7 +95,7 @@ type slurm_scheduler_parameters = {
     'enable_user_top' ? boolean
     'Ignore_NUMA' ? boolean
     'inventory_interval' ? long(0..)
-    'kill_invalid_depend' ? boolean
+    'kill_5finvalid_5fdepend' ? boolean
     'max_array_tasks' ? long(0..)   # should be smaller than MaxArraySize
     'max_depend_depth' ? long(0..)
     'max_rpc_cnt' ? long(0..)

--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -179,16 +179,27 @@ type slurm_mpi_params = {
 type slurm_launch_params = {
     'batch_step_set_cpu_freq' ? boolean
     'cray_net_exclusive' ? boolean
+    'disable_send_gids' ? boolean
+    'enable_nss_slurm' ? boolean
     'lustre_no_flush' ? boolean
     'mem_sort' ? boolean
+    'mpir_use_nodeaddr' ? boolean
     'send_gids' ? boolean
     'slurmstepd_memlock' ? boolean
     'slurmstepd_memlock_all' ? boolean
     'test_exec' ? boolean
+    'use_interactive_step' ? boolean
+};
+
+type slurm_authalt_params = {
+    'disable_token_creation' ? boolean
+    'jwt_key' ? absolute_file_path
 };
 
 type slurm_conf_control = {
     'AllowSpecResourcesUsage' ? long(0..1)  # actually a boolean, defaults to 0 for non-Cray systems
+    'AuthAltParameters' ? slurm_authalt_params
+    'AuthAltTypes' ? choice('jwt')
     'AuthInfo' ? string[]
     'AuthType' ? choice('none', 'munge')
     'BackupController' ? string
@@ -196,6 +207,7 @@ type slurm_conf_control = {
     'BurstBufferType' ? choice('none', 'datawarp')
     'CheckpointType' ? choice('blcr', 'none', 'ompi')
     'ChosLoc' ? absolute_file_path  # see https://github.com/scanon/chos
+    'CliFilterPlugins' ? string[]
     'ClusterName' : string
     'CompleteWait' ? long(0..65535)
     'ControlMachine' : string
@@ -304,6 +316,20 @@ type slurm_conf_prolog_epilog = {
     'TaskProlog' ? absolute_file_path
 };
 
+type slurm_ctld_parameters = {
+    'allow_user_triggers' ? boolean
+    'cloud_dns' ? boolean
+    'cloud_reg_addrs' ? boolean
+    'enable_configless' ? boolean
+    'idle_on_node_suspend' ? boolean
+    'power_save_interval' ? long(0..)
+    'power_save_min_interval' ? long(0..)
+    'max_dbd_msg_action' ? choice('discard', 'exit')
+    'preempt_send_user_signal' ? boolean
+    'reboot_from_controller' ? boolean
+    'user_resv_delete' ? boolean
+};
+
 type slurm_conf_process = {
     'MCSParameters' ? dict # see https://slurm.schedmd.com/mcs.html
     'MCSPlugin' ? choice( 'none', 'account', 'group', 'user')
@@ -313,6 +339,7 @@ type slurm_conf_process = {
 
     'SlurmUser' ? string
     'SlurmdUser' ? string
+    'SlurmctldParameters' ? slurm_ctld_parameters
     'SlurmctldPidFile' ? absolute_file_path
     'SlurmctldPlugstack' ? string[]
     @{a port range}

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
@@ -25,6 +25,7 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 "GroupUpdateForce" = false;
 "GroupUpdateTime" = 600;
 "JobCheckpointDir" = "/var/spool/slurm/checkpoint";
+"JobContainerType" = "tmpfs";
 #JobCredentialPrivateKey=
 #JobCredentialPublicCertificate=
 #JobFileAppend=0
@@ -155,7 +156,6 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 #JobCompPort=
 "JobCompType" = "filetxt";
 #JobCompUser=
-#JobContainerType=job_container/none
 "JobAcctGatherFrequency" = dict(
     "network", 30,
     "energy", 10,

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
@@ -10,6 +10,8 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 #ControlAddr = ;
 #BackupController = ;
 #BackupAddr = ;
+"AuthAltParameters" = dict("jwt_key", "/etc/slurm/jwt.key");
+"AuthAltTypes" = "jwt";
 "AuthType" = "munge";
 "CryptoType" = "munge";
 "ClusterName" = "thecluster";
@@ -30,6 +32,7 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 "JobSubmitPlugins" = list("lua", "pbs");
 #KillOnBadExit=0
 #LaunchType=launch/slurm
+"LaunchParameters" = dict("use_interactive_step", true);
 #Licenses=foo*4,bar
 "MailProg" = "/bin/mail";
 "MaxJobCount" = 5000;
@@ -55,6 +58,10 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 
 prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/contents/process";
 
+"SlurmctldParameters" = dict(
+    "preempt_send_user_signal", true,
+    "power_save_interval", 20,
+);
 "SlurmctldPidFile" = "/var/run/slurmctld.pid";
 "SlurmctldPort" = list(6817);
 "SlurmdPidFile" = "/var/run/slurmd.pid";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
@@ -107,7 +107,7 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 #SchedulerTimeSlice = 30;
 "SchedulerType" = "backfill";
 "SchedulerParameters" = dict(
-    "default_queue_depth", 128,
+    "default_5fqueue_5fdepth", 128,
     "bf_max_job_test", 1024,
     "bf_continue", true,
     "bf_window", 4320,

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
@@ -107,7 +107,7 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 #SchedulerTimeSlice = 30;
 "SchedulerType" = "backfill";
 "SchedulerParameters" = dict(
-    "default_5fqueue_5fdepth", 128,
+    "{default_queue_depth}", 128,
     "bf_max_job_test", 1024,
     "bf_continue", true,
     "bf_window", 4320,

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/gres.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/gres.pan
@@ -1,0 +1,31 @@
+object template gres;
+
+function pkg_repl = { null; };
+include 'metaconfig/slurm/gres';
+'/software/components/metaconfig/dependencies' = null;
+
+prefix "/software/components/metaconfig/services/{/etc/slurm/gres.conf}/contents";
+'Default' = dict(
+    'AutoDetect', 'off',
+);
+'Nodes' = list(
+    dict(
+        'NodeName', list('node001', 'node005'),
+        'AutoDetect', 'nvml',
+    ),
+    dict(
+        'NodeName', list('node002'),
+        'AutoDetect', 'off',
+        'Name', 'mps',
+        'File', '/dev/nvidia[0-3]',
+        'Type', 'TeslaP100',
+    ),
+    dict(
+        'NodeName', list('node003'),
+        'Name', 'mps',
+        'File', '/dev/nvidia1',
+        'Count', 100,
+        'Cores', list(2, 4),
+        'Flags', list('CountOnly'),
+    ),
+);

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/job_container.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/job_container.pan
@@ -1,0 +1,18 @@
+object template job_container;
+
+function pkg_repl = { null; };
+include 'metaconfig/slurm/job_container';
+'/software/components/metaconfig/dependencies' = null;
+
+prefix "/software/components/metaconfig/services/{/etc/slurm/job_container.conf}/contents";
+'Default' = dict(
+    'AutoBasePath', true,
+    'Basepath', '/var/tmp/slurm',
+);
+'Nodes' = list(
+    dict(
+        'AutoBasePath', true,
+        'Basepath', '/tmp/slurm',
+        'NodeName', list('node001', 'node005'),
+    ),
+);

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/config/base
@@ -17,6 +17,8 @@ JobCompType=jobcomp/filetxt
 
 # control
 
+AuthAltParameters=jwt_key=/etc/slurm/jwt.key
+AuthAltTypes=auth/jwt
 AuthType=auth/munge
 ClusterName=thecluster
 ControlMachine=master.example.com
@@ -28,6 +30,7 @@ GroupUpdateForce=NO
 GroupUpdateTime=600
 JobCheckpointDir=/var/spool/slurm/checkpoint
 JobSubmitPlugins=lua,pbs
+LaunchParameters=use_interactive_step
 MailProg=/bin/mail
 MaxJobCount=5000
 MaxJobId=9999999
@@ -78,6 +81,7 @@ PriorityWeightJobSize=2500
 # process
 
 SlurmUser=slurm
+SlurmctldParameters=power_save_interval=20,preempt_send_user_signal
 SlurmctldPidFile=/var/run/slurmctld.pid
 SlurmctldPort=6817
 SlurmdPidFile=/var/run/slurmd.pid

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/config/base
@@ -29,6 +29,7 @@ FirstJobId=1
 GroupUpdateForce=NO
 GroupUpdateTime=600
 JobCheckpointDir=/var/spool/slurm/checkpoint
+JobContainerType=job_container/tmpfs
 JobSubmitPlugins=lua,pbs
 LaunchParameters=use_interactive_step
 MailProg=/bin/mail

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/gres/base
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/gres/base
@@ -1,0 +1,11 @@
+Config file for slurm gres
+---
+/etc/slurm/gres.conf
+quote
+---
+
+AutoDetect=off
+
+NodeName=node001,node005 AutoDetect=nvml
+NodeName=node002 AutoDetect=off File=/dev/nvidia\[0-3\] Name=mps Type=TeslaP100
+NodeName=node003 Cores=2,4 Count=100 File=/dev/nvidia1 Flags=CountOnly Name=mps

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/job_container/base
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/job_container/base
@@ -1,0 +1,10 @@
+Config file for slurm job_container
+---
+/etc/slurm/job_container.conf
+quote
+---
+
+AutoBasePath=true
+Basepath=/var/tmp/slurm
+
+NodeName=node001,node005 AutoBasePath=YES Basepath=/tmp/slurm

--- a/ncm-metaconfig/src/main/metaconfig/slurm/type.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/type.tt
@@ -7,6 +7,7 @@
         JobComp = 'jobcomp'
         Scheduler = 'sched'
         Storage = 'accounting_storage' # from dbd
+        AuthAlt = 'auth'
     };
     IF shortname == 'DefaultStorage';
         prefix = '';

--- a/ncm-metaconfig/src/main/metaconfig/slurm/value.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/value.tt
@@ -1,4 +1,4 @@
-[%- IF key.match('(Type|Plugin)$') -%]
+[%- IF key.match('(Types?|Plugin)$') -%]
 [%-     INCLUDE 'metaconfig/slurm/type.tt' name=key data=value -%]
 [%- ELSIF key.match('(Frequency|Param((eter)?s)?)$') -%]
 [%-     INCLUDE 'metaconfig/slurm/params.tt' data=value -%]


### PR DESCRIPTION
This builds on top of #1422 and add/changes a couple of things so it works with slurm 20.11