### PR TITLE
ncm-opennebula: Add Ceph system datastore support

### DIFF
--- a/ncm-opennebula/src/main/pan/components/opennebula/common.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/common.pan
@@ -36,6 +36,9 @@ function is_consistent_datastore = {
             if (ds['tm_mad'] != 'ceph') {
                 error("for a ceph datastore both ds_mad and tm_mad should have value 'ceph'");
             };
+            if (ds['type'] == 'SYSTEM_DS') {
+                error("SYSTEM datastores cannot have DS_MAD defined");
+            };
             req = list(
                 'disk_type',
                 'bridge_list',

--- a/ncm-opennebula/src/main/pan/components/opennebula/common.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/common.pan
@@ -60,6 +60,11 @@ function is_consistent_datastore = {
     };
 
     if (exists(ds['ds_mad'])) {
+        if (ds['ds_mad'] == 'fs') {
+            if (ds['tm_mad'] != 'shared') {
+                error("for a fs datastore only 'shared' tm_mad is supported for the moment");
+            };
+        };
         if (ds['ds_mad'] == 'dev') {
             if (ds['tm_mad'] != 'dev') {
                 error("for a RDM datastore both ds_mad and tm_mad should have value 'dev'");

--- a/ncm-opennebula/src/main/pan/components/opennebula/common.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/common.pan
@@ -31,29 +31,35 @@ check if a specific type of datastore has the right attributes
 }
 function is_consistent_datastore = {
     ds = ARGV[0];
-    if (exists(ds['ds_mad'])) {
-        if (ds['ds_mad'] == 'ceph') {
-            if (ds['tm_mad'] != 'ceph') {
+    reqceph = list(
+        'disk_type',
+        'bridge_list',
+        'ceph_host',
+        'ceph_secret',
+        'ceph_user',
+        'pool_name',
+    );
+
+    if (ds['tm_mad'] == 'ceph') {
+        if (exists(ds['ds_mad'])) {
+            if ((ds['ds_mad'] != 'ceph')) {
                 error("for a ceph datastore both ds_mad and tm_mad should have value 'ceph'");
             };
             if (ds['type'] == 'SYSTEM_DS') {
                 error("SYSTEM datastores cannot have DS_MAD defined");
             };
-            req = list(
-                'disk_type',
-                'bridge_list',
-                'ceph_host',
-                'ceph_secret',
-                'ceph_user',
-                'ceph_user_key',
-                'pool_name',
-                );
-            foreach(idx; attr; req) {
-                if(!exists(ds[attr])) {
-                    error("Invalid ceph image datastore! Expected '%s' ", attr);
-                };
+            if(!exists(ds['ceph_user_key'])) {
+                error("Invalid ceph image datastore. Expected 'ceph_user_key' attribute");
             };
         };
+        foreach(idx; attr; reqceph) {
+            if(!exists(ds[attr])) {
+                error("Invalid ceph image or system datastore! Expected '%s' ", attr);
+            };
+        };
+    };
+
+    if (exists(ds['ds_mad'])) {
         if (ds['ds_mad'] == 'dev') {
             if (ds['tm_mad'] != 'dev') {
                 error("for a RDM datastore both ds_mad and tm_mad should have value 'dev'");

--- a/ncm-opennebula/src/main/pan/components/opennebula/common.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/common.pan
@@ -31,28 +31,33 @@ check if a specific type of datastore has the right attributes
 }
 function is_consistent_datastore = {
     ds = ARGV[0];
-    if (ds['ds_mad'] == 'ceph') {
-        if (ds['tm_mad'] != 'ceph') {
-            error("for a ceph datastore both ds_mad and tm_mad should have value 'ceph'");
-        };
-        req = list('disk_type', 'bridge_list', 'ceph_host', 'ceph_secret', 'ceph_user', 'ceph_user_key', 'pool_name');
-        foreach(idx; attr; req) {
-            if(!exists(ds[attr])) {
-                error("Invalid ceph datastore! Expected '%s' ", attr);
+    if (exists(ds['ds_mad'])) {
+        if (ds['ds_mad'] == 'ceph') {
+            if (ds['tm_mad'] != 'ceph') {
+                error("for a ceph datastore both ds_mad and tm_mad should have value 'ceph'");
+            };
+            req = list(
+                'disk_type',
+                'bridge_list',
+                'ceph_host',
+                'ceph_secret',
+                'ceph_user',
+                'ceph_user_key',
+                'pool_name',
+                );
+            foreach(idx; attr; req) {
+                if(!exists(ds[attr])) {
+                    error("Invalid ceph image datastore! Expected '%s' ", attr);
+                };
             };
         };
-    };
-    if (ds['type'] == 'SYSTEM_DS') {
-        if (ds['tm_mad'] == 'ceph') {
-            error("system datastores do not support '%s' TM_MAD", ds['tm_mad']);
-        };
-    };
-    if (ds['ds_mad'] == 'dev') {
-        if (ds['tm_mad'] != 'dev') {
-            error("for a RDM datastore both ds_mad and tm_mad should have value 'dev'");
-        };
-        if(!exists(ds['disk_type'])) {
-            error("Invalid RDM datastore! Expected 'disk_type'");
+        if (ds['ds_mad'] == 'dev') {
+            if (ds['tm_mad'] != 'dev') {
+                error("for a RDM datastore both ds_mad and tm_mad should have value 'dev'");
+            };
+            if(!exists(ds['disk_type'])) {
+                error("Invalid RDM datastore! Expected 'disk_type'");
+            };
         };
     };
     # Checks for other types can be added here

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -276,6 +276,7 @@ type opennebula_datastore = {
         ceph: Uses Ceph storage backend.
     }
     "tm_mad" : choice('shared', 'ceph', 'ssh', 'vmfs', 'dev') = 'ceph'
+    #HEREEE
     "type" : string = 'IMAGE_DS' with match (SELF, '^(IMAGE_DS|SYSTEM_DS)$')
     @{datastore labels is a list of strings to group the datastores under a given name and filter them
     in the admin and cloud views. It is also possible to include in the list

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -268,7 +268,7 @@ type opennebula_datastore = {
     "bridge_list" ? string[]  # mandatory for ceph ds, lvm ds, ..
     "datastore_capacity_check" : boolean = true
     "disk_type" ? choice('RBD', 'BLOCK', 'CDROM', 'FILE')
-    "ds_mad" : choice('fs', 'ceph', 'dev') = 'ceph'
+    "ds_mad" ? choice('fs', 'ceph', 'dev')
     @{set system Datastore TM_MAD value.
         shared: The storage area for the system datastore is a shared directory across the hosts.
         vmfs: A specialized version of the shared one to use the vmfs file system.

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -276,8 +276,7 @@ type opennebula_datastore = {
         ceph: Uses Ceph storage backend.
     }
     "tm_mad" : choice('shared', 'ceph', 'ssh', 'vmfs', 'dev') = 'ceph'
-    #HEREEE
-    "type" : string = 'IMAGE_DS' with match (SELF, '^(IMAGE_DS|SYSTEM_DS)$')
+    "type" : choice('IMAGE_DS', 'SYSTEM_DS') = 'IMAGE_DS'
     @{datastore labels is a list of strings to group the datastores under a given name and filter them
     in the admin and cloud views. It is also possible to include in the list
     sub-labels using a common slash: list("Name", "Name/SubName")}

--- a/ncm-opennebula/src/main/perl/OpenNebula/Ceph.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Ceph.pm
@@ -26,7 +26,7 @@ sub enable_ceph_node
     my ($self, $host, $datastores) = @_;
 
     foreach my $ceph (sort keys %$datastores) {
-        if (($datastores->{$ceph}->{tm_mad} || "") eq 'ceph') {
+        if (($datastores->{$ceph}->{ds_mad} || "") eq 'ceph'){
             my $secret;
             if ($datastores->{$ceph}->{ceph_user_key}) {
                 $self->verbose("Found Ceph user key in $ceph datastore");
@@ -109,7 +109,7 @@ sub detect_ceph_datastores
     my @datastores = $one->get_datastores();
 
     foreach my $datastore (@datastores) {
-        if ($datastore->{data}->{TM_MAD}->[0] eq "ceph") {
+        if ($datastore->{data}->{DS_MAD}->[0] eq "ceph") {
             $self->verbose("Detected Ceph datastore: ", $datastore->name);
             return 1;
         }

--- a/ncm-opennebula/src/main/resources/tests/profiles/datastore_cephsys.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/datastore_cephsys.pan
@@ -1,21 +1,17 @@
-object template datastore_ceph;
+object template datastore_cephsys;
 
 include 'components/opennebula/schema';
 
-bind "/metaconfig/contents/datastore/ceph" = opennebula_datastore;
+bind "/metaconfig/contents/datastore/cephsys" = opennebula_datastore;
 
 "/metaconfig/module" = "datastore";
 
-prefix "/metaconfig/contents/datastore/ceph";
+prefix "/metaconfig/contents/datastore/cephsys";
 "bridge_list" = list("hyp004.cubone.os");
 "ceph_host" = list("ceph001.cubone.os", "ceph002.cubone.os", "ceph003.cubone.os");
 "ceph_secret" = "35b161e7-a3bc-440f-b007-cb98ac042646";
 "ceph_user" = "libvirt";
-"ceph_user_key" = "dummydummycephuserkey";
 "disk_type" = "RBD";
-"datastore_capacity_check" = true;
 "pool_name" = "one";
-"type" = "IMAGE_DS";
-"ds_mad" = "ceph";
-"rbd_format" = 2;
+"type" = "SYSTEM_DS";
 "labels" = list("quattor", "quattor/ceph");

--- a/ncm-opennebula/src/main/resources/tests/regexps/datastore_cephsys/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/datastore_cephsys/simple
@@ -1,0 +1,15 @@
+OpenNebula ceph datastore test
+---
+multiline
+---
+^NAME\s?=\s?".+"\s*$
+^BRIDGE_LIST\s?=\s?".+"\s*$
+^CEPH_HOST\s?=\s?".+"\s*$
+^CEPH_SECRET\s?=\s?".+"\s*$
+^CEPH_USER\s?=\s?".+"\s*$
+^DISK_TYPE\s?=\s?".+"\s*$
+^LABELS\s?=\s?"quattor,quattor/ceph"$
+^POOL_NAME\s?=\s?".+"\s*$
+^TM_MAD\s?=\s?".+"\s*$
+^TYPE\s?=\s?".+"\s*$
+^QUATTOR\s?=\s?\d+\s*$

--- a/ncm-opennebula/src/test/perl/opennebula.t
+++ b/ncm-opennebula/src/test/perl/opennebula.t
@@ -18,7 +18,7 @@ is($NCM::Component::OpenNebula::Server::ONEADMINGRP, 4, "One admin group id");
 $CAF::Object::NoAction = 1;
 
 # Set OpenNebula file version
-set_file_contents("/var/lib/one/remotes/VERSION", "6.0.0.2");
+set_file_contents("/var/lib/one/remotes/VERSION", "6.6.0");
 
 my $cmp = NCM::Component::opennebula->new("opennebula");
 

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -537,6 +537,23 @@ $cmds{rpc_create_newdatastore3}{params} = [$data, -1];
 $cmds{rpc_create_newdatastore3}{method} = "one.datastore.allocate";
 $cmds{rpc_create_newdatastore3}{out} = 104;
 
+$data = <<'EOF';
+NAME = "cephsys.altaria"
+BRIDGE_LIST = "hyp004.cubone.os"
+CEPH_HOST = "ceph001.cubone.os ceph002.cubone.os ceph003.cubone.os"
+CEPH_SECRET = "8371ae8a-386d-44d7-a228-c42de4259c6e"
+CEPH_USER = "libvirt"
+DATASTORE_CAPACITY_CHECK = "yes"
+DISK_TYPE = "RBD"
+POOL_NAME = "one"
+TM_MAD = "ceph"
+TYPE = "SYSTEM_DS"
+QUATTOR = 1
+EOF
+$cmds{rpc_create_newdatastore4}{params} = [$data, -1];
+$cmds{rpc_create_newdatastore4}{method} = "one.datastore.allocate";
+$cmds{rpc_create_newdatastore4}{out} = 105;
+
 $cmds{rpc_delete_datastore}{params} = [102];
 $cmds{rpc_delete_datastore}{method} = "one.datastore.delete";
 $cmds{rpc_delete_datastore}{out} = 102;
@@ -577,6 +594,12 @@ $cmds{rpc_list_datastore4}{params} = [104];
 $cmds{rpc_list_datastore4}{method} = "one.datastore.info";
 $cmds{rpc_list_datastore4}{out} = <<'EOF';
 <DATASTORE><ID>104</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>rdm</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>1</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><DS_MAD><![CDATA[dev]]></DS_MAD><TM_MAD><![CDATA[dev]]></TM_MAD><BASE_PATH><![CDATA[/var/lib/one//datastores/104]]></BASE_PATH><TYPE>0</TYPE><DISK_TYPE>2</DISK_TYPE><STATE>0</STATE><CLUSTERS><ID>-1</ID></CLUSTERS><TOTAL_MB>1</TOTAL_MB><FREE_MB>1</FREE_MB><USED_MB>0</USED_MB><IMAGES><ID>136</ID></IMAGES><TEMPLATE><ALLOW_ORPHANS><![CDATA[NO]]></ALLOW_ORPHANS><CLONE_TARGET><![CDATA[NONE]]></CLONE_TARGET><DISK_TYPE><![CDATA[BLOCK]]></DISK_TYPE><DS_MAD><![CDATA[dev]]></DS_MAD><LN_TARGET><![CDATA[NONE]]></LN_TARGET><RESTRICTED_DIRS><![CDATA[/]]></RESTRICTED_DIRS><SAFE_DIRS><![CDATA[/var/tmp]]></SAFE_DIRS><TM_MAD><![CDATA[dev]]></TM_MAD><TYPE><![CDATA[IMAGE_DS]]></TYPE></TEMPLATE></DATASTORE>
+EOF
+
+$cmds{rpc_list_datastore5}{params} = [105];
+$cmds{rpc_list_datastore5}{method} = "one.datastore.info";
+$cmds{rpc_list_datastore5}{out} = <<'EOF';
+<DATASTORE><ID>105</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>cephsys.altaria</NAME><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>0</OWNER_A><GROUP_U>1</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>0</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><DS_MAD><![CDATA[-]]></DS_MAD><TM_MAD><![CDATA[ceph]]></TM_MAD><BASE_PATH><![CDATA[/var/lib/one//datastores/105]]></BASE_PATH><TYPE>1</TYPE><DISK_TYPE>3</DISK_TYPE><STATE>0</STATE><CLUSTERS><ID>0</ID></CLUSTERS><TOTAL_MB>45966232</TOTAL_MB><FREE_MB>45824176</FREE_MB><USED_MB>142054</USED_MB><IMAGES/><TEMPLATE><ALLOW_ORPHANS><![CDATA[mixed]]></ALLOW_ORPHANS><BRIDGE_LIST><![CDATA[one02.altaria.os]]></BRIDGE_LIST><CEPH_HOST><![CDATA[ceph001.cubone.os ceph002.cubone.os ceph003.cubone.os]]></CEPH_HOST><CEPH_SECRET><![CDATA[8371ae8a-386d-44d7-a228-c42de4259c6e]]></CEPH_SECRET><CEPH_USER><![CDATA[altaria]]></CEPH_USER><DISK_TYPE><![CDATA[RBD]]></DISK_TYPE><DS_MIGRATE><![CDATA[NO]]></DS_MIGRATE><POOL_NAME><![CDATA[altaria]]></POOL_NAME><RESTRICTED_DIRS><![CDATA[/]]></RESTRICTED_DIRS><SAFE_DIRS><![CDATA[/var/tmp]]></SAFE_DIRS><SHARED><![CDATA[YES]]></SHARED><TM_MAD><![CDATA[ceph]]></TM_MAD><TYPE><![CDATA[SYSTEM_DS]]></TYPE></TEMPLATE></DATASTORE>
 EOF
 
 $data = <<'EOF';

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -170,6 +170,7 @@ prefix "/software/components/opennebula";
             "ceph_user_key", "AQCGZr1TeFUBMRBBHExosSnNXvlhuKexxcczpw==",
             "pool_name", "one",
             "type", "IMAGE_DS",
+            "ds_mad", "ceph",
             "labels", list("quattor", "quattor/ceph"),
         ),
         "nfs", dict(
@@ -198,6 +199,17 @@ prefix "/software/components/opennebula";
             "disk_type", "BLOCK",
             "datastore_capacity_check", false,
             "labels", list("quattor", "quattor/rdm"),
+        ),
+        "cephsys.altaria", dict(
+            "tm_mad", "ceph",
+            "type", "SYSTEM_DS",
+            "bridge_list", list("hyp004.cubone.os"),
+            "ceph_host", list("ceph001.cubone.os", "ceph002.cubone.os", "ceph003.cubone.os"),
+            "ceph_secret", "8371ae8a-386d-44d7-a228-c42de4259c6e",
+            "ceph_user", "libvirt",
+            "disk_type", "RBD",
+            "pool_name", "one",
+            "clusters", list("default", "red.cluster"),
         ),
 );
 


### PR DESCRIPTION
This includes a new type of ceph datastore in opennebula. The ceph system datastore replaces the current shared system ds for live migrations. It should be the default one for ceph. 

* Fixes: #1649 
