### PR TITLE
ncm-network: check if ovs-vswitchd has been initialized to prevent failure

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -476,11 +476,11 @@ sub get_current_config
         $output .= "\nMissing $BRIDGECMD executable.\n";
     };
 
-    if ($self->_is_executable($OVS_VCMD)) {
+    if ($self->_is_executable($OVS_VCMD) && -S "/var/run/openvswitch/db.sock") {
         $output .= "\n$OVS_VCMD show\n";
         $output .= $self->runrun([$OVS_VCMD, "show"]);
     } else {
-        $output .= "\nMissing $OVS_VCMD executable.\n";
+        $output .= "\nMissing $OVS_VCMD executable or socket.\n";
     };
 
     return $output;


### PR DESCRIPTION
If open-vswitch is installed but not running, it prevents the network from being reconfigured:

[VERB] Getting output of command: /usr/bin/ovs-vsctl show
[ERROR] Error '/usr/bin/ovs-vsctl show' output: ovs-vsctl: unix:/var/run/openvswitch/db.sock: database connection failed (No such file or directory)

The suggested change adds a check for the existence of the default database socket before running "ovs-vsctl show".

The only side effect I can imagine is that the change would also not gather the current Open vSwitch status if it's configured to use any database besides the default local socket.