### PR TITLE
workflows: Run unit tests on EL8

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   runtests:
     runs-on: ubuntu-latest
-    container: centos:7
+    container: rockylinux:8
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -14,20 +14,24 @@ jobs:
       run: echo "pomcachekey=${{ hashFiles('**/pom.xml') }}" >> $GITHUB_ENV
     - name: set up dependencies
       run: |
-        yum -y install epel-release http://yum.quattor.org/devel/quattor-release-1-1.noarch.rpm
+        dnf -y install dnf-plugins-core
+        dnf config-manager --set-enabled appstream
+        dnf config-manager --set-enabled powertools
+        dnf -y install epel-release \
+          http://yum.quattor.org/devel/quattor-yum-repo-2-1.noarch.rpm
         # The available version of perl-Test-Quattor is too old for mvnprove.pl to
         # work, but this is a quick way of pulling in a lot of required dependencies.
         # Surprisingly `which` is not installed by default and panc depends on it.
         # libselinux-utils is required for /usr/sbin/selinuxenabled
-        yum install -y maven perl-Test-Quattor which panc aii-ks ncm-lib-blockdevices \
+        dnf install -y maven which panc ncm-lib-blockdevices \
           ncm-ncd git libselinux-utils sudo perl-Crypt-OpenSSL-X509 \
           perl-Data-Compare perl-Date-Manip perl-File-Touch perl-JSON-Any \
           perl-Net-DNS perl-Net-FreeIPA perl-Net-OpenNebula \
           perl-Net-OpenStack-Client perl-NetAddr-IP perl-REST-Client \
-          perl-Set-Scalar perl-Text-Glob cpanminus gcc wget
-        #perl-Git-Repository perl-Data-Structure-Util
-        # Hack around the two missing Perl rpms for ncm-ceph
-        cpanm install Git::Repository Data::Structure::Util
+          perl-Set-Scalar perl-Text-Glob cpanminus gcc wget \
+          perl-Git-Repository perl-Data-Structure-Util \
+          http://yum.quattor.org/devel/perl-Test-Quattor-18.3.0-SNAPSHOT20180406083650.noarch.rpm \
+          http://yum.quattor.org/devel/aii-ks-21.12.1-SNAPSHOT20230627130118.noarch.rpm
     - name: set up template library core from git master
       run: |
         cd /tmp


### PR DESCRIPTION
EL7 is too old of a default environment for us now, although we will still build nightlies on it as long as we have to support it.