### PR TITLE
ncm-systemd: add support for slice and more resource control

### DIFF
--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -222,18 +222,29 @@ valid for [Slice], [Scope], [Service], [Socket], [Mount], or [Swap] sections
 type ${project.artifactId}_unitfile_config_systemd_resource_control = {
     'CPUAccounting' ? boolean
     'CPUShares' ? long(2..262144)
+    'CPUWeight' ? long(1..10000)
+    'StartupCPUWeight' ? long(1..10000)
     'StartupCPUShares' ? long(2..262144)
     'CPUQuota' ? long(0..100)  # percentages
     'MemoryAccounting' ? boolean
     'MemoryLimit' ? long  # in bytes
+    'MemoryMin' ? long  # in bytes
+    'MemoryMax' ? long  # in bytes
+    'MemoryLow' ? long  # in bytes
+    'MemoryHigh' ? long  # in bytes
+    'MemorySwapMax' ? long  # in bytes
     'TasksAccounting' ? boolean
     'TasksMax' ? string with match(SELF, '^([0-9]+%?|infinity)$')
     'BlockIOAccounting' ? boolean
     'BlockIOWeight' ? long(10..1000)
+    'IOWeight' ? long(1..10000)
+    'StartupIOWeight' ? long(1..10000)
     'StartupBlockIOWeight' ? long(10..1000)
     'BlockIODeviceWeight' ? ${project.artifactId}_unitfile_config_systemd_resource_control_block_weight[]
     'BlockIOReadBandwidth' ? ${project.artifactId}_unitfile_config_systemd_resource_control_block_weight[]
     'BlockIOWriteBandwidth' ? ${project.artifactId}_unitfile_config_systemd_resource_control_block_weight[]
+    'IPAccounting' ? boolean
+    'IPAddressAllow' ? string[]
     'DeviceAllow' ? ${project.artifactId}_unitfile_config_systemd_resource_control_devicelist[]
     'DevicePolicy' ? choice('auto', 'closed', 'strict')
     'Slice' ? string

--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -407,6 +407,15 @@ type ${project.artifactId}_unitfile_config_timer = {
 };
 
 @documentation{
+the [Slice] section
+http://www.freedesktop.org/software/systemd/man/systemd.slice.html
+}
+type ${project.artifactId}_unitfile_config_slice = {
+    include ${project.artifactId}_unitfile_config_systemd_resource_control
+};
+
+
+@documentation{
 Unit configuration sections
     includes, unit and install are type agnostic
         unit and install are mandatory, but not enforced by schema (possible issues in case of replace=true)
@@ -423,6 +432,7 @@ type ${project.artifactId}_unitfile_config = {
     'automount' ? ${project.artifactId}_unitfile_config_automount
     'timer' ? ${project.artifactId}_unitfile_config_timer
     'unit' ? ${project.artifactId}_unitfile_config_unit
+    'slice' ? ${project.artifactId}_unitfile_config_slice
 };
 
 @documentation{
@@ -463,7 +473,7 @@ type ${project.artifactId}_target = string with match(SELF, "^(default|poweroff|
 type ${project.artifactId}_unit_type = {
     "name" ? string # shortnames are ok; fullnames require matching type
     "targets" : ${project.artifactId}_target[] = list("multi-user")
-    "type" : choice('service', 'target', 'sysv', 'socket', 'mount', 'automount', 'timer') = 'service'
+    "type" : choice('service', 'target', 'sysv', 'socket', 'mount', 'automount', 'timer', 'slice') = 'service'
     "startstop" : boolean = true
     "state" : string = 'enabled' with match(SELF, '^(enabled|disabled|masked)$')
     @{unitfile configuration}

--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -409,7 +409,7 @@ http://www.freedesktop.org/software/systemd/man/systemd.automount.html
 type ${project.artifactId}_unitfile_config_automount = {
     'Where': absolute_file_path
     'DirectoryMode' ? type_octal_mode
-    'TimeoutSec' ? long(0..)
+    'TimeoutIdleSec' ? long(0..)
 };
 
 @documentation{

--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -48,6 +48,23 @@ type ${project.artifactId}_valid_execpath = string with match(SELF, '^([@+!:-]|!
 # type for a relative directory: no leading / and may not include ".."
 type ${project.artifactId}_relative_directory = string with !match(SELF, '(^/|\.\.)');
 
+@documentation{
+    Validate that a property is either a size (in bytes), a relative size (in %)
+    or 'infinity'. Used for memory limits in cgroups.
+}
+function is_absolute_or_relative_size = {
+    l = ARGV[0];
+    if (is_long(l) && l > 0) {
+        return(true);
+    };
+    if (is_string(l) && match(l, '^(infinity|1?[0-9]?[0-9]%)$')) {
+        return(true);
+    };
+    false;
+};
+
+type ${project.artifactId}_absolute_or_relative_size = element with is_absolute_or_relative_size(SELF);
+
 # adding new ones
 # go to http://www.freedesktop.org/software/systemd/man/systemd.directives.html
 # and follow the link to the manual
@@ -227,12 +244,12 @@ type ${project.artifactId}_unitfile_config_systemd_resource_control = {
     'StartupCPUShares' ? long(2..262144)
     'CPUQuota' ? long(0..100)  # percentages
     'MemoryAccounting' ? boolean
-    'MemoryLimit' ? long  # in bytes
-    'MemoryMin' ? long  # in bytes
-    'MemoryMax' ? long  # in bytes
-    'MemoryLow' ? long  # in bytes
-    'MemoryHigh' ? long  # in bytes
-    'MemorySwapMax' ? long  # in bytes
+    'MemoryLimit' ? ${project.artifactId}_absolute_or_relative_size
+    'MemoryMin' ? ${project.artifactId}_absolute_or_relative_size
+    'MemoryMax' ? ${project.artifactId}_absolute_or_relative_size
+    'MemoryLow' ? ${project.artifactId}_absolute_or_relative_size
+    'MemoryHigh' ? ${project.artifactId}_absolute_or_relative_size
+    'MemorySwapMax' ? ${project.artifactId}_absolute_or_relative_size
     'TasksAccounting' ? boolean
     'TasksMax' ? string with match(SELF, '^([0-9]+%?|infinity)$')
     'BlockIOAccounting' ? boolean

--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -261,7 +261,7 @@ type ${project.artifactId}_unitfile_config_systemd_resource_control = {
     'BlockIOReadBandwidth' ? ${project.artifactId}_unitfile_config_systemd_resource_control_block_weight[]
     'BlockIOWriteBandwidth' ? ${project.artifactId}_unitfile_config_systemd_resource_control_block_weight[]
     'IPAccounting' ? boolean
-    'IPAddressAllow' ? string[]
+    'IPAddressAllow' ? type_network_name[]
     'DeviceAllow' ? ${project.artifactId}_unitfile_config_systemd_resource_control_devicelist[]
     'DevicePolicy' ? choice('auto', 'closed', 'strict')
     'Slice' ? string

--- a/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
+++ b/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
@@ -82,7 +82,8 @@ bind "/unitfile" = systemd_unitfile_config[];
         ),
     'slice', dict(
         'MemoryAccounting', true,
-        'MemoryLimit', 2048,
+        'MemoryLimit', 'infinity',
+        'MemoryMax', '28%',
         ),
     'install', dict(
         'WantedBy', list('1.service', '2.service'),

--- a/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
+++ b/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
@@ -80,6 +80,10 @@ bind "/unitfile" = systemd_unitfile_config[];
         'OnCalendar', list('weekly', '2021-04-07 10:32:01'),
         'Persistent', true,
         ),
+    'slice', dict(
+        'MemoryAccounting', true,
+        'MemoryLimit', 2048,
+        ),
     'install', dict(
         'WantedBy', list('1.service', '2.service'),
         ),

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -37,6 +37,9 @@ contentspath=/unitfile/0
 ^RuntimeDirectoryPreserve=restart$
 ^TTYReset=yes$
 ^TTYVHangup=no$
+^\[Slice\]$
+^MemoryAccounting=yes$
+^MemoryLimit=2048$
 ^\[Socket\]$
 ^ExecStartPre=/some/path arg1$
 ^ExecStartPre=-/some/other/path arg2$

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -39,7 +39,8 @@ contentspath=/unitfile/0
 ^TTYVHangup=no$
 ^\[Slice\]$
 ^MemoryAccounting=yes$
-^MemoryLimit=2048$
+^MemoryLimit=infinity$
+^MemoryMax=28%$
 ^\[Socket\]$
 ^ExecStartPre=/some/path arg1$
 ^ExecStartPre=-/some/other/path arg2$

--- a/ncm-systemd/src/main/resources/unitfile/slice.tt
+++ b/ncm-systemd/src/main/resources/unitfile/slice.tt
@@ -1,0 +1,1 @@
+[% INCLUDE 'systemd/unitfile/service-socket.tt' section='Slice' data=data -%]


### PR DESCRIPTION
The resource control options are from the man page of rockylinux 8.6. It's mostly about cgroupvs2.