### PR TITLE
ncm-metaconfig: httpd: Add carevocationcheck configuration option

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
@@ -216,6 +216,7 @@ type httpd_ssl_global = {
     "cacertificatefile" ? string
     "carevocationfile" ? string
     "carevocationpath" ? string
+    "carevocationcheck" ? choice("chain", "leaf", "none")
 
     "verifydepth" ? long
 


### PR DESCRIPTION
This option enables certificate revocation list checking, as per the httpd docs: https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcarevocationcheck

The change is backwards compatiable, as `carevocationcheck` has been added as an optional.