### PR TITLE
ncm-opennebula: add cpu overcommit ratio option

### DIFF
--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -347,4 +347,8 @@ type opennebula_vmtemplate = {
     @{Use Virtual Machine Timer Management:
     https://libvirt.org/formatdomain.html#time-keeping}
     "hypervclock" ? boolean
+    @{Define VM CPU overcommit ratio, by default it is disabled and set to 1, 1 CPU per VCPU:
+    https://docs.opennebula.io/6.10/management_and_operations/capacity_planning/overcommitment.html
+    }
+    "cpuratio" : double(0..1) = 1.0
 } = dict();

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -217,3 +217,6 @@ prefix "/system/opennebula";
     "vmgroup_name", "ha_group",
     "role", "backup"
 ));
+
+"cpuratio" = 1.0;
+

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -32,7 +32,8 @@ HOSTNAME = "[%- fqdn %]",
 TOKEN = "YES"
 [%-    END %]
 ]
-CPU = "[% vcpus %]"
+CPU = "[% vcpus * system.opennebula.cpuratio %]"
+VCPU = "[% vcpus %]"
 DESCRIPTION = "[% hardware.model %] [% fqdn %]"
 [%-    FOR pair IN hardware.harddisks.pairs %]
 DISK = [

--- a/ncm-opennebula/src/test/resources/vm.pan
+++ b/ncm-opennebula/src/test/resources/vm.pan
@@ -182,3 +182,4 @@ prefix "/system/opennebula";
     "hugepages",
 );
 
+"cpuratio" = 1.0;


### PR DESCRIPTION
Included cpuratio VM option for host overcommitment.
This change is backwards compatible

Resolves: #1736