### PR TITLE
ncm-chkconfig: ensure that the services property doesn't remain undefined

### DIFF
--- a/ncm-chkconfig/src/main/pan/components/chkconfig/schema.pan
+++ b/ncm-chkconfig/src/main/pan/components/chkconfig/schema.pan
@@ -25,11 +25,11 @@ function chkconfig_allow_combinations = {
         'off', list("on", "reset"),
         'on', list("reset"),
     );
-    foreach(win_svt;svt_list;svt_map) {
+    foreach(win_svt; svt_list; svt_map) {
         if (exists(service[win_svt])) {
-            foreach(idx;svt;svt_list) {
+            foreach(idx; svt; svt_list) {
                 if (exists(service[svt])) {
-                    error(format("Cannot combine '%s' with '%s' (%s would win).", win_svt, svt, win_svt));
+                    error("Cannot combine '%s' with '%s' (%s would win).", win_svt, svt, win_svt);
                 };
             };
         };

--- a/ncm-chkconfig/src/main/pan/components/chkconfig/schema.pan
+++ b/ncm-chkconfig/src/main/pan/components/chkconfig/schema.pan
@@ -49,6 +49,6 @@ type service_type = {
 
 type component_chkconfig_type = {
     include structure_component
-    "service" : service_type{}
+    "service" : service_type{} = dict()
     "default" ? string with match (SELF, '^(ignore|off)$')
 };


### PR DESCRIPTION
- With the migration to ncm-systemd, a configuration can define the legacy module and endup with an invalid
configuration if no service has been added to ncm-chkconfig
