### PR TITLE
Fix types for refactored components

### DIFF
--- a/ncm-pam/src/main/pan/components/pam/schema.pan
+++ b/ncm-pam/src/main/pan/components/pam/schema.pan
@@ -29,58 +29,57 @@ declaration template components/pam/schema;
 
 include 'quattor/schema';
 
-type component_pam_options = extensible {
+type pam_component_options = extensible {
 };
 
-type component_listfile_acl = {
+type pam_component_listfile_acl = {
+
     "filename" : string
     "items" : string[]
 };
 
-type component_pam_module_stack = {
+type pam_component_module_stack = {
     "control" : string with match(SELF, '^(requisite|required|optional|sufficient|[^=]+=[^=]+(\s+[^=]+=[^=]+)*)$')
     "module" : string
-    "options" ? component_pam_options
+    "options" ? pam_component_options
     "options_list" ? string[]
-    "allow" ? component_listfile_acl
-    "deny" ? component_listfile_acl
+    "allow" ? pam_component_listfile_acl
+    "deny" ? pam_component_listfile_acl
 };
 
-type component_pam_service_type = {
-    "auth" ? component_pam_module_stack[]
-    "account" ? component_pam_module_stack[]
-    "password" ? component_pam_module_stack[]
-    "session" ? component_pam_module_stack[]
+type pam_component_service_type = {
+    "auth" ? pam_component_module_stack[]
+    "account" ? pam_component_module_stack[]
+    "password" ? pam_component_module_stack[]
+    "session" ? pam_component_module_stack[]
     "mode" ? string with match(SELF, "0[0-7][0-7][0-7]")
 };
 
-type component_pam_module = {
+type pam_component_module = {
     "path" ? string
 };
 
 # see pam_access(8)
 
-type component_pam_access_entry = {
+type pam_component_access_entry = {
     "permission" : string with match(SELF, "^[-+]$")
     "users" : string
         "origins" : string
 };
 
-type component_pam_access = {
+type pam_component_access = {
     "filename" : string
-    "acl" : component_pam_access_entry[]
-    "lastacl" : component_pam_access_entry
+    "acl" : pam_component_access_entry[]
+    "lastacl" : pam_component_access_entry
     "allowpos" : boolean
     "allowneg" : boolean
 };
 
-type component_pam_entry = {
+type pam_component = {
     include       structure_component
-    "modules" ? component_pam_module{}
-    "services" ? component_pam_service_type{}
+    "modules" ? pam_component_module{}
+    "services" ? pam_component_service_type{}
     "directory" ? string
     "acldir" ? string
-    "access" ? component_pam_access{}
+    "access" ? pam_component_access{}
 };
-
-bind "/software/components/pam" = component_pam_entry;

--- a/ncm-resolver/src/main/pan/components/resolver/schema.pan
+++ b/ncm-resolver/src/main/pan/components/resolver/schema.pan
@@ -15,17 +15,15 @@ include 'quattor/schema';
   introspect these keys, just the type, so new keys can be added to this
   resource and the component will write them.
 }
-type type_resolver_options = {
+type resolver_component_options = {
     'rotate' ? boolean
     'timeout' ? long(0..30)
 };
 
-type component_resolver_type = {
+type resolver_component = {
     include structure_component
     'servers' : type_ip[..3]
     'search' ? type_fqdn[..6] with { length(replace('(^\[ )|,|( \])$', '', to_string(SELF))) <= 256 }
     'dnscache' : boolean = false
-    'options' ? type_resolver_options
+    'options' ? resolver_component_options
 };
-
-bind "/software/components/resolver" = component_resolver_type;


### PR DESCRIPTION
As a result of modernisation and refactoring work done to `ncm-resolver` and `ncm-pam`, the type definitions in the schema need renaming to match the standard format. e.g. `type component_resolver_type` should be `type resolver_component`.

The changes which caused this to be necessary were made in the following PRs, but the breakage was not noticeable at the time as macro expansion only happens during the release process (in this case for a release candidate) when the component templates are updated in the template library.
- quattor/configuration-modules-core#1511
- quattor/configuration-modules-core#1512

The schema should also not be bound to a path in the schema template, as this is inserted into `config.pan` by the macro.

See quattor/release#339.