### PR TITLE
ncm-network: allow NetworkManager configuration for EL9 compatibility

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -2148,10 +2148,8 @@ sub Configure
     #   1. stop everythig using old config
     #   2. replace updated/new config; remove REMOVE
     #   3. (re)start things
-    my $service_name;
-    if ($self->_is_executable($CHKCONFIG_CMD)) {
-        $service_name = "network";
-    } elsif (defined($allow_nm) && $allow_nm) {
+    my $service_name = "network";
+    if (!$self->_is_executable($CHKCONFIG_CMD) && defined($allow_nm) && $allow_nm) {
         $service_name = "NetworkManager";
     } else {
         $self->error("chkconfig unavailable, NetworkManager not allowed");


### PR DESCRIPTION
Justification:
* allow configuration through NetworkManager on EL9 where `chkconfig` and the legacy `network` service have been deprecated.
* use `nmcli`/`ip` commands to start and stop the network interfaces if the legacy `ifup`/`ifdown` scripts aren't installed.

Incompatibilities:
* none: legacy binaries, scripts and behavior are prioritized.

Acknowledgment:
* some changes come from [Abdul Karim's work](https://github.com/quattor/configuration-modules-core/compare/master...aka7:configuration-modules-core:ncm_network_nm_fix)