### PR TITLE
ncm-metaconfig: fix a typo in 'actions' resource description

### DIFF
--- a/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
+++ b/ncm-metaconfig/src/main/pan/components/metaconfig/schema.pan
@@ -39,7 +39,7 @@ type ${project.artifactId}_textrender_convert = {
     foreach (idx; name; boolean_conversion) {
         if(exists(SELF[name]) && SELF[name]) {
             if(found) {
-                error(format('metaconfig element can only have one boolean conversion enabled, got %s', SELF));
+                error('metaconfig element can only have one boolean conversion enabled, got %s', SELF);
             };
             found = true;
         };
@@ -51,7 +51,7 @@ type ${project.artifactId}_textrender_convert = {
     foreach (idx; name; string_conversion) {
         if(exists(SELF[name]) && SELF[name]) {
             if(found) {
-                error(format('metaconfig element can only have one string conversion enabled, got %s', SELF));
+                error('metaconfig element can only have one string conversion enabled, got %s', SELF);
             };
             found = true;
         };
@@ -63,7 +63,7 @@ type ${project.artifactId}_textrender_convert = {
     foreach (idx; name; list_conversion) {
         if(exists(SELF[name]) && SELF[name]) {
             if(found) {
-                error(format('metaconfig element can only have one list conversion enabled, got %s', SELF));
+                error('metaconfig element can only have one list conversion enabled, got %s', SELF);
             };
             found = true;
         };
@@ -75,7 +75,7 @@ type ${project.artifactId}_textrender_convert = {
     foreach (idx; name; key_conversion) {
         if(exists(SELF[name]) && SELF[name]) {
             if(found) {
-                error(format('metaconfig element can only have one key case conversion enabled, got %s', SELF));
+                error('metaconfig element can only have one key case conversion enabled, got %s', SELF);
             };
             found = true;
         };
@@ -135,7 +135,7 @@ type ${project.artifactId}_config =  {
     'contents' : ${project.artifactId}_extension
     @{Predefined conversions from EDG::WP4::CCM::TextRender}
     'convert' ? ${project.artifactId}_textrender_convert
-    @{Actions (i.e. names found in /software/components/metadata/commands) to run when processing the service.
+    @{Actions (i.e. names found in /software/components/metaconfig/commands) to run when processing the service.
       Refer to the metaconfig_actions type definition for the available hooks
       for when a command may be run.}
     'actions' ? ${project.artifactId}_actions


### PR DESCRIPTION
Fix a small but misleading typo in `ncm-metaconfig` schema
