### PR TITLE
ncm-metaconfig: udev: Restore missing bind and prefix

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/udev/pan/rule.pan
+++ b/ncm-metaconfig/src/main/metaconfig/udev/pan/rule.pan
@@ -53,6 +53,11 @@ prefix "/software/components/metaconfig/services/&lbrace;/etc/udev/rules.d/51-qu
 'udev_assign_rule/run/0/operator' = "+=";
 }
 include 'metaconfig/udev/rule_schema/schema';
+
+bind "/software/components/metaconfig/services/{/etc/udev/rules.d/51-quattor.rules}/contents" = udev_rules;
+
+prefix "/software/components/metaconfig/services/{/etc/udev/rules.d/51-quattor.rules}";
+
 "mode" = 0644;
 "owner" = "root";
 "group" = "root";


### PR DESCRIPTION
It looks like these got nuked during a refactoring and rebase from 4949fda539a70dc56e5c7f6027b9b536a47b48d6 to ad09b9bbd92eadd777fc3fa36772f382ea390254.