### PR TITLE
ncm-network: nmstate - add additional route rule parameters

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -77,18 +77,28 @@ type structure_rule = {
     "table" ? network_valid_routing_table
     @{priority, The priority of the rule over the others. Required by Network Manager when setting routing rules.}
     "priority" ? long(0..0xffffffff)
+    @{nmstate-action used by nmstate module}
+    "nmstate-action" ? choice('blackhole', 'prohibit', 'unreachable')
+    @{nmstate-state used by nmstate module, Can only set to absent for deleting matching route rules}
+    "nmstate-state" ? choice('absent')
+    @{nmstate-iif used by nmstate module, Incoming interface name}
+    "nmstate-iff" ? string
+    @{nmstate-fwmark used by nmstate module. Select the fwmark value to match}
+    "nmstate-fwmark" ? string
+    @{nmstate-fwmask used by nmstate module. Select the fwmask value to match}
+    "nmstate-fwmask" ? string
     @{rule add options to use (cannot be combined with other options)}
     "command" ? string with !match(SELF, '[;]')
 } with {
+    module = value('/software/components/network/ncm-module', '');
     if (exists(SELF['command'])) {
-        module = value('/software/components/network/ncm-module', '');
-        if (module == 'nmstate') error("Command routes are not supported by the nmstate backend");
+        if (module == 'nmstate') error("Command rule are not supported by the nmstate backend");
         if (length(SELF) != 1) error("Cannot use command and any of the other attributes as rule");
     } else {
         if (!exists(SELF['to']) && !exists(SELF['from'])) {
             error("Rule requires selector to or from (or use command)");
         };
-        if (!exists(SELF['table'])) {
+        if (!exists(SELF['table']) && (module != 'nmstate')) {
             error("Rule requires action table (or use command)");
         };
     };

--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -107,6 +107,7 @@ sub make_nm_ip_rule
     my ($self, $device, $rules, $routing_table_hash) = @_;
 
     my @rule_entry;
+    my %rule_entry_absent;
     foreach my $rule (@$rules) {
         if ($rule->{command}){
             $self->warn("Rule command entry not supported with nmstate, ignoring '$rule->{command}'");
@@ -120,8 +121,20 @@ sub make_nm_ip_rule
         $thisrule{'route-table'} = "$routing_table_hash->{$rule->{table}}" if $rule->{table};
         $thisrule{'ip-to'} = $rule->{to} if $rule->{to};
         $thisrule{'ip-from'} = $rule->{from} if $rule->{from};
+        $thisrule{'action'} = $rule->{'nmstate-action'} if $rule->{'nmstate-action'};
+        $thisrule{'state'} = $rule->{'nmstate-state'} if $rule->{'nmstate-state'};
+        $thisrule{'iff'} = $rule->{'nmstate-iff'} if $rule->{'nmstate-iff'};
+        $thisrule{'fwmark'} = $rule->{'nmstate-fwmark'} if $rule->{'nmstate-fwmark'};
+        $thisrule{'fwmask'} = $rule->{'nmstate-fwmask'} if $rule->{'nmstate-fwmask'};
         push (@rule_entry, \%thisrule);
+        
+        # Add a default absent rule to match table defined. This will clear any existing rules for this table, instead of merging.
+        if ($rule->{table}) {
+           $rule_entry_absent{'state'} = "absent";
+           $rule_entry_absent{'route-table'} = $routing_table_hash->{$rule->{table}};
+        };
     }
+    push (@rule_entry, \%rule_entry_absent) if %rule_entry_absent;
     return \@rule_entry;
 }
 


### PR DESCRIPTION
provide additional route rule parameters for nmstate config as defined in https://nmstate.io/devel/yaml_api.html#routes

Also add a default absent rule to clear route rules entries for the table. nmstate by default will merge rules therefore won't clear if there are any old rules already present. This will make sure only rules defined by profile is present.

* Why the change is necessary.
Enhancement to policy based routing.
* What backwards incompatibility it may introduce.
None.