### PR TITLE
gh action test: first download all maven dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -43,7 +43,9 @@ jobs:
         # make sure it exists before chown
         mkdir -p /tmp/m2
         chown -R nobody:nobody . /tmp/m2
-        su --shell /bin/bash --preserve-environment --command="source /usr/bin/mvn_test.sh && mvn_test" nobody
+        # we have to run as a non-root user to pass the spma tests
+        # secondly, we first download all maven dependencies and then run the tests because it fails with hanging downloads otherwise.
+        runuser --shell /bin/bash --preserve-environment --command "source /usr/bin/mvn_test.sh && mvn_run \"dependency:resolve $MVN_ARGS\" && mvn_test" nobody
       env:
         QUATTOR_TEST_TEMPLATE_LIBRARY_CORE: /tmp/template-library-core-master
         MVN_ARGS: -Dmaven.repo.local=/tmp/m2


### PR DESCRIPTION
For reason unknown to me, downloading maven dependencies can fail if you run it with github actions. First downloading all dependencies and then running the tests does seem to work consistently.

@ned21 this works (so far) all the time for me. The caching with github action doesn't seem to be 100% reliable. Sometimes it gets a hit, sometimes not.