### PR TITLE
ncm-network: add two  missing schema types

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -74,6 +74,8 @@ type structure_rule = {
     "not" ? boolean
     @{routing table action}
     "table" ? network_valid_routing_table
+    @{priority, The priority of the rule over the others. Required by Network Manager when setting routing rules.}
+    "priority" ? long(0..0xffffffff)
     @{rule add options to use (cannot be combined with other options)}
     "command" ? string with !match(SELF, '[;]')
 } with {
@@ -167,6 +169,7 @@ type structure_ethtool_offload = {
     @{Set the TCP segment offload parameter to "off" or "on"}
     "tso" ? string with match (SELF, '^(on|off)$')
     "gro" ? string with match (SELF, '^(on|off)$')
+    "gso" ? string with match (SELF, '^(on|off)$')
 };
 
 @documentation{


### PR DESCRIPTION
add missing gso for ethtool offload
add priority used in  nmstate.pm

* Why the change is necessary.
to able to set gso for offload and priority values for configuring network manager policy rule.

* What backwards incompatibility it may introduce.
*None
