### PR TITLE
ncm-mysql: add an option to use encrypted user password

### DIFF
--- a/ncm-mysql/src/main/pan/components/mysql/schema.pan
+++ b/ncm-mysql/src/main/pan/components/mysql/schema.pan
@@ -59,6 +59,7 @@ type component_mysql_db_user = {
     'password' : string with (length(SELF) == 0) || component_mysql_password_valid(SELF)
     'rights' : component_mysql_user_right[] = list('SELECT')
     'shortPwd' : boolean = false
+    'encrypted_pwd' : boolean = false
 };
 
 
@@ -84,6 +85,7 @@ type component_mysql_server_options = {
     'host' ? string
     'adminuser' : string
     'adminpwd' : string with component_mysql_password_valid(SELF)
+    'encrypted_adminpwd' : boolean = false
     'options' ? string{}
     'users' ? component_mysql_db_user{}
 };

--- a/ncm-mysql/src/main/perl/mysql.pod
+++ b/ncm-mysql/src/main/perl/mysql.pod
@@ -45,9 +45,11 @@ Value is a nlist with the following possible keys :
 
 =over
 
-=item password : user MySQL password. Must be a cleartext password.
+=item password : user MySQL password. Must be a cleartext password if encrypted_pwd is false (default value) or an encrypted password (using mysql command : select password('my_secret_password');).
 
 =item rights : list of MySQL privileges to grant to the user.
+
+=item encrypted_pwd : boolean (optional). If true, password will be used as an encrypted value.
 
 =back
 

--- a/ncm-mysql/src/test/resources/basic_service.pan
+++ b/ncm-mysql/src/test/resources/basic_service.pan
@@ -11,6 +11,9 @@ prefix "/software/components/mysql/databases/opennebula";
 "server" = "one";
 "users/oneadmin/password" = 'p4ss';
 "users/oneadmin/rights" = list("ALL PRIVILEGES");
+"users/oneuser/password" = '*2F01F3D078AE27EB3017F8F53DF9C31AEA6D90C5'; # clear password : plop
+"users/oneuser/encrypted_adminpwd" = true;
+"users/oneuser/rights" = list("ALL PRIVILEGES");
 "createDb" = false;
 "initScript/file" = "/dev/null";
 


### PR DESCRIPTION
Add the possibility to store password in an encrypted way inside templates.
The schema is modified (`component_mysql_db_user` and `component_mysql_server_options` types) to add a boolean option `encrypted_adminpwd` which is false by default.

When `true`, the password has to be set in its encrypted form.
The easiest way to generate the encrypted password is the MySQL command `select password('plop');`

These modifications is fully backward compatible and could be use without changing anything in the templates.