### PR TITLE
ncm-spma: yumdnf: Don't attempt to expand groups with repoquery

### DIFF
--- a/ncm-spma/src/main/perl/spma/yumdnf.pm
+++ b/ncm-spma/src/main/perl/spma/yumdnf.pm
@@ -10,6 +10,8 @@ use constant YUM_CONF_FILE => "/etc/dnf/dnf.conf";
 
 use constant DNF_MODULES_DIR => "/etc/dnf/modules.d";
 
+use constant REPOGROUP => qw(true);
+
 use constant REPOQUERY_FORMAT => qw(--nevra);
 
 use constant REPO_DEPS => qw(repoquery -C --requires --resolve --qf %{NAME};%{ARCH});


### PR DESCRIPTION
We don't support them anyway (the schema forces `/software/groups` to be empty).

Resolves #1524.