### PR TITLE
ncm-resolver: support to allow another local caching server to be used.

### DIFF
--- a/ncm-resolver/src/main/pan/components/resolver/schema.pan
+++ b/ncm-resolver/src/main/pan/components/resolver/schema.pan
@@ -24,6 +24,14 @@ type resolver_component = {
     include structure_component
     'servers' : type_ip[..3]
     'search' ? type_fqdn[..6] with { length(replace('(^\[ )|,|( \])$', '', to_string(SELF))) <= 256 }
+    @{dnscache - configure dnscache client, based on djbdns}
     'dnscache' : boolean = false
+    @{localcache - use already configured local dns caching client}
+    'localcache' : boolean = false
     'options' ? resolver_component_options
+} with {
+    if((SELF['dnscache'] == true) && (SELF['localcache'] == true)) {
+        error('dnscache and localcache cannot be enabled together');
+    };
+    true;
 };

--- a/ncm-resolver/src/main/perl/resolver.pm
+++ b/ncm-resolver/src/main/perl/resolver.pm
@@ -59,8 +59,8 @@ sub Configure {
 
     my @testservers = ();
     my $resolv = "";
-    if ($inf->{dnscache}) {
-        # If we are using dnscache the server we want to test is dnscache itself
+    if ($inf->{dnscache} or $inf->{localcache} ) {
+        # If we are using dnscache (or another local caching server) the server we want to test is locally configured caching server.
         push(@testservers, "127.0.0.1");
         $resolv .= "nameserver 127.0.0.1\n";
     } else {


### PR DESCRIPTION
option to turn off use of dnscache which only configures for djbdns. 
new option allows resolver to still be used to update resolv.conf but with local dns caching client already configured. so usual test to make sure it works before updating resolv.conf to be local.

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
use resolver outside of dnscache.
* What backwards incompatibility it may introduce.
none