### PR TITLE
ncm-ntpd: fix type of ntpd_tinker_options/step #1600

### DIFF
--- a/ncm-ntpd/src/main/pan/components/ntpd/schema.pan
+++ b/ncm-ntpd/src/main/pan/components/ntpd/schema.pan
@@ -74,7 +74,7 @@ type ntpd_tinker_options = {
     "freq" ? long
     "huffpuff" ? long
     "panic" ? long
-    "step" ? long
+    "step" ? double
     "stepout" ? long
 };
 


### PR DESCRIPTION
The step value is represented in seconds.
See tinker definition in https://www.ntp.org/documentation/4.2.8-series/miscopt/