### PR TITLE
ncm-postfix: remove misplaced unused global variables

### DIFF
--- a/ncm-postfix/src/main/pan/components/postfix/schema.pan
+++ b/ncm-postfix/src/main/pan/components/postfix/schema.pan
@@ -64,16 +64,10 @@ type postfix_ldap_database = {
     "tls_cipher_suite" ? string
 };
 
-final variable MINUTES = 60;
-final variable HOURS = MINUTES * 60;
-final variable DAYS = HOURS * 24;
-final variable WEEKS = DAYS * 7;
-
 @{
     All fields available in main.cf. Nothing is mandatory here, since
     it all has default values. Time limits are expressed in
-    SECONDS. Multiply by the appropriate constant above to simplify
-    your code.
+    seconds.
 }
 type postfix_main = {
     "_2bounce_notice_recipient" ? string


### PR DESCRIPTION
As discussed in https://github.com/quattor/configuration-modules-core/pull/1519 the globals defined in the postfix schema should either be in another repo, or they should be removed. As I can't find any use of them in our tree, I'm removing them. However, I don't know if they are used in other sites.