### PR TITLE
ncm-dirperm: fix the wrong variable which causes confusion on error display 

### DIFF
--- a/ncm-dirperm/src/main/perl/dirperm.pm
+++ b/ncm-dirperm/src/main/perl/dirperm.pm
@@ -90,7 +90,7 @@ sub process_path {
         $gid = (getgrnam($group))[2] if ($group);
 
         if (!defined($uid) or !defined($gid)) {
-            $self->error("Bad owner or group ($owner/".($group ? $group : 'default user group').")");
+            $self->error("Bad owner or group ($user/".($group ? $group : 'default user group').")");
             return 0;
         }
     } else {


### PR DESCRIPTION
What changed:

Variable in error display

Why it was necessary:

Simple typo fix. Replacing the "$user:$group" format $owner in the error display. This necessary because the current error message causes confusion with the format (user:group/group) 

Compatibility:

A string in the module logs, it does not break any dependency. 

