### PR TITLE
ncm-network: fix typos and updated comments

### DIFF
--- a/ncm-network/src/main/pan/components/network/config-nmstate.pan
+++ b/ncm-network/src/main/pan/components/network/config-nmstate.pan
@@ -12,3 +12,5 @@ prefix "/software/components/network";
 # Add dependency that can't be added to rpm directly
 prefix '/software/packages';
 'nmstate' = dict();
+prefix "/system/aii/osinstall/ks";
+"NetworkManager-config-server" = dict();


### PR DESCRIPTION

Describe the change you are making here, in particular we would like to know:

changes to nmstate.pm to address comments in previous pr.

* Why the change is necessary.
- fixed typos and updated comments and docs to be more meaningful.
- commented out start_openvswitch, support for this will come later.

* What backwards incompatibility it may introduce.
none
