### PR TITLE
ncm-network: fix nmstate package definition in Kickstart config

### DIFF
--- a/ncm-network/src/main/pan/components/network/config-nmstate.pan
+++ b/ncm-network/src/main/pan/components/network/config-nmstate.pan
@@ -13,4 +13,4 @@ prefix "/software/components/network";
 prefix '/software/packages';
 'nmstate' = dict();
 prefix "/system/aii/osinstall/ks";
-"NetworkManager-config-server" = dict();
+'packages' = append("NetworkManager-config-server");


### PR DESCRIPTION
Fixes #1629
