### PR TITLE
ncm-network core schema: allow realhostname to be a short hostname

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -421,7 +421,7 @@ type structure_ipv6 = {
 type structure_network = {
     "domainname" : type_fqdn
     "hostname" : type_shorthostname
-    "realhostname" ? type_fqdn
+    "realhostname" ? string with is_shorthostname(SELF) || is_fqdn(SELF)
     "default_gateway" ? type_ip
     @{When default_gateway is not set, the component will try to guess the default
       gateway using the first configured gateway set on an interface.

--- a/ncm-network/src/test/perl/simple.t
+++ b/ncm-network/src/test/perl/simple.t
@@ -7,7 +7,7 @@ BEGIN {
 }
 
 use Test::More;
-use Test::Quattor qw(simple simple_ethtool simple_noethtool simple_realhostname simple_nobroadcast simple_tun);
+use Test::Quattor qw(simple simple_ethtool simple_noethtool simple_realhostname simple_shortrealhostname simple_nobroadcast simple_tun);
 use Test::MockModule;
 
 use NCM::Component::network;
@@ -292,6 +292,19 @@ unlike(get_file_contents("/etc/sysconfig/network"),
 ok(command_history_ok([
     '/usr/bin/hostnamectl set-hostname realhost.example.com --static',
 ]), "hostnamectl called with realhostname");
+
+
+command_history_reset();
+$cfg = get_config_for_profile('simple_shortrealhostname');
+$executables{'/usr/bin/hostnamectl'} = 1;
+is($cmp->Configure($cfg), 1, "Component runs correctly with shortrealhostname test profile w hostnamectl");
+unlike(get_file_contents("/etc/sysconfig/network"),
+     qr/HOSTNAME=/m,
+     "shortrealhostname not used as hostname w hostnamectl");
+ok(command_history_ok([
+     '/usr/bin/hostnamectl set-hostname shortrealhost --static',
+]), "hostnamectl called with shortrealhostname");
+
 
 
 # removing broadcast that was same as computed default is ok (triggers no network restart)

--- a/ncm-network/src/test/resources/simple_shortrealhostname.pan
+++ b/ncm-network/src/test/resources/simple_shortrealhostname.pan
@@ -1,0 +1,5 @@
+object template simple_shortrealhostname;
+
+include 'simple_base_profile';
+
+"/system/network/realhostname" = "shortrealhost";


### PR DESCRIPTION
- Allow better support of software like Ceph where it is the recommended setting

This change is backward compatible but relaxes the requirements on `realhostname` property. I also checked the `template-library-standard`, `template-library-os`, `template_library_core` and `template-library-grid` repositories, as well as `configuration-modules-core`. `realhostname` is not referenced in any of them (except ncm-network schema definition in`template_library_core`) . Only `hostname` is set in `template-library-standard` but this property is not affected by this PR.