### PR TITLE
ncm-sysctl: Cleanup & fixes

### DIFF
--- a/ncm-sysctl/src/main/pan/components/sysctl/schema.pan
+++ b/ncm-sysctl/src/main/pan/components/sysctl/schema.pan
@@ -16,7 +16,7 @@ type component_sysctl_structure = {
     include structure_component
 
     'command' : string = '/sbin/sysctl' with match(SELF, '^/.+')
-    'compat-v1' : boolean = false
+    'compat-v1' ? boolean with deprecated(0, 'compat-v1 has no effect and will be removed in a future release')
     'confFile' : string = '/etc/sysctl.conf' with match(SELF, '^(/.+|[^/]+)\.conf$') # disallow / unless an absolute path is supplied.
     'variables' ? string{}
 };

--- a/ncm-sysctl/src/test/perl/configure.t
+++ b/ncm-sysctl/src/test/perl/configure.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-# -*- mode: cperl -*-
 use strict;
 use warnings;
 

--- a/ncm-sysctl/src/test/resources/simple.pan
+++ b/ncm-sysctl/src/test/resources/simple.pan
@@ -4,6 +4,3 @@ prefix "/software/components/sysctl";
 "command" = "/sbin/sysctl";
 "confFile" = "50-quattor.conf";
 "variables/kernel.sysrq" = "1";
-
-
-


### PR DESCRIPTION
* Trim newlines at EOF
* Remove shebang and editor config from tests
* Deprecate compat-v1 as having no effect 
  (The code was removed pre-2008)