### PR TITLE
ncm-ssh: add MaxSessions ssh option

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -125,6 +125,7 @@ type ssh_daemon_options_type = {
     "LoginGraceTime" ? long
     "MaxAuthTries" ? long
     "MaxStartups" ? long
+    "MaxSessions" ? long(0..)
     "NoneEnabled" ? legacy_binary_affirmation_string
     "PermitEmptyPasswords" ? legacy_binary_affirmation_string
     "PermitRootLogin" ? choice(


### PR DESCRIPTION
add MaxSessions ssh option.


Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
Allow setting of MaxSessions option for ssh
* What backwards incompatibility it may introduce.
None.
