### PR TITLE
ncm-ipmi: Enhancements to IPMI module

### DIFF
--- a/ncm-ipmi/src/main/pan/components/ipmi/schema.pan
+++ b/ncm-ipmi/src/main/pan/components/ipmi/schema.pan
@@ -22,4 +22,3 @@ type component_ipmi_type = {
 };
 
 bind "/software/components/ipmi" = component_ipmi_type;
-

--- a/ncm-ipmi/src/main/pan/components/ipmi/schema.pan
+++ b/ncm-ipmi/src/main/pan/components/ipmi/schema.pan
@@ -2,22 +2,77 @@
 # ${developer-info}
 # ${author-info}
 
-
+@{
+    See Intelligent Platform Management Interface Specification v2.0 rev. 1.1
+    https://www.intel.co.uk/content/www/uk/en/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html
+}
 declaration template components/ipmi/schema;
 
 include 'quattor/schema';
 
 type structure_users = {
-    "login" : string
-    "password" : string
-    "priv" ? string
-    "userid" ? long
+    @{
+        User Name String in ASCII (16 bytes)
+        See IPMI Spec v2.0 rev 1.1 section 22.28 Set User Name Command
+
+        Restricted to only printable ASCII characters
+    }
+    "login" : string_trimmed(1..16) with match(SELF, '^\p{Print}+$')
+
+    @{
+        Password String in ASCII (16/20 bytes)
+        See IPMI Spec v2.0 rev 1.1 section 22.30 Set User Password Command
+
+        Restricted to only printable ASCII characters
+    }
+    "password" : string_trimmed(0..20) with match(SELF, '^\p{Print}+$')
+
+    @{
+        Channel Privilege Level Limit (4 bits)
+        See IPMI Spec v2.0 rev 1.1 section 22.26 Set User Access Command
+
+        Standard Levels:
+            0 = Reserved (not supported)
+            1 = CALLBACK
+            2 = USER
+            3 = OPERATOR
+            4 = ADMINISTRATOR
+            5 = OEM Proprietary
+            15 = No access
+    }
+    "priv" ? long(1..15) with SELF <= 5 || SELF == 15
+
+    @{
+        Numeric User ID (6 bits)
+
+        Standard values:
+            0 = Reserved (not supported)
+            1 = The null user
+    }
+    "userid" ? long(1..63)
 };
 
 type component_ipmi_type = {
     include structure_component
 
-    "channel" : long = 1
+    @{
+        Channel Number (4 bits)
+        See IPMI Spec v2.0 rev 1.1 section 6.3 Channel Numbers
+
+        Standard Channels:
+            0       Primary IPMB (not supported)
+            1-11    Implementation-specific (normal range)
+            12-13   Reserved (not supported)
+            14      Reserved for identifying current channel (not supported)
+            15      System Interface (not supported)
+    }
+    "channel" : long(1..11) = 1
+
+    @{
+        User Configuration
+
+        List of structure_users type.
+    }
     "users" : structure_users[]
 };
 

--- a/ncm-ipmi/src/main/pan/components/ipmi/schema.pan
+++ b/ncm-ipmi/src/main/pan/components/ipmi/schema.pan
@@ -19,7 +19,6 @@ type component_ipmi_type = {
 
     "channel" : long = 1
     "users" : structure_users[]
-    "net_interface" : string
 };
 
 bind "/software/components/ipmi" = component_ipmi_type;

--- a/ncm-ipmi/src/main/perl/ipmi.pm
+++ b/ncm-ipmi/src/main/perl/ipmi.pm
@@ -9,6 +9,15 @@ use CAF::Process;
 use constant IPMI_EXEC => "/usr/bin/ipmitool";
 use constant BASEPATH => "/software/components/ipmi/";
 
+sub ConfigureNetwork {
+  my ($self, $channel) = @_;
+  #Ensure IPMI over LAN is enabled
+  CAF::Process->new([IPMI_EXEC, qw(lan set), $channel, qw(access on)], log => $self)->run();
+  #Set user authentication to use MD5 security (about as good as it gets)
+  CAF::Process->new([IPMI_EXEC, qw(lan set), $channel, qw(auth USER MD5)], log => $self)->run();
+    return;
+}
+
 sub Configure
 {
 
@@ -21,10 +30,6 @@ sub Configure
 
   CAF::Process->new([qw(chkconfig ipmi on)], log => $self)->run();
   CAF::Process->new([qw(service ipmi restart)], log => $self)->run();
-  #Ensure IPMI over LAN is enabled
-  CAF::Process->new([IPMI_EXEC, qw(lan set), $channel, qw(access on)], log => $self)->run();
-  #Set user authentication to use MD5 security (about as good as it gets)
-  CAF::Process->new([IPMI_EXEC, qw(lan set), $channel, qw(auth USER MD5)], log => $self)->run();
 
   for my $user (@{$users}) {
       my $userid = $user->{userid};
@@ -46,16 +51,13 @@ sub Configure
                         log => $self)->run();
   }
 
-  CAF::Process->new([IPMI_EXEC, qw(mc reset cold)],
-                    log => $self)->run();
+  $self->ConfigureNetwork($channel);
+
+  # Reset BMC to ensure changes have been made active
+  CAF::Process->new([IPMI_EXEC, qw(mc reset cold)], log => $self)->run();
 
   return; # return code is not checked.
 }
 
-
-
-sub ConfigureNetwork {
-    return;
-}
 
 1; # Perl module requirement.

--- a/ncm-ipmi/src/main/perl/ipmi.pm
+++ b/ncm-ipmi/src/main/perl/ipmi.pm
@@ -21,6 +21,10 @@ sub Configure
 
   CAF::Process->new([qw(chkconfig ipmi on)], log => $self)->run();
   CAF::Process->new([qw(service ipmi restart)], log => $self)->run();
+  #Ensure IPMI over LAN is enabled
+  CAF::Process->new([IPMI_EXEC, qw(lan set), $channel, qw(access on)], log => $self)->run();
+  #Set user authentication to use MD5 security (about as good as it gets)
+  CAF::Process->new([IPMI_EXEC, qw(lan set), $channel, qw(auth USER MD5)], log => $self)->run();
 
   for my $user (@{$users}) {
       my $userid = $user->{userid};
@@ -28,9 +32,17 @@ sub Configure
       my $passwd = $user->{password};
       my $priv   = $user->{priv};
 
+      #Create and enable user account
       CAF::Process->new([IPMI_EXEC, qw(user set name), $userid, $login],
                         log => $self)->run();
       CAF::Process->new([IPMI_EXEC, qw(user set password), $userid, $passwd],
+                        log => $self)->run();
+      CAF::Process->new([IPMI_EXEC, qw(user set priv), $userid, sprintf("0x%X", $priv)],
+                        log => $self)->run();
+      CAF::Process->new([IPMI_EXEC, qw(user enable), $userid],
+                        log => $self)->run();
+      #Set remote access via LAN
+      CAF::Process->new([IPMI_EXEC, qw(channel setaccess), $channel, $userid, qw(link=on ipmi=on callin=on)],
                         log => $self)->run();
   }
 

--- a/ncm-ipmi/src/main/perl/ipmi.pm
+++ b/ncm-ipmi/src/main/perl/ipmi.pm
@@ -18,7 +18,6 @@ sub Configure
 
   my $users   = $ipmi_config->{users};
   my $channel = $ipmi_config->{channel};
-  my $net_interface = $ipmi_config->{net_interface};
 
   CAF::Process->new([qw(chkconfig ipmi on)], log => $self)->run();
   CAF::Process->new([qw(service ipmi restart)], log => $self)->run();

--- a/ncm-ipmi/src/test/perl/configure.t
+++ b/ncm-ipmi/src/test/perl/configure.t
@@ -28,7 +28,7 @@ Readonly my $CMD => NCM::Component::ipmi::IPMI_EXEC;
 
 $cmp->Configure($cfg);
 
-my $cmd = get_command(join(" ", $CMD, qw(user set name), "userid", "login"));
+my $cmd = get_command(join(" ", $CMD, qw(user set name), "1", "login"));
 ok(defined($cmd), "ipmitool user set name was called");
 
 $cmd = get_command(join(" ", $CMD, qw(mc reset cold)));

--- a/ncm-ipmi/src/test/perl/configure.t
+++ b/ncm-ipmi/src/test/perl/configure.t
@@ -28,11 +28,10 @@ Readonly my $CMD => NCM::Component::ipmi::IPMI_EXEC;
 
 $cmp->Configure($cfg);
 
-my $cmd = get_command(join(" ", $CMD,
-                           qw(user set name), "userid", "login"));
+my $cmd = get_command(join(" ", $CMD, qw(user set name), "userid", "login"));
 ok(defined($cmd), "ipmitool user set name was called");
-$cmd = get_command(join(" ", $CMD, qw(mc reset cold)));
 
-ok(defined($cmd), "mc is reset inconditionally");
+$cmd = get_command(join(" ", $CMD, qw(mc reset cold)));
+ok(defined($cmd), "mc is reset unconditionally");
 
 done_testing();

--- a/ncm-ipmi/src/test/perl/pod-syntax.t
+++ b/ncm-ipmi/src/test/perl/pod-syntax.t
@@ -1,4 +1,3 @@
-
 use Test::More;
 use Test::Pod;
 

--- a/ncm-ipmi/src/test/resources/ipmi.pan
+++ b/ncm-ipmi/src/test/resources/ipmi.pan
@@ -4,7 +4,9 @@ include 'components/ipmi/schema';
 
 prefix "/software/components/ipmi";
 
-"users/0/userid" = "userid";
+"channel" = 1;
+
+"users/0/userid" = 1;
 "users/0/login" = "login";
 "users/0/password" = "password";
-"users/0/priv" = "priv";
+"users/0/priv" = 2;

--- a/ncm-ipmi/src/test/resources/ipmi.pan
+++ b/ncm-ipmi/src/test/resources/ipmi.pan
@@ -1,5 +1,7 @@
 object template ipmi;
 
+include 'components/ipmi/schema';
+
 prefix "/software/components/ipmi";
 
 "users/0/userid" = "userid";


### PR DESCRIPTION
* Add more user account access control functionality including Privilege level
* Explicitly enable IPMI over LAN
* Uses existing variables and structure
* Remove the mandatory, but unused `net_interface` property