### PR TITLE
ncm-ssh: extend AllowTcpForwarding to support valid values

### DIFF
--- a/ncm-ssh/src/main/pan/components/ssh/schema.pan
+++ b/ncm-ssh/src/main/pan/components/ssh/schema.pan
@@ -97,7 +97,7 @@ type ssh_daemon_options_type = {
     "AcceptEnv" ? string[]
     "AllowAgentForwarding" ? legacy_binary_affirmation_string
     "AllowGroups" ? string
-    "AllowTcpForwarding" ? legacy_binary_affirmation_string
+    "AllowTcpForwarding" ? choice('yes', 'no', 'all', 'local', 'remote')
     "AllowUsers" ? string
     "AuthorizedKeysFile" ? string
     "Banner" ? string


### PR DESCRIPTION
AllowTcpForwarding in ncm-ssh uses legacy_binary_affirmation_string, but other options such as "remote" and "local" are valid, so change schema to support valid values

Resolves #1690