### PR TITLE
workflows: Fully move travis-build into panlint

### DIFF
--- a/.github/workflows/panlint.yaml
+++ b/.github/workflows/panlint.yaml
@@ -16,5 +16,9 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: pip install colorama prettytable six
+      - name: Install panlint
+        run: |
+          wget -q https://raw.githubusercontent.com/quattor/pan/master/panc/src/main/scripts/panlint/panlint.py -O /tmp/panlint.py
+          chmod u+x /tmp/panlint.py
       - name: run panlint
-        run: ./travis-build
+        run: git diff --name-only HEAD^ | grep '\.pan$' | xargs -r /tmp/panlint.py --allow_mvn_templates || exit 1

--- a/travis-build
+++ b/travis-build
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-rm -f /tmp/panlint.py
-wget -q https://raw.githubusercontent.com/quattor/pan/master/panc/src/main/scripts/panlint/panlint.py -O /tmp/panlint.py
-chmod u+x /tmp/panlint.py
-
-git diff --name-only HEAD^ | grep '\.pan$' | xargs -r /tmp/panlint.py --allow_mvn_templates || exit 1


### PR DESCRIPTION
We no longer use Travis.