### PR TITLE
ncm-systemd: Add PrivateNetwork schema entry

### DIFF
--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -204,6 +204,7 @@ type ${project.artifactId}_unitfile_config_systemd_exec = {
     'Nice' ? long(-20..19)
     'OOMScoreAdjust' ? long(-1000..1000)
     'PrivateTmp' ? boolean
+    'PrivateNetwork' ? boolean
     'RootDirectory' ? ${project.artifactId}_relative_directory
     'RuntimeDirectoryMode' ? type_octal_mode
     'RuntimeDirectoryPreserve' ? choice('yes', 'no', 'restart')


### PR DESCRIPTION
Add a schema entry for PrivateNetwork to systemd 
(https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#PrivateNetwork=)

When deploying Rocky 9, I encounterd a problem where I needed to change this from its default setting, but was unable to as quattor did not know about this configuration option to systemd.
