### PR TITLE
ncm-systemd: Add path support

### DIFF
--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -386,6 +386,23 @@ type ${project.artifactId}_unitfile_config_socket = {
 };
 
 @documentation{
+the [Path] section
+https://www.freedesktop.org/software/systemd/man/systemd.path.html
+}
+type ${project.artifactId}_unitfile_config_path = {
+    'PathExists' ? absolute_file_path
+    'PathExistsGlob' ? absolute_file_path
+    'PathChanged' ? absolute_file_path
+    'PathModified' ? absolute_file_path
+    'DirectoryNotEmpty' ? absolute_file_path
+    'Unit' ? string
+    'MakeDirectory' ? boolean
+    'DirectoryMode' ? type_octal_mode
+    'TriggerLimitIntervalSec' ? long(0..)
+    'TriggerLimitBurst' ? long(0..)
+};
+
+@documentation{
 the [mount] section
 http://www.freedesktop.org/software/systemd/man/systemd.mount.html
 }
@@ -460,6 +477,7 @@ type ${project.artifactId}_unitfile_config = {
     'socket' ? ${project.artifactId}_unitfile_config_socket
     'mount' ? ${project.artifactId}_unitfile_config_mount
     'automount' ? ${project.artifactId}_unitfile_config_automount
+    'path' ? ${project.artifactId}_unitfile_config_path
     'timer' ? ${project.artifactId}_unitfile_config_timer
     'unit' ? ${project.artifactId}_unitfile_config_unit
     'slice' ? ${project.artifactId}_unitfile_config_slice
@@ -503,7 +521,7 @@ type ${project.artifactId}_target = string with match(SELF, "^(default|poweroff|
 type ${project.artifactId}_unit_type = {
     "name" ? string # shortnames are ok; fullnames require matching type
     "targets" : ${project.artifactId}_target[] = list("multi-user")
-    "type" : choice('service', 'target', 'sysv', 'socket', 'mount', 'automount', 'timer', 'slice') = 'service'
+    "type" : choice('service', 'target', 'sysv', 'socket', 'mount', 'automount', 'timer', 'slice', 'path') = 'service'
     "startstop" : boolean = true
     "state" : string = 'enabled' with match(SELF, '^(enabled|disabled|masked)$')
     @{unitfile configuration}

--- a/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
+++ b/ncm-systemd/src/main/resources/regular/tests/profiles/unitfile.pan
@@ -69,6 +69,18 @@ bind "/unitfile" = systemd_unitfile_config[];
         'SocketGroup', 'pipegroup',
         'SocketMode', '660',
         ),
+    'path', dict(
+        'PathExists', '/path/to/file',
+        'PathExistsGlob', '/path/to/glob*',
+        'PathChanged', '/path/to/file',
+        'PathModified', '/path/to/file',
+        'DirectoryNotEmpty', '/path/to/dir',
+        'Unit', 'unitname',
+        'MakeDirectory', true,
+        'DirectoryMode', '0755',
+        'TriggerLimitIntervalSec', 10,
+        'TriggerLimitBurst', 5,
+        ),
     'mount', dict(
         'What', 'server:/share',
         'Where', '/data/share',

--- a/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
+++ b/ncm-systemd/src/main/resources/regular/tests/regexps/unitfile0/value
@@ -15,6 +15,17 @@ contentspath=/unitfile/0
 ^Type=glusterfs$
 ^What=server:/share$
 ^Where=/data/share$
+^\[Path\]$
+^DirectoryMode=0755$
+^DirectoryNotEmpty=/path/to/dir$
+^MakeDirectory=yes$
+^PathChanged=/path/to/file$
+^PathExists=/path/to/file$
+^PathExistsGlob=/path/to/glob\*$
+^PathModified=/path/to/file$
+^TriggerLimitBurst=5$
+^TriggerLimitIntervalSec=10$
+^Unit=unitname$
 ^\[Service\]$
 ^BlockIODeviceWeight=/var 100$
 ^BlockIODeviceWeight=/tmp 50$

--- a/ncm-systemd/src/main/resources/unitfile/path.tt
+++ b/ncm-systemd/src/main/resources/unitfile/path.tt
@@ -1,0 +1,1 @@
+[%- INCLUDE 'systemd/unitfile/section.tt' section='Path' data=data -%]


### PR DESCRIPTION
Adds support for [path] directives. This is useful for credential handling, where we can detect the template file changing and trigger a one-shot service.

