### PR TITLE
ncm-metaconfig: generic: add multiline_exact module (avoids spurious newline)

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/generic/multiline_exact.tt
+++ b/ncm-metaconfig/src/main/metaconfig/generic/multiline_exact.tt
@@ -1,0 +1,1 @@
+[%- CCM.contents.join("\n") -%]

--- a/ncm-metaconfig/src/main/metaconfig/generic/pan/multiline_exact.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/pan/multiline_exact.pan
@@ -1,0 +1,5 @@
+structure template metaconfig/generic/multiline_exact;
+
+include 'metaconfig/generic/multiline';
+
+"module" = "generic/multiline_exact";

--- a/ncm-metaconfig/src/main/metaconfig/generic/tests/profiles/multiline_exact.pan
+++ b/ncm-metaconfig/src/main/metaconfig/generic/tests/profiles/multiline_exact.pan
@@ -1,0 +1,10 @@
+object template multiline_exact;
+
+include 'metaconfig/generic/schema';
+
+# explicit bind with metaconfig_generic_multiline here so it is tested
+bind "/software/components/metaconfig/services/{/a/b/c}/contents" = metaconfig_generic_multiline;
+
+"/software/components/metaconfig/services/{/a/b/c}" = create('metaconfig/generic/multiline',
+    "contents", list("first", "second", "third"),
+    );

--- a/ncm-metaconfig/src/main/metaconfig/generic/tests/regexps/multiline_exact
+++ b/ncm-metaconfig/src/main/metaconfig/generic/tests/regexps/multiline_exact
@@ -1,0 +1,8 @@
+Test multiline_exact string
+---
+/a/b/c
+quote
+---
+first
+second
+third


### PR DESCRIPTION
ncm-metaconfig already adds a newline. A new multiline_exact was added instead of "fixing" multiline itself, so admins can migrate to the correct/exact format