### PR TITLE
ncm-metaconfig: fix GresTypes in slurm config

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/pan/schema.pan
@@ -480,6 +480,7 @@ type slurm_conf_compute_nodes = {
     'Boards' ? long(0..)
     'CoreSpecCount' ? long(0..)
     'CoresPerSocket' ? long(0..)
+    'CpuBind' ? choice('none', 'board', 'socket', 'ldom', 'core', 'thread')
     'CPUs' ? long(0..)
     'CpuSpecList' ? long(0..)[]
     'Feature' ? string[]
@@ -532,9 +533,13 @@ type slurm_conf_partition = {
     'AllowGroups' ? string[]
     'AllowQos' ? string[]
     'Alternate' ? string
+    'CpuBind' ? choice('none', 'board', 'socket', 'ldom', 'core', 'thread')
     'Default' ? boolean
+    'DefCpuPerGPU' ? long(0..)
     @{in megabytes}
     'DefMemPerCPU' ? long(0..)
+    @{in megabytes}
+    'DefMemPerGPU' ? long(0..)
     @{in megabytes}
     'DefMemPerNode' ? long(0..)
     'DenyAccounts' ? string[]

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/profiles/config.pan
@@ -21,7 +21,7 @@ prefix "/software/components/metaconfig/services/{/etc/slurm/slurm.conf}/content
 #EpilogSlurmctld=
 "FirstJobId" = 1;
 "MaxJobId" = 9999999;
-#GresTypes=
+"GresTypes" = list("gpu", "mps");
 "GroupUpdateForce" = false;
 "GroupUpdateTime" = 600;
 "JobCheckpointDir" = "/var/spool/slurm/checkpoint";

--- a/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/config/base
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/tests/regexps/config/base
@@ -26,6 +26,7 @@ CryptoType=crypto/munge
 DisableRootJobs=YES
 EnforcePartLimits=NO
 FirstJobId=1
+GresTypes=gpu,mps
 GroupUpdateForce=NO
 GroupUpdateTime=600
 JobCheckpointDir=/var/spool/slurm/checkpoint

--- a/ncm-metaconfig/src/main/metaconfig/slurm/type.tt
+++ b/ncm-metaconfig/src/main/metaconfig/slurm/type.tt
@@ -8,6 +8,7 @@
         Scheduler = 'sched'
         Storage = 'accounting_storage' # from dbd
         AuthAlt = 'auth'
+        Gres = ''
     };
     IF shortname == 'DefaultStorage';
         prefix = '';


### PR DESCRIPTION
@itkovian FYI, this is currently broken.