### PR TITLE
ncm-network: Throw error if commands used with nmstate

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -30,8 +30,9 @@ type structure_route = {
     "command" ? string with !match(SELF, '[;]')
 } with {
     if (exists(SELF['command'])) {
-        if (length(SELF) != 1)
-            error("Cannot use command and any of the other attributes as route");
+        module = value('/software/components/network/ncm-module', '');
+        if (module == 'nmstate') error("Command routes are not supported by the nmstate backend");
+        if (length(SELF) != 1) error("Cannot use command and any of the other attributes as route");
     } else {
         if (!exists(SELF['address']))
             error("Address is mandatory for route (in absence of command)");
@@ -80,8 +81,9 @@ type structure_rule = {
     "command" ? string with !match(SELF, '[;]')
 } with {
     if (exists(SELF['command'])) {
-        if (length(SELF) != 1)
-            error("Cannot use command and any of the other attributes as rule");
+        module = value('/software/components/network/ncm-module', '');
+        if (module == 'nmstate') error("Command routes are not supported by the nmstate backend");
+        if (length(SELF) != 1) error("Cannot use command and any of the other attributes as rule");
     } else {
         if (!exists(SELF['to']) && !exists(SELF['from'])) {
             error("Rule requires selector to or from (or use command)");


### PR DESCRIPTION
This is the schema part of the fix for #1627.