### PR TITLE
ncm-metaconfig: schema updates and tests for elasticsearch 8.1

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config_8.1.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/config_8.1.pan
@@ -1,4 +1,4 @@
-unique template metaconfig/elasticsearch/config;
+unique template metaconfig/elasticsearch/config_8.1;
 
 variable METACONFIG_ELASTICSEARCH_VERSION ?= '8.1';
 include 'metaconfig/elasticsearch/schema';

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema.pan
@@ -21,14 +21,14 @@ type elasticsearch_index_search = {
 
 
 type elasticsearch_translog = {
-    "flush_threshold_ops" : long = 5000 with {deprecated(0, "Removed in ES 5.0"); true;}
+    "flush_threshold_ops" : long = 5000 with {deprecated(0, "Removed in ES 5.0"); true; }
 };
 
 type elasticsearch_index = {
     "number_of_shards" ? long(0..)
-    "number_of_replicas" ? long(0..) with {deprecated(0, "Removed in ES 5.0"); true;}
+    "number_of_replicas" ? long(0..) with {deprecated(0, "Removed in ES 5.0"); true; }
     "search" ? elasticsearch_index_search
-    "refresh" ? long(0..) with {deprecated(0, "Removed in ES 5.0"); true;}
+    "refresh" ? long(0..) with {deprecated(0, "Removed in ES 5.0"); true; }
     "translog" ? elasticsearch_translog
 };
 
@@ -85,8 +85,10 @@ type elasticsearch_discovery_zen = {
 };
 
 type elasticsearch_discovery = {
-    "zen" ? elasticsearch_discovery_zen
+    "zen" ? elasticsearch_discovery_zen with {deprecated(0, "Removed in ES 8.1"); true; }
+    "seed_hosts" ? type_hostport[]
 };
+
 
 @{include version specific types at the end}
 include format('metaconfig/elasticsearch/schema_%s', METACONFIG_ELASTICSEARCH_VERSION);

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema_8.1.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/pan/schema_8.1.pan
@@ -1,0 +1,94 @@
+declaration template metaconfig/elasticsearch/schema_8.1;
+
+@{version specific types for Elasticsearch version 8.1 and later}
+
+type elasticsearch_bootstrap = {
+    "memory_lock" ? boolean
+};
+
+type elasticsearch_path = {
+    "repo" ? absolute_file_path[]
+    "data" : absolute_file_path
+    "logs" : absolute_file_path
+};
+
+@{fixed thread pool}
+type elasticsearch_thread_pool_fixed = {
+    "size" ? long(0..)
+    "queue_size" ? long(-1..)
+};
+
+@{scaling thread pool}
+type elasticsearch_thread_pool_scaling = {
+    "core" ? long(1..)
+    "max" ? long(1..)
+    @{time in seconds to keep idle thread in thread pool}
+    "keep_alive" ? long(0..)
+};
+
+@documentation{
+    Thread pool management.  See
+    http://www.elasticsearch.org/guide/reference/modules/threadpool/
+@}
+type elasticsearch_threadpool = {
+    "generic" ? elasticsearch_thread_pool_scaling
+    "search" ? elasticsearch_thread_pool_fixed
+    "index" ? elasticsearch_thread_pool_fixed
+    "get" ? elasticsearch_thread_pool_fixed
+    "write" ? elasticsearch_thread_pool_fixed  # This replaces the bulk setting, starting with 6.3.0
+    "snapshot" ? elasticsearch_thread_pool_scaling
+    "warmer" ? elasticsearch_thread_pool_scaling
+    "refresh" ? elasticsearch_thread_pool_scaling
+    "listener" ? elasticsearch_thread_pool_scaling
+};
+
+type elasticsearch_xpack_transport_ssl = {
+    "enabled" : boolean
+    "key" : string
+    "certificate" : string
+    "verification_mode" : string with match(SELF, "^(certificate|full|none)$")
+    "certificate_authorities" : absolute_file_path[]
+};
+
+type elasticsearch_xpack_transport = {
+    "ssl" : elasticsearch_xpack_transport_ssl
+};
+
+type elasticsearch_xpack_http_ssl = {
+    "enabled" : boolean
+    "key" : string
+    "certificate" : string
+    "verification_mode" : string with match(SELF, "^(certificate|full|none)$")
+    "certificate_authorities" : absolute_file_path[]
+};
+
+type elasticsearch_xpack_http = {
+    "ssl" : elasticsearch_xpack_http_ssl
+};
+
+type elasticsearch_xpack_security = {
+    "enabled" : boolean
+    "transport" : elasticsearch_xpack_transport
+    "http" : elasticsearch_xpack_http
+};
+
+type elasticsearch_xpack = {
+    "security" : elasticsearch_xpack_security
+};
+
+type elasticsearch_service = {
+    "node" ? elasticsearch_node
+    "index" ? elasticsearch_index
+    "gateway" ? elasticsearch_gw
+    "indices" ? elasticsearch_indices
+    "network" : elasticsearch_network = dict("host", "localhost")
+    "monitor.jvm.gc" : elasticsearch_monitoring = dict()
+    "thread_pool" ? elasticsearch_threadpool
+    "bootstrap" ? elasticsearch_bootstrap
+    "cluster" ? elasticsearch_cluster
+    "transport" ? elasticsearch_transport
+    "discovery" ? elasticsearch_discovery
+    "path" : elasticsearch_path
+    "processors" ? long(1..)
+    "xpack" ? elasticsearch_xpack
+};

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/tests/profiles/config_8.1.pan
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/tests/profiles/config_8.1.pan
@@ -1,0 +1,26 @@
+object template config_8.1;
+
+# 2 4-core cpus
+"/hardware/cpu" = list(dict("cores", 4), dict("cores", 4));
+
+# 8.1 is default
+include 'metaconfig/elasticsearch/config';
+
+prefix "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}/contents/thread_pool";
+"index/size" = length(value("/hardware/cpu")) * value("/hardware/cpu/0/cores");
+"index/queue_size" = 1000;
+"listener/core" = 2;
+"listener/max" = 4;
+"listener/keep_alive" = 30 * 60;
+
+prefix "/software/components/metaconfig/services/{/etc/elasticsearch/elasticsearch.yml}/contents";
+"processors" = 4;
+"indices/memory/index_buffer_size" = "50%";
+"index/number_of_replicas" = 1;
+"bootstrap/memory_lock" = true;
+"network/host" = "myhost.mydomain";
+"node/name" = "myname";
+"discovery/seed_hosts" = list('master1:1234', 'master2:5678');
+"path/data" = "/somewhere/elsewhere";
+"path/logs" = "/somewhere/elsewhere/logs";
+

--- a/ncm-metaconfig/src/main/metaconfig/elasticsearch/tests/regexps/config_8.1/base
+++ b/ncm-metaconfig/src/main/metaconfig/elasticsearch/tests/regexps/config_8.1/base
@@ -1,0 +1,34 @@
+Base test for config
+---
+/etc/elasticsearch/elasticsearch.yml
+---
+^---$
+^bootstrap:$
+^  memory_lock: true$
+^discovery:$
+^  seed_hosts:$
+^  - master1:1234$
+^  - master2:5678$
+^index:$
+^  number_of_replicas: 1$
+^indices:$
+^  memory:$
+^    index_buffer_size: 50%$
+^monitor.jvm.gc:$
+^  enabled: false$
+^network:$
+^  host: myhost.mydomain$
+^node:$
+^  name: myname$
+^path:$
+^  data: /somewhere/elsewhere$
+^  logs: /somewhere/elsewhere/logs$
+^processors: 4$
+^thread_pool:$
+^  index:$
+^    queue_size: 1000$
+^    size: 8$
+^  listener:$
+^    core: 2$
+^    keep_alive: 1800$
+^    max: 4$


### PR DESCRIPTION
ES removed part of the discovery schema in 8.x.