### PR TITLE
ncm-spma: Include APT backend in RPM for now

### DIFF
--- a/ncm-spma/pom.xml
+++ b/ncm-spma/pom.xml
@@ -225,7 +225,6 @@
                 <sources>
                   <source>
                     <excludes>
-                      <exclude>**/apt.pm</exclude>
                       <exclude>**/ips.pm</exclude>
                       <exclude>**/spma-run</exclude>
                     </excludes>
@@ -240,7 +239,6 @@
                 <sources>
                   <source>
                     <excludes>
-                      <exclude>**/*apt*</exclude>
                       <exclude>**/*ips*</exclude>
                       <!-- no - here, this is the pod of the package -->
                       <exclude>**/*spmarun*</exclude>


### PR DESCRIPTION
As we are building the DEBs from the RPMs for now.

Pending an overhaul of how packages are built.