### PR TITLE
ncm-network: nmstate: add mac-address to nmstate config

### DIFF
--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -293,6 +293,7 @@ sub generate_nmstate_config
     my $ifaceconfig->{name} = $name;
 
     $ifaceconfig->{mtu} = $iface->{mtu} if $iface->{mtu};
+    $ifaceconfig->{'mac-address'} = $iface->{hwaddr} if $iface->{hwaddr};
     if ($is_eth) {
         $ifaceconfig->{type} = "ethernet";
         if ($is_bond_eth) {


### PR DESCRIPTION
Set  mac-address for interface in nmstate config.

* Why the change is necessary.
setting mac-address for interface when applying nmstate config.

* What backwards incompatibility it may introduce.
None.
