### PR TITLE
ncm-network: nmstate - down the interface connection before applying

### DIFF
--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -518,6 +518,8 @@ sub nmstate_apply
             # apply config using nmstatectl
             my $ymlfile = $self->iface_filename($iface);
             if ($self->any_exists($ymlfile)){
+                $self->verbose("Applying config for interface $iface");
+                push(@cmds, [$NMCLI_CMD, "conn", "down", $iface ]) if $self->is_active_interface($iface);
                 push(@cmds, [$NMSTATECTL, "apply", $ymlfile]);
                 push(@cmds, [qw(sleep 10)]) if ($iface =~ m/bond/);
             } else {


### PR DESCRIPTION
take down the connection using nmcli before applying changes.

nmstatectl apply does not replace running config instead it seems to append. This is not useful when settings have been removed such as policy routing. Therefore down the interface connection during configuration changes. This will be now similar to original main ncm network module where it runs ifdown and ifup during config changes.
#1643 

* Why the change is necessary.
Get correct configs applied after a change to profile
 
* What backwards incompatibility it may introduce.
None