### PR TITLE
ncm-altlogrotate: Support 'su' directive

### DIFF
--- a/ncm-altlogrotate/src/main/pan/components/altlogrotate/schema.pan
+++ b/ncm-altlogrotate/src/main/pan/components/altlogrotate/schema.pan
@@ -95,7 +95,7 @@ type altlogrotate_component = {
     if(!exists(SELF['entries']['global'])) {
         foreach(name; entry; SELF['entries']) {
             if(exists(entry['global']) && entry['global']) {
-                error(format("Cannot have altlogrotate entry %s (with global=true) without 'global' entry", name));
+                error("Cannot have altlogrotate entry %s (with global=true) without 'global' entry", name);
             };
         };
     };

--- a/ncm-altlogrotate/src/main/pan/components/altlogrotate/schema.pan
+++ b/ncm-altlogrotate/src/main/pan/components/altlogrotate/schema.pan
@@ -16,6 +16,11 @@ type structure_altlogrotate_create_params = {
     'group' : string
 };
 
+type structure_altlogrotate_su = {
+    'user' : string_trimmed
+    'group' : string_trimmed
+};
+
 type structure_altlogrotate_logrot = {
     'pattern' ? string
     @{part of global configuration file, requires an entry called 'global'.
@@ -65,6 +70,8 @@ type structure_altlogrotate_logrot = {
     'frequency' ? choice('daily', 'weekly', 'monthly', 'yearly')
 
     'scripts' ? structure_altlogrotate_scripts
+
+    'su' ? structure_altlogrotate_su
 } with {
     if (exists(SELF['pattern']) && exists(SELF['include'])) {
         error('altlogrotate entry: pattern and include are mutually exclusive');

--- a/ncm-altlogrotate/src/main/perl/altlogrotate.pm
+++ b/ncm-altlogrotate/src/main/perl/altlogrotate.pm
@@ -74,6 +74,10 @@ sub process_entry
     print $fh 'tabooext ', $entry->{taboo_replace} ? '' : '+ ', join(',', @{$entry->{tabooext}}), "\n"
         if defined($entry->{tabooext});
 
+    if (defined($entry->{su})) {
+        print $fh join(' ', 'su', $entry->{su}->{user}, $entry->{su}->{group}), "\n";
+    }
+
     foreach my $name (sort keys %{$entry->{scripts} || {}}) {
         print $fh "$name\n\n", $entry->{scripts}->{$name}, "\n\nendscript\n";
     }

--- a/ncm-altlogrotate/src/test/perl/simple.t
+++ b/ncm-altlogrotate/src/test/perl/simple.t
@@ -32,6 +32,7 @@ create 0751 someuser agroup
 mailfirst
 nomail
 tabooext a,b
+su foouser bargroup
 lastaction
 
 /run/this

--- a/ncm-altlogrotate/src/test/resources/simple.pan
+++ b/ncm-altlogrotate/src/test/resources/simple.pan
@@ -20,6 +20,8 @@ prefix '/software/components/altlogrotate/entries/test1';
 "scripts" = dict("lastaction", "/run/this");
 "tabooext" = list('a', 'b');
 "taboo_replace" = true;
+"su/user" = 'foouser';
+"su/group" = 'bargroup';
 
 prefix '/software/components/altlogrotate/entries/global';
 "include" = "some_file";


### PR DESCRIPTION
This allows `logrotate` to rotate files as a specific user and group instead of the default (i.e. root).