### PR TITLE
ncm-nmstate: remove confusing warning in IPv6 configuration

### DIFF
--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -502,7 +502,6 @@ sub generate_nmstate_config
             }
             # IPv6 configuration
             if ($iface->{ipv6addr}) {
-                $self->warn("ipv6 addr still under development");
                 $ifaceconfig->{ipv6}->{enabled} = $YFALSE;
                 my $ip_list = {};
                 my $ip = NetAddr::IP->new($iface->{ipv6addr});


### PR DESCRIPTION
Fixes #1732