### PR TITLE
Don't specify Python 3 minor version

### DIFF
--- a/.github/workflows/panlint.yaml
+++ b/.github/workflows/panlint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3
       - name: Install dependencies
         run: pip install colorama prettytable six
       - name: run panlint


### PR DESCRIPTION
GitHub is updating runner images at the moment which makes the availability of specific versions unpredictable.