### PR TITLE
Fixes #1704: ncm-grub::pxeboot return SUCCESS on non-UEFI systems

### DIFF
--- a/ncm-grub/src/main/perl/grub.pm
+++ b/ncm-grub/src/main/perl/grub.pm
@@ -21,6 +21,7 @@ Readonly my $GRUB2_USER_CFG      => "$GRUB2_DIR/user.cfg";
 Readonly my $GRUBBY              => '/sbin/grubby';
 Readonly my $PREFIX              => '/boot';
 Readonly my $EFIBOOTMGR          => '/sbin/efibootmgr';
+Readonly my $SYS_FIRMWARE_EFI    => '/sys/firmware/efi';
 Readonly::Hash my %SERIAL_CONSOLE_DEFAULTS => {
     unit => 0,
     speed => 9600,
@@ -891,6 +892,11 @@ sub pxeboot
 
     if (!$self->file_exists($EFIBOOTMGR)) {
         $self->info("pxeboot: no $EFIBOOTMGR found. Not doing anything");
+        return SUCCESS;
+    }
+
+    if (!$self->directory_exists($SYS_FIRMWARE_EFI)) {
+        $self->info("pxeboot: no $SYS_FIRMWARE_EFI found. Not doing anything");
         return SUCCESS;
     }
 

--- a/ncm-grub/src/test/perl/methods.t
+++ b/ncm-grub/src/test/perl/methods.t
@@ -405,20 +405,25 @@ ok(command_history_ok([
 =cut
 
 my $ebm = '/sbin/efibootmgr';
+my $sfe = '/sys/firmware/efi';
 command_history_reset();
 ok (!$cmp->file_exists($ebm), "efibootmgr does not exist");
 ok($cmp->pxeboot(), "pxeboot returns success when efibootmgr is missing");
 ok(command_history_ok(undef, ['']), "No commands were run when efibootmgr is missing");
+ok (!$cmp->directory_exists($sfe), "/sys/firmware/efi does not exist");
+ok($cmp->pxeboot(), "pxeboot returns success when /sys/firmware/efi is missing");
+ok(command_history_ok(undef, ['']), "No commands were run when /sys/firmware/efi is missing");
 
+$mock->mock('directory_exists', 1);
 set_file_contents($ebm, '');
 set_desired_output("$ebm -v", "$EFIBOOTMGROUT");
 ok ($cmp->file_exists($ebm), "efibootmgr does exist");
 ok($cmp->pxeboot(), "pxeboot returns success");
+$mock->unmock('directory_exists');
 ok(command_history_ok([
    "$ebm -v",
    "$ebm -o 4,3,2",
 ]), "efibootmgr called, correct bootorder set");
-
 
 =head1 sanitize_arguments
 


### PR DESCRIPTION
Ensure the title of this pull-request starts with the component name followed by a colon, e.g.
> ncm-example: demonstrate what titles should look like

Describe the change you are making here, in particular we would like to know:

* Why the change is necessary.
* What backwards incompatibility it may introduce.
