### PR TITLE
ncm-sudo: support all values for lecture option and the lecture_file option

### DIFF
--- a/ncm-sudo/src/main/pan/components/sudo/schema.pan
+++ b/ncm-sudo/src/main/pan/components/sudo/schema.pan
@@ -46,7 +46,9 @@ type sudo_default_options = {
     "mail_no_host" ? boolean
     "mail_no_perms" ? boolean
     "tty_tickets" ? boolean
-    "lecture" ? boolean
+    # old boolean behaviour: true means once, false means never
+    "lecture" ? choice('always', 'once', 'never')
+    "lecture_file" ? absolute_file_path
     "authenticate" ? boolean
     "root_sudo" ? boolean
     "log_host" ? boolean

--- a/ncm-sudo/src/main/perl/sudo.pm
+++ b/ncm-sudo/src/main/perl/sudo.pm
@@ -73,7 +73,6 @@ use constant BOOLEAN_OPTS => qw(
     mail_no_host
     mail_no_perms
     tty_tickets
-    lecture
     authenticate
     root_sudo
     log_host
@@ -124,6 +123,8 @@ use constant STRING_OPTS => qw(
     verifypw
     listpw
     secure_path
+    lecture
+    lecture_file
 );
 
 # generate_aliases method


### PR DESCRIPTION
this is backwards incompatible

@jrha needs to be checked if this supported on el7 or ~el6~