### PR TITLE
ncm-network: provide a better way to cleanup inactive connections

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -443,6 +443,8 @@ type structure_network = {
     "allow_nm" ? boolean
     @{let NetworkManager manage the dns (only for nmstate)}
     "nm_manage_dns" : boolean = false
+    @{let ncm-network cleanup inactive connections (only for nmstate)}
+    "nm_clean_inactive_conn" : boolean = true
     "primary_ip" ? string
     "routers" ? structure_router{}
     "ipv6" ? structure_ipv6

--- a/ncm-network/src/test/perl/nmstate_simple.t
+++ b/ncm-network/src/test/perl/nmstate_simple.t
@@ -104,7 +104,6 @@ ok(command_history_ok([
   '/usr/bin/nmcli connection',
   'service NetworkManager reload',
   'systemctl disable nmstate',
-  '/usr/bin/nmcli -t -f name conn',
   '/usr/bin/nmstatectl apply /etc/nmstate/eth0.yml',
   '/usr/bin/nmstatectl apply /etc/nmstate/resolv.yml',
   'service NetworkManager reload',
@@ -115,6 +114,7 @@ ok(command_history_ok([
   '/usr/bin/nmstatectl show',
   '/usr/bin/nmcli dev status',
   '/usr/bin/nmcli connection',
+  '/usr/bin/nmcli -t -f uuid,device,name,state,active conn',
   'ccm-fetch'
 ], []));
 


### PR DESCRIPTION
New approach to cleaning up inactive connections so have clean output after the run.

This also fixes an issue where active connnections named 'Wired connection ethX' are deleted before network changes are applied. This is means in some edge cases if first ncm-network run fails then you have no networking. Therefore no need to delete any auto connections created by NetworkManager, instead we just cleanup connections which are inactive at the end.

Wired connection ethX is created by NM automatically, to stop this one can install NetworkManage-config-server package, which stops NM creating such auto connections automaticailly.

provide option to turned this off.

* Why the change is necessary.
to cleanup connections which have been made inactive after ncm run is completed with nmstate.

* What backwards incompatibility it may introduce.
None, this change is to nmstate backend.