### PR TITLE
ncm-metaconfig: zookeeper: fix 4lw options to a list of choice

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/pan/schema.pan
@@ -22,7 +22,8 @@ type zookeeper_main = {
     "autopurge.snapRetainCount" ? long
     "autopurge.purgeInterval" ? long
     "syncEnabled" ? boolean
-    "4lw.commands.whitelist" ? string
+    "4lw.commands.whitelist" ? choice('conf', 'cons', 'crst', 'dump', 'envi', 'mntr',
+        'ruok', 'srst', 'srvr', 'stat', 'wchc', 'wchp', 'wchs') []
 
     # cluster/ensemble
     "initLimit" : long = 10

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/server.tt
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/server.tt
@@ -1,9 +1,12 @@
 [%- booleans = ["leaderServes", "syncEnabled"] -%]
+[%- lists = ["4lw.commands.whitelist",] -%]
 [%- FOREACH pair IN main.pairs -%]
 [%      pair.key %]=
 [%-     SWITCH pair.key -%]
 [%-         CASE booleans -%]
 [%-             pair.value ? "yes" : "no" %]
+[%-         CASE lists -%]
+[%-             pair.value.join(', ') %]
 [%-         CASE -%]
 [%-             pair.value %]
 [%-     END %]

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/profiles/server_config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/profiles/server_config.pan
@@ -4,6 +4,8 @@ include 'metaconfig/zookeeper/config';
 
 prefix "/software/components/metaconfig/services/{/etc/zookeeper/zoo.cfg}/contents";
 "main/dataDir" = "/var/lib/zookeeper";
+"main/4lw.commands.whitelist" = list("stat" , "srvr" , "mntr");
+
 "servers" =  list(
     dict("hostname", "host1.domain"),
     dict("hostname", "host2.domain"),

--- a/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/values
+++ b/ncm-metaconfig/src/main/metaconfig/zookeeper/tests/regexps/server_config/values
@@ -3,6 +3,7 @@ Values test for zookeeper main server config
 multiline
 metaconfigservice=/etc/zookeeper/zoo.cfg
 ---
+^4lw.commands.whitelist=stat, srvr, mntr$
 ^clientPort=2181$
 ^dataDir=/var/lib/zookeeper$
 ^initLimit=10$


### PR DESCRIPTION
fixes #1606 
