### PR TITLE
ncm-hostsfile: Fix NoAction support declaration

### DIFF
--- a/ncm-hostsfile/src/main/perl/hostsfile.pm
+++ b/ncm-hostsfile/src/main/perl/hostsfile.pm
@@ -49,7 +49,7 @@ use strict;
 use base 'NCM::Component';
 
 our $EC = LC::Exception::Context->new->will_store_all;
-our $NoActionSupported = 1;
+our $NoActionSupported = 0;
 
 use LC::Check;
 use LC::File;


### PR DESCRIPTION
The component uses LC rather than CAF, so cannot support NoAction properly.