### PR TITLE
ncm-network: mirror "old" bootproto behaviour in nmstate

### DIFF
--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -282,7 +282,7 @@ sub generate_nmstate_config
     my $iface = $net->{interfaces}->{$name};
     my $device = $iface->{device} || $name;
     my $is_eth = $iface->{set_hwaddr};
-    my $eth_bootproto = $iface->{bootproto};
+    my $eth_bootproto = $iface->{bootproto} || 'static';
     my $is_ip = exists $iface->{ip} ? 1 : 0;
     my $is_vlan_eth = exists $iface->{vlan} ? 1 : 0;
     my $is_bond_eth = exists $iface->{master} ? 1 : 0;


### PR DESCRIPTION
I spent a good time figuring out why `nmstate.pm` was not changing IP's. The code of nmstate is:
```
    if (defined($eth_bootproto)) {
        if ($eth_bootproto eq 'static') {
```

In our templates we don't set `bootproto`.

but if I look in `network.pm` it does:
```
    # set the bootprotocol
    &$makeline('bootproto', def => 'static');

    my $bootproto = $iface->{bootproto} || 'static';
```

So I think `nmstate.pm` should mimic that behavior.
