### PR TITLE
ncm-metaconfig: Add service action condrestart

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -84,7 +84,7 @@ type ${project.artifactId}_textrender_convert = {
     true;
 };
 
-type caf_service_action = string with match(SELF, '^(restart|reload|stop_sleep_start)$');
+type caf_service_action = string with match(SELF, '^(restart|condrestart|reload|stop_sleep_start)$');
 
 type ${project.artifactId}_actions = {
     @{Always run, happens before possible modifications.


### PR DESCRIPTION
Current list of allowed service actions includes restart, reload, and stop_sleep_start.
This creates problems when the metaconfig component issues a reload action for a given service on a brand new host.
Since the host is new, that service has never been started, and therefore the reload command fails.
This also prevents the rest of Quattor components depending on metaconfig from running.
To solve this, allow service command condrestart, which works whether the service is already running or not.

Ensure the title of this pull-request starts with the component name followed by a colon, e.g.
> ncm-example: demonstrate what titles should look like

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
* What backwards incompatibility it may introduce.
