### PR TITLE
ncm-metaconfig: Allow basic httpd remoteip config to be expressed

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/httpd/config/global.tt
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/config/global.tt
@@ -3,7 +3,10 @@
                 "hostnamelookups", 
                 ]
 -%]
-[%- lists = ["directoryindex", "indexoptions", "indexignore"] -%]
+[%- lists = ["directoryindex", "indexoptions", "indexignore",
+             "remoteiptrustedproxy", "remoteipproxyprotocolexceptions"
+            ]
+-%]
 [%- quotes = ["serverroot"] -%] 
 [%- FOREACH pair IN desc.pairs -%]
 [%-     SWITCH pair.key -%]

--- a/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/httpd/pan/schema.pan
@@ -680,6 +680,10 @@ type httpd_global_system = {
 
     "limitrequestfieldsize" ? long
     "traceenable" ? string with match(SELF, '^(on|off|extended)$')
+
+    "remoteipproxyprotocol" ? choice('on', 'off')
+    "remoteipproxyprotocolexceptions" ? type_network_name[]
+    "remoteiptrustedproxy" ? type_network_name[]
 };
 
 type httpd_ifmodule_parameters = {


### PR DESCRIPTION
### Why the change is necessary.

- Needed to allow a basic remoteip config to be expressed for httpd, see https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html.
- I have added the new definitions to the global section because, even though `RemoteIPProxyProtocol` can be defined at the vhost level, only one such definition will take affect, and do so globally.

### What backwards incompatibility it may introduce.
None, the new features have been added as optional.