### PR TITLE
ncm-spma: update to dnf backend to exclude additional kernel packages.

### DIFF
--- a/ncm-spma/src/main/perl/spma/dnf.pm
+++ b/ncm-spma/src/main/perl/spma/dnf.pm
@@ -553,7 +553,7 @@ sub Configure
         my $rpm_version = (split(':', $rpm))[-1];
 
         # Do not remove core packages for currently running kernel.
-        if ( ($rpm =~ /^(kernel|kernel-core|kernel-modules)-(\d+):/) &&
+        if ( ($rpm =~ /^(kernel(-[\w-]+)?)-(\d+):/) &&
             (index($rpm_version, $kvers) == 0 || match_glob($kvers, $rpm_version))) {
             $self->info("Skip removal of core package(s) for running kernel: $rpm");
             $will_remove->delete($rpm);


### PR DESCRIPTION
exclude additional kernel packages part of the running kernel.

* Why the change is necessary.
on rhel9, spma tries to remove kernel-module-core package even if version is the running kernel. This creates dependency package  kernel-core package to be removed by spma, and we get following error from dnf when spma runs:
  ```
  Problem: The operation would result in removing the following protected packages: kernel-core
  Nothing to do.
  ```

* What backwards incompatibility it may introduce.
None.
