### PR TITLE
ncm-nfs: Allow daemon to reload to be specified

### DIFF
--- a/ncm-nfs/src/main/pan/components/nfs/schema.pan
+++ b/ncm-nfs/src/main/pan/components/nfs/schema.pan
@@ -29,6 +29,8 @@ type ${project.artifactId}_component = {
       If true, missing exports forces an empty exports file and a NFS service reload.
       If false, missing exports has no effect.}
     'server' : boolean = true
+    @{ Daemon to reload when changes are made }
+    'daemon' : string_trimmed = 'nfs-server'
     @{This is a list of dicts with "path" giving the export path and
       "hosts" being a dict of host/option entries where the key is the escaped host name and
       the value the export options(e.g. for "nfsclient.example.org(rw)",

--- a/ncm-nfs/src/main/perl/nfs.pm
+++ b/ncm-nfs/src/main/perl/nfs.pm
@@ -477,9 +477,9 @@ sub Configure
     if (! exists($tree->{server}) || $tree->{server}) {
         if ($self->exports($tree))  {
             # Force a reload of the nfs daemon.
-            $self->info("Forcing nfs reload");
+            $self->info("Forcing ", $tree->{daemon}, " reload");
             # report error on failure
-            CAF::Service->new(["nfs"], log => $self)->reload();
+            CAF::Service->new([$tree->{daemon}], log => $self)->reload();
         };
     } else {
         $self->verbose("Not a NFS server configuration");

--- a/ncm-nfs/src/test/perl/configure.t
+++ b/ncm-nfs/src/test/perl/configure.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Quattor qw(configure configure_noserver configure_nomounts);
+use Test::Quattor qw(configure configure_noserver configure_nomounts configure_daemon);
 use Test::MockModule;
 
 use Test::Quattor::RegexpTest;
@@ -42,14 +42,14 @@ foreach my $change (qw(exports)){
     command_history_reset();
     $res = {$change => 1};
     is($cmp->Configure($cfg), 1, "Configure returns 1 (change $change)");
-    ok(command_history_ok([qr{service nfs reload}]), "nfs service reload when $change changed");
+    ok(command_history_ok([qr{service nfs-server reload}]), "nfs service reload when $change changed");
 };
 
 foreach my $change (qw(fstab_changed action)){
     command_history_reset();
     $res = {$change => 1};
     is($cmp->Configure($cfg), 1, "Configure returns 1 (change $change)");
-    ok(command_history_ok(undef, [qr{service nfs reload}]), "no nfs service reload when $change changed");
+    ok(command_history_ok(undef, [qr{service nfs-server reload}]), "no nfs service reload when $change changed");
 };
 
 # noserver config
@@ -58,7 +58,7 @@ foreach my $change (qw(exports fstab_changed action)){
     command_history_reset();
     $res = {$change => 1};
     is($cmp->Configure($nosrvcfg), 1, "Configure returns 1 (change $change) with server=false");
-    ok(command_history_ok(undef, [qr{service nfs reload}]), "no nfs service reload when $change changed with server=false");
+    ok(command_history_ok(undef, [qr{service nfs-server reload}]), "no nfs service reload when $change changed with server=false");
 };
 
 # noserver config
@@ -68,5 +68,13 @@ $process_mounts_arg = undef;
 is($cmp->Configure($nomounts), 1, "Configure returns 1 without mounts");
 ok(!defined($process_mounts_arg), "no nfs process_mounts without mounts");
 
+# configure with alternative daemon set
+my $cfgdaemon = get_config_for_profile('configure_daemon');
+foreach my $change (qw(exports)){
+    command_history_reset();
+    $res = {$change => 1};
+    is($cmp->Configure($cfgdaemon), 1, "Configure returns 1 (change $change)");
+    ok(command_history_ok([qr{service nfs-kernel-server reload}]), "nfs-server service reload when $change changed");
+};
 
 done_testing();

--- a/ncm-nfs/src/test/resources/configure_daemon.pan
+++ b/ncm-nfs/src/test/resources/configure_daemon.pan
@@ -1,0 +1,5 @@
+object template configure_daemon;
+
+include 'fstab_simple';
+
+"/software/components/nfs/daemon" = 'nfs-kernel-server';


### PR DESCRIPTION
The name of the service/daemon is OS dependent, default to the more modern name.
For example in EL6 it was `nfs`, in EL7 `nfs` was a symlink to `nfs-server`, in EL8 only `nfs-server` exists and in Ubuntu it is `nfs-kernel-server`.

Resolves #1618.