### PR TITLE
ncm-network: Move nmstate options to new schema

### DIFF
--- a/ncm-network/src/main/pan/components/network/core-schema-legacy.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema-legacy.pan
@@ -27,16 +27,10 @@ type structure_route = {
     @{route add command options to use (cannot be combined with other options)}
     "command" ? string with !match(SELF, '[;]')
 } with {
-    if (exists(SELF['command'])) {
-        module = value('/software/components/network/ncm-module', '');
-        if (module == 'nmstate') error("Command routes are not supported by the nmstate backend");
-        if (length(SELF) != 1) error("Cannot use command and any of the other attributes as route");
-    } else {
-        if (!exists(SELF['address']))
-            error("Address is mandatory for route (in absence of command)");
-        if (exists(SELF['prefix']) && exists(SELF['netmask']))
-            error("Use either prefix or netmask as route");
-    };
+    if (!exists(SELF['address']))
+        error("Address is mandatory for route (in absence of command)");
+    if (exists(SELF['prefix']) && exists(SELF['netmask']))
+        error("Use either prefix or netmask as route");
 
     if (exists(SELF['prefix'])) {
         pref = SELF['prefix'];
@@ -439,10 +433,6 @@ type structure_network = {
     "set_hwaddr" ? boolean
     "nmcontrolled" ? boolean
     "allow_nm" ? boolean
-    @{let NetworkManager manage the dns (only for nmstate)}
-    "nm_manage_dns" : boolean = false
-    @{let ncm-network cleanup inactive connections (only for nmstate)}
-    "nm_clean_inactive_conn" : boolean = true
     "primary_ip" ? string
     "routers" ? structure_router{}
     "ipv6" ? structure_ipv6

--- a/ncm-network/src/main/pan/components/network/core-schema.pan
+++ b/ncm-network/src/main/pan/components/network/core-schema.pan
@@ -2,7 +2,7 @@
 
 declaration template components/network/core-schema;
 
-final variable QUATTOR_TYPES_NETWORK_LEGACY ?= true;
+final variable QUATTOR_TYPES_NETWORK_LEGACY ?= false;
 
 include if (QUATTOR_TYPES_NETWORK_LEGACY) 'components/network/core-schema-legacy'
     else 'components/network/types/network';

--- a/ncm-network/src/main/pan/components/network/types/network.pan
+++ b/ncm-network/src/main/pan/components/network/types/network.pan
@@ -41,6 +41,7 @@ type network_ipv6 = {
     when using ncm-network (unless specified otherwise).
 }
 type structure_network = {
+    include structure_network_backend_specific
     "domainname" : type_fqdn
     "hostname" : type_shorthostname
     "realhostname" ? string with is_shorthostname(SELF) || is_fqdn(SELF)
@@ -63,10 +64,6 @@ type structure_network = {
     "set_hwaddr" ? boolean
     "nmcontrolled" ? boolean
     "allow_nm" ? boolean
-    @{let NetworkManager manage the dns (only for nmstate)}
-    "nm_manage_dns" : boolean = false
-    @{let ncm-network cleanup inactive connections (only for nmstate)}
-    "nm_clean_inactive_conn" : boolean = true
     "primary_ip" ? string
     "routers" ? network_router{}
     "ipv6" ? network_ipv6

--- a/ncm-network/src/main/pan/components/network/types/network/backend/initscripts.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/backend/initscripts.pan
@@ -1,3 +1,6 @@
 declaration template components/network/types/network/backend/initscripts;
 
 @{implement types specific for initscripts / network.pm}
+
+type structure_network_backend_specific = {
+};

--- a/ncm-network/src/main/pan/components/network/types/network/backend/initscripts.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/backend/initscripts.pan
@@ -4,3 +4,15 @@ declaration template components/network/types/network/backend/initscripts;
 
 type structure_network_backend_specific = {
 };
+
+function network_valid_route = {
+    if (exists(SELF['prefix']) && exists(SELF['netmask'])) {
+        error("Use either prefix or netmask as route");
+    };
+
+    if (exists(SELF['prefix'])) {
+        network_valid_prefix(SELF);
+    };
+
+    true;
+};

--- a/ncm-network/src/main/pan/components/network/types/network/backend/nmstate.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/backend/nmstate.pan
@@ -8,3 +8,20 @@ type structure_network_backend_specific = {
     @{let ncm-network cleanup inactive connections}
     "clean_inactive_conn" : boolean = true
 };
+
+function network_valid_route = {
+    if (exists(SELF['command'])) {
+        if (length(SELF) != 1) error("Cannot use command and any of the other attributes as route");
+    } else {
+        if (!exists(SELF['address']))
+            error("Address is mandatory for route (in absence of command)");
+        if (exists(SELF['prefix']) && exists(SELF['netmask']))
+            error("Use either prefix or netmask as route");
+    };
+
+    if (exists(SELF['prefix'])) {
+        network_valid_prefix(SELF);
+    };
+
+    true;
+};

--- a/ncm-network/src/main/pan/components/network/types/network/backend/nmstate.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/backend/nmstate.pan
@@ -1,3 +1,10 @@
 declaration template components/network/types/network/backend/nmstate;
 
 @{implement types specific for nmstate / nmstate.pm}
+
+type structure_network_backend_specific = {
+    @{let NetworkManager manage the dns}
+    "manage_dns" : boolean = false
+    @{let ncm-network cleanup inactive connections}
+    "clean_inactive_conn" : boolean = true
+};

--- a/ncm-network/src/main/pan/components/network/types/network/route.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/route.pan
@@ -2,37 +2,23 @@ declaration template components/network/types/network/route;
 
 type network_valid_routing_table = string with exists("/system/network/routing_table/" + SELF);
 
-function network_valid_route = {
-    if (exists(SELF['command'])) {
-        network_exclude_backend('nmstate', 'command routes');
-        if (length(SELF) != 1) error("Cannot use command and any of the other attributes as route");
+function network_valid_prefix = {
+    pref = ARGV[0]['prefix'];
+    ipv6 = false;
+    foreach (k; v; ARGV[0]) {
+        if (match(to_string(v), ':')) {
+            ipv6 = true;
+        };
+    };
+    if (ipv6) {
+        if (!is_ipv6_prefix_length(pref)) {
+            error("Prefix %s is not a valid IPv6 prefix", pref);
+        };
     } else {
-        if (!exists(SELF['address']))
-            error("Address is mandatory for route (in absence of command)");
-        if (exists(SELF['prefix']) && exists(SELF['netmask']))
-            error("Use either prefix or netmask as route");
-    };
-
-    if (exists(SELF['prefix'])) {
-        pref = SELF['prefix'];
-        ipv6 = false;
-        foreach (k; v; SELF) {
-            if (match(to_string(v), ':')) {
-                ipv6 = true;
-            };
-        };
-        if (ipv6) {
-            if (!is_ipv6_prefix_length(pref)) {
-                error("Prefix %s is not a valid IPv6 prefix", pref);
-            };
-        } else {
-            if (!is_ipv4_prefix_length(pref)) {
-                error("Prefix %s is not a valid IPv4 prefix", pref);
-            };
+        if (!is_ipv4_prefix_length(pref)) {
+            error("Prefix %s is not a valid IPv4 prefix", pref);
         };
     };
-
-    true;
 };
 
 @documentation{

--- a/ncm-network/src/main/pan/components/network/types/network/route.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/route.pan
@@ -2,26 +2,7 @@ declaration template components/network/types/network/route;
 
 type network_valid_routing_table = string with exists("/system/network/routing_table/" + SELF);
 
-@documentation{
-    Add route (IPv4 of IPv6)
-    Presence of ':' in any of the values indicates this is IPv6 related.
-}
-type network_route = {
-    @{The ADDRESS in ADDRESS/PREFIX via GATEWAY}
-    "address" ? string with {SELF == 'default' || is_ip(SELF)}
-    @{The PREFIX in ADDRESS/PREFIX via GATEWAY}
-    "prefix"  ? long
-    @{The GATEWAY in ADDRESS/PREFIX via GATEWAY}
-    "gateway" ? type_ip
-    @{alternative notation for prefix (cannot be combined with prefix)}
-    "netmask" ? type_ip
-    @{routing table}
-    "table" ? network_valid_routing_table
-    @{pretend that the nexthop is directly attached to this link}
-    "onlink" ? boolean
-    @{route add command options to use (cannot be combined with other options)}
-    "command" ? string with !match(SELF, '[;]')
-} with {
+function network_valid_route = {
     if (exists(SELF['command'])) {
         network_exclude_backend('nmstate', 'command routes');
         if (length(SELF) != 1) error("Cannot use command and any of the other attributes as route");
@@ -53,3 +34,24 @@ type network_route = {
 
     true;
 };
+
+@documentation{
+    Add route (IPv4 of IPv6)
+    Presence of ':' in any of the values indicates this is IPv6 related.
+}
+type network_route = {
+    @{The ADDRESS in ADDRESS/PREFIX via GATEWAY}
+    "address" ? string with {SELF == 'default' || is_ip(SELF)}
+    @{The PREFIX in ADDRESS/PREFIX via GATEWAY}
+    "prefix"  ? long
+    @{The GATEWAY in ADDRESS/PREFIX via GATEWAY}
+    "gateway" ? type_ip
+    @{alternative notation for prefix (cannot be combined with prefix)}
+    "netmask" ? type_ip
+    @{routing table}
+    "table" ? network_valid_routing_table
+    @{pretend that the nexthop is directly attached to this link}
+    "onlink" ? boolean
+    @{route add command options to use (cannot be combined with other options)}
+    "command" ? string with !match(SELF, '[;]')
+} with network_valid_route(SELF);

--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -32,7 +32,7 @@ use Readonly;
 
 Readonly my $NMSTATECTL => '/usr/bin/nmstatectl';
 Readonly my $NMCLI_CMD => '/usr/bin/nmcli';
-# pick a config name for nmstate yml to configure dns-resolver: settings. if nm_manage_dns=true
+# pick a config name for nmstate yml to configure dns-resolver: settings. if manage_dns=true
 Readonly my $NM_RESOLV_YML => "/etc/nmstate/resolv.yml";
 Readonly my $NM_DROPIN_CFG_FILE => "/etc/NetworkManager/conf.d/90-quattor.conf";
 
@@ -82,7 +82,7 @@ sub is_valid_interface
 
 # By default, NetworkManager on Red Hat Enterprise Linux (RHEL) 8+ dynamically updates the /etc/resolv.conf
 # file with the DNS settings from active NetworkManager connection profiles. we manage this using ncm-resolver.
-# so disable this unless nm_manage_dns = true. resolver details can be set using nmstate but not doing this now.
+# so disable this unless manage_dns = true. resolver details can be set using nmstate but not doing this now.
 sub disable_nm_manage_dns
 {
     my ($self, $manage_dns, $nwsrv) = @_;
@@ -571,7 +571,7 @@ sub generate_nmstate_config
 };
 
 # Generate hash of dns-resolver config for nmstate.
-# only used if nm_manage_dns = true.
+# only used if manage_dns = true.
 sub generate_nm_resolver_config
 {
     my ($self, $net, $manage) = @_;
@@ -699,7 +699,7 @@ sub nmstate_apply
         $action = 0;
     }
     # apply resolver config if exists.
-    # this will exist at this stage if nm_manage_dns is set to true.
+    # this will exist at this stage if manage_dns is set to true.
     my $resolv_state = $exifiles->{$NM_RESOLV_YML} || 0;
     if ($self->file_exists($NM_RESOLV_YML))
     {
@@ -770,7 +770,7 @@ sub Configure
     my $nwtree = $config->getTree($NETWORK_PATH);
 
     my $hostname = $nwtree->{realhostname} || "$nwtree->{hostname}.$nwtree->{domainname}";
-    my $manage_dns = $nwtree->{nm_manage_dns} || 0;
+    my $manage_dns = $nwtree->{manage_dns} || 0;
     my $dgw = $nwtree->{default_gateway};
     if (!$dgw) {
         $self->warn ("No default gateway configured");
@@ -911,7 +911,7 @@ sub Configure
 
     # cleanup dangling inactive connections after ncm network changes are applied.
     # defaults to cleanup
-    my $clean_inactive_conn = $net->{nm_clean_inactive_conn};
+    my $clean_inactive_conn = $net->{clean_inactive_conn};
     if ($clean_inactive_conn and $stopstart) {
         # look to cleanup connections only when something is changed.
         $self->clear_inactive_nm_connections;

--- a/ncm-network/src/test/perl/nmstate_simple.t
+++ b/ncm-network/src/test/perl/nmstate_simple.t
@@ -118,6 +118,7 @@ ok(command_history_ok([
   '/usr/bin/nmcli connection',
   'service NetworkManager reload',
   'systemctl disable nmstate',
+  'systemctl stop nmstate',
   '/usr/bin/nmstatectl apply /etc/nmstate/eth0.yml',
   '/usr/bin/nmstatectl apply /etc/nmstate/resolv.yml',
   'service NetworkManager reload',

--- a/ncm-network/src/test/resources/nmstate_simple.pan
+++ b/ncm-network/src/test/resources/nmstate_simple.pan
@@ -1,5 +1,7 @@
 object template nmstate_simple;
 
+variable QUATTOR_TYPES_NETWORK_BACKEND = 'nmstate';
+
 include 'simple_base_profile';
 "/hardware/cards/nic/eth0/hwaddr" = "6e:a5:1b:55:77:0a";
 # the next include is mainly to the profile, it is not used in the tests


### PR DESCRIPTION
@aka7 as promised this splits out the nmstate specific parts of the schema into the new structure @stdweird designed.

This also defaults to using the new schema and to be honest I don't see a reason to keep the legacy schema file around.

Backwards incompatible from 23.6.0 for anyone setting `"nm_manage_dns" = true` or more generally for any sites using the current code from master.