### PR TITLE
ncm-network: nmstate dgw fix

### DIFF
--- a/ncm-network/src/test/perl/nmstate_advance.t
+++ b/ncm-network/src/test/perl/nmstate_advance.t
@@ -45,6 +45,9 @@ routes:
   config:
   - next-hop-interface: eth0
     state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 4.3.2.254
+    next-hop-interface: eth0
   - destination: 1.2.3.4/32
     next-hop-interface: eth0
   - destination: 1.2.3.5/24
@@ -82,6 +85,9 @@ routes:
   config:
   - next-hop-interface: eth0.123
     state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 4.3.2.254
+    next-hop-interface: eth0.123
   - destination: 1.2.3.4/32
     next-hop-interface: eth0.123
 EOF
@@ -107,6 +113,9 @@ routes:
   config:
   - next-hop-interface: vlan0
     state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 4.3.2.254
+    next-hop-interface: eth0.123
   - destination: 1.2.3.4/32
     next-hop-interface: vlan0
 EOF
@@ -152,6 +161,9 @@ routes:
   config:
   - next-hop-interface: bond0
     state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 4.3.2.254
+    next-hop-interface: bond0
 EOF
 
 

--- a/ncm-network/src/test/perl/nmstate_simple.t
+++ b/ncm-network/src/test/perl/nmstate_simple.t
@@ -61,6 +61,9 @@ routes:
   config:
   - next-hop-interface: eth0
     state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 4.3.2.254
+    next-hop-interface: eth0
 EOF
 
 Readonly my $NOTTOREMOVE => <<EOF;

--- a/ncm-network/src/test/resources/nmstate_advance.pan
+++ b/ncm-network/src/test/resources/nmstate_advance.pan
@@ -3,6 +3,7 @@ object template nmstate_advance;
 include 'simple_base_profile';
 include 'components/network/config-nmstate';
 
+"/system/network/default_gateway" = "4.3.2.254";
 # additional interface testing for nmstate.
 "/system/network/interfaces/eth1" = create("dhcpinterface");
 "/hardware/cards/nic/eth1/hwaddr" = "6e:a5:1b:55:77:0b";


### PR DESCRIPTION
Fix for setting default gateway in nmstate with correct interface by looking up if gateway falls within subnet boundary.
next-hop-interface is mandatory for nmstate therefore figure out which interface subnet this gateway falls in. 
This will provide backward compatibility with network.pm

closes #1655 

* Why the change is necessary.
to provide backward compatibility with network.pm when setting default gateway. without having to set gateway address on interface.

* What backwards incompatibility it may introduce.
None.