### PR TITLE
ncm-modprobe: Change mkinitrd references to dracut

### DIFF
--- a/ncm-modprobe/src/main/perl/modprobe.pm
+++ b/ncm-modprobe/src/main/perl/modprobe.pm
@@ -47,7 +47,7 @@ foreach my $method (qw(alias options install remove blacklist)) {
 use strict 'refs';
 
 # Re-generates the initrds, if needed.
-sub mkinitrd
+sub dracut
 {
     my ($self) = @_;
 
@@ -60,7 +60,7 @@ sub mkinitrd
             my $rl = $1;
             my $target = "/boot/initrd-$rl.img";
             $target = "/boot/initramfs-$rl.img" if -f "/boot/initramfs-$rl.img";
-            CAF::Process->new(["mkinitrd", "-f", $target, $rl], log => $self)->run();
+            CAF::Process->new(["dracut", "-f", $target, $rl], log => $self)->run();
             $self->error("Unable to build the initrd for $rl") if $?;
         }
     }
@@ -83,7 +83,7 @@ sub Configure
     $self->process_remove($t, $fh);
     $self->process_blacklist($t, $fh);
 
-    $self->mkinitrd($fh) if $fh->close();
+    $self->dracut($fh) if $fh->close();
     return 1;
 }
 

--- a/ncm-modprobe/src/test/perl/configure.t
+++ b/ncm-modprobe/src/test/perl/configure.t
@@ -29,7 +29,7 @@ $cmp = Test::MockObject::Extends->new($cmp);
 
 no warnings 'redefine';
 
-my @methods = grep($_ =~ m{^process|mkinitr},
+my @methods = grep($_ =~ m{^process|dracut},
                    @{Class::Inspector->functions("NCM::Component::modprobe")});
 
 foreach my $method (@methods) {
@@ -49,8 +49,8 @@ foreach my $i (@methods) {
 
 $cmp->Configure($cfg);
 foreach my $method (@methods) {
-    if ($method =~ m{mkinitrd}) {
-        is($cmp->{uc($method)}, 1, "mkinitrd is not called if there are no changes");
+    if ($method =~ m{dracut}) {
+        is($cmp->{uc($method)}, 1, "dracut is not called if there are no changes");
     } else {
         is($cmp->{uc($method)}, 2, "Method $method is called inconditionally");
     }

--- a/ncm-modprobe/src/test/perl/dracut.t
+++ b/ncm-modprobe/src/test/perl/dracut.t
@@ -7,9 +7,9 @@
 
 =head1 DESCRIPTION
 
-Test the C<mkinitrd> method.
+Test the C<dracut> method.
 
-Ensures the C<mkinitrd> command will be executed for all the
+Ensures the C<dracut> command will be executed for all the
 C<System.map> files present in a directory.
 
 =cut
@@ -24,7 +24,7 @@ use NCM::Component::modprobe;
 use CAF::FileWriter;
 use CAF::Object;
 
-use constant MKINITRD => "mkinitrd -f /boot/initrd-2.6.35.img 2.6.35";
+use constant DRACUT => "dracut -f /boot/initrd-2.6.35.img 2.6.35";
 
 
 my $mock = Test::MockModule->new('NCM::Component::modprobe');
@@ -36,15 +36,15 @@ $CAF::Object::NoAction = 1;
 my $cmp = NCM::Component::modprobe->new("modprobe");
 
 
-$cmp->mkinitrd();
+$cmp->dracut();
 
-my $cmd = get_command(MKINITRD);
-ok(defined($cmd), "mkinitrd was called");
+my $cmd = get_command(DRACUT);
+ok(defined($cmd), "dracut was called");
 
-set_command_status(MKINITRD, 1);
+set_command_status(DRACUT, 1);
 
-$cmp->mkinitrd();
-is($cmp->{ERROR}, 1, "Errors in mkinitrd are reported");
+$cmp->dracut();
+is($cmp->{ERROR}, 1, "Errors in dracut are reported");
 
 
 done_testing();


### PR DESCRIPTION
mkinitrd is dropped in RHEL9 - in previous OS releases mkinitrd was a wrapper that called dracut, with the options building an args string for dracut.  We only use a single option which is the same for mkinitrd and dracut, so it should be safe to replace mkinitrd references with dracut

Fixes #1577

Ensure the title of this pull-request starts with the component name followed by a colon, e.g.
> ncm-example: demonstrate what titles should look like

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
* What backwards incompatibility it may introduce.
