### PR TITLE
ncm-metaconfig beats: add seccomp to file beat schema to allow seccomp config for filebeat.yml

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_6.3.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_6.3.pan
@@ -133,7 +133,7 @@ type beats_logging = {
     (see https://www.elastic.co/guide/en/beats/filebeat/6.8/linux-seccomp.html)
 }
 type beats_seccomp = {
-    'default_action' : string
+    'default_action' : choice('errno', 'trace', 'trap', 'kill_thread', 'kill_process', 'log', 'allow');
 };
 
 @documenation{

--- a/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_6.3.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_6.3.pan
@@ -128,6 +128,14 @@ type beats_logging = {
     'level' ? string with match(SELF, '^(critical|error|warning|info|debug)$')
 };
 
+@documentation{
+    Secomp settings for RHEL with Linux >3.16
+    (see https://www.elastic.co/guide/en/beats/filebeat/6.8/linux-seccomp.html)
+}
+type beats_seccomp = {
+    'default_action' : string
+};
+
 @documenation{
     Shared components for each beats service
 }
@@ -140,6 +148,7 @@ type beats_service = {
     'refresh_topology_freq' ? long(0..)
     'topology_expire' ? long(0..)
     'geoip' ? beats_shipper_geoip
+    'seccomp' ? beats_seccomp
 };
 
 @documentation{


### PR DESCRIPTION
**Why the change is necessary.**
To append the schema to support configuration `seccomp` default action. This is because in Rocky 9 filebeat may be presented to start See: [https://www.elastic.co/guide/en/beats/filebeat/6.8/linux-seccomp.html)](https://www.elastic.co/guide/en/beats/filebeat/6.8/linux-seccomp.html) 

resolves #1699 

**What backwards incompatibility it may introduce.**
The change has been tested on both Rocky 8 and Rocky 9 aquilon hosts with filebeat. This change allows filebeat to work on Rocky 9 while not showing negative effects for existing Rocky 8 hosts.
Services which configures filebeat.yml using this module should ensure that it continues to produce the correct configuration.