### PR TITLE
ncm-network: set profile-name and set dhcp to disable for static config

### DIFF
--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -294,6 +294,7 @@ sub generate_nmstate_config
 
     $ifaceconfig->{mtu} = $iface->{mtu} if $iface->{mtu};
     $ifaceconfig->{'mac-address'} = $iface->{hwaddr} if $iface->{hwaddr};
+    $ifaceconfig->{'profile-name'} = $name;
     if ($is_eth) {
         $ifaceconfig->{type} = "ethernet";
         if ($is_bond_eth) {
@@ -334,6 +335,7 @@ sub generate_nmstate_config
 
                 # TODO: append alias ip to ip_list as array, providing ips as array of hashref.
                 $ifaceconfig->{ipv4}->{address} = [$ip_list];
+                $ifaceconfig->{ipv4}->{dhcp} = $YFALSE;
                 $ifaceconfig->{ipv4}->{enabled} = $YTRUE;
             } else {
                 # TODO: configure IPV6 enteries

--- a/ncm-network/src/test/perl/nmstate_simple.t
+++ b/ncm-network/src/test/perl/nmstate_simple.t
@@ -49,6 +49,7 @@ interfaces:
 - link-aggregation:
     port: []
   name: eth0
+  profile-name: eth0
   type: bond
 EOF
 


### PR DESCRIPTION
- add profile name to make sure nmstateclt apply picks the right profile.
- explicitly set dhcp to false when setting static address. if there is an existing connection for same device with dhcp enabled nmstate wll not apply the change unless dhcp is explicitly is set to false.

closes #1636


* Why the change is necessary.
To make sure right profile config is used by NM when nmstate applies the config.
* What backwards incompatibility it may introduce.
None.
