### PR TITLE
ncm-network: fix gso hash mapping

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -112,10 +112,10 @@ Readonly::Array my @ETHTOOL_OPTION_ROOT => qw(offload ring ethtool);
 
 Readonly::Hash my %ETHTOOL_OPTION_MAP => {
     offload => {
-        tso => "tcp segmentation offload",
+        tso => "tcp-segmentation-offload",
         tx  => "tx-checksumming",
         rx  => "rx-checksumming",
-        ufo => "udp fragmentation offload",
+        ufo => "udp-fragmentation-offload",
         gso => "generic-segmentation-offload",
         gro => "generic-receive-offload",
         sg  => "scatter-gather",

--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -116,7 +116,7 @@ Readonly::Hash my %ETHTOOL_OPTION_MAP => {
         tx  => "tx-checksumming",
         rx  => "rx-checksumming",
         ufo => "udp fragmentation offload",
-        gso => "generic segmentation offload",
+        gso => "generic-segmentation-offload",
         gro => "generic-receive-offload",
         sg  => "scatter-gather",
     },


### PR DESCRIPTION
update ethtool option mapping of gso, correct output seen from ethtool --show-offload DEVNAME is generic-segmentation-offload

* Why the change is necessary.
setting gso in templates won't change this setting. 
see following in ncm log.

[INFO] running component: network
---------------------------------------------------------
[INFO] ethtool_set_iface_options: Skipping setting for eth2/offload/gso to off as not in ethtool

* What backwards incompatibility it may introduce.
Not aware of any, checked output from ethtool -show-offload  DEVNAME on rhel7, 8 and 9.
