### PR TITLE
ncm-metaconfig: beats: Remove trailing comma in choice

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_7.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_7.0.pan
@@ -194,7 +194,7 @@ type beats_filebeat_input = {
         'utf-16be',
         'utf-16be-bom',
         'utf-16le',
-        'utf-8',
+        'utf-8'
     )
     'type' ? choice('log', 'stdin')
     'exclude_lines' ? string_trimmed[]


### PR DESCRIPTION
For some reason this is a syntax error with choice.

As noted in quattor/release#344.