### PR TITLE
CI: panlint: Allow maven templates as first line

### DIFF
--- a/.ci-scripts/panlint
+++ b/.ci-scripts/panlint
@@ -5,4 +5,4 @@ rm -f /tmp/panlint.py
 wget -q https://raw.githubusercontent.com/quattor/pan/master/panc/src/main/scripts/panlint/panlint.py -O /tmp/panlint.py
 chmod u+x /tmp/panlint.py
 
-git diff --name-only --diff-filter=d HEAD^ | grep '\.pan$' | xargs -r /tmp/panlint.py || exit 1
+git diff --name-only --diff-filter=d HEAD^ | grep '\.pan$' | xargs -r /tmp/panlint.py --allow_mvn_templates || exit 1


### PR DESCRIPTION
This was mistakenly removed in 6818e3930b1f2c35ad402866aeaa93b67991a1e0