### PR TITLE
ncm-network: fix multi bonding configuration and arp_ip_target bonding options

### DIFF
--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -800,7 +800,12 @@ sub process_network
                             $la->{options} ||= {};
                             $la = $la->{options};
                         }
-                        $la->{$opt} = $opts->{$opt};
+                        # nmstate config requires arp_ip_target as comma seperated string
+                        if ($opt eq 'arp_ip_target') {
+                            $la->{$opt} = join(',', @{$opts->{$opt}});
+                        } else {
+                            $la->{$opt} = $opts->{$opt};
+                        }
                     }
                 }
                 # TODO for briging_opts

--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -163,12 +163,12 @@ sub make_nm_ip_route
 # - port in nmstate config file
 sub get_bonded_eth
 {
-    my ($self, $interfaces) = @_;
+    my ($self, $bond_name, $interfaces) = @_;
     my @data =  ();
     foreach my $name (sort keys %$interfaces) {
         my $iface = $interfaces->{$name};
         if ( $iface->{master} ){
-            push @data, $name;
+            push @data, $name if $iface->{master} eq $bond_name;
         }
     }
     return \@data;
@@ -279,7 +279,6 @@ sub generate_nmstate_config
 {
     my ($self, $name, $net, $ipv6, $routing_table) = @_;
 
-    my $bonded_eth = get_bonded_eth($self, $net->{interfaces});
     my $iface = $net->{interfaces}->{$name};
     my $device = $iface->{device} || $name;
     my $is_eth = $iface->{set_hwaddr};
@@ -313,6 +312,7 @@ sub generate_nmstate_config
         # if bond device
         $ifaceconfig->{type} = "bond";
         $ifaceconfig->{'link-aggregation'} = $iface->{link_aggregation};
+        my $bonded_eth = get_bonded_eth($self, $name, $net->{interfaces});
         if ($bonded_eth){
             $ifaceconfig->{'link-aggregation'}->{port} = $bonded_eth;
         }


### PR DESCRIPTION
two bug fixes for nmstate

fix to enable configuration for mutiple bonding interfaces. fixes #1638  
convert bonding option arp_ip_target to comma separated string. fixes #1639 

* Why the change is necessary.
bug fix.

* What backwards incompatibility it may introduce.
None.