### PR TITLE
ncm-network: nmstate - remove config route entry not in profile

### DIFF
--- a/ncm-network/src/test/perl/nmstate_simple.t
+++ b/ncm-network/src/test/perl/nmstate_simple.t
@@ -51,6 +51,10 @@ interfaces:
   name: eth0
   profile-name: eth0
   type: bond
+routes:
+  config:
+  - next-hop-interface: eth0
+    state: absent
 EOF
 
 Readonly my $NOTTOREMOVE => <<EOF;


### PR DESCRIPTION
nmstatectl apply does not replace running config instead merges current state config with desired state. This is not useful when settings have been removed such as policy routing.

'state: absent' will remove config routes entry that matches the interface as next hop and therefore will only apply the routes configured in host profile profile.

* Why the change is necessary.
Allow capability to  change policy routes or adding static routes after host is built and without having to rebuild the host.

* What backwards incompatibility it may introduce.
None.

#1643 
