### PR TITLE
Only search for the parent POM in Maven repositories

### DIFF
--- a/ncm-freeipa/pom.xml
+++ b/ncm-freeipa/pom.xml
@@ -10,6 +10,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
   <licenses>
     <license>

--- a/ncm-nss/pom.xml
+++ b/ncm-nss/pom.xml
@@ -10,6 +10,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
   <licenses>
     <license>

--- a/ncm-opennebula/pom.xml
+++ b/ncm-opennebula/pom.xml
@@ -10,6 +10,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
   <licenses>
     <license>

--- a/ncm-systemd/pom.xml
+++ b/ncm-systemd/pom.xml
@@ -10,6 +10,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
   <licenses>
     <license>


### PR DESCRIPTION
Disable local file resolution in four remaining component POMs.

This gets rid of the remaining messages like:
> Project build error: 'parent.relativePath' of POM org.quattor.cfg.module:foo:1.2.3-SNAPSHOT (/foo/bar/configuration-modules-core/ncm-foo/pom.xml) points at org.quattor:configuration-modules-core instead of org.quattor.maven:build-profile, please verify your project structure