### PR TITLE
ncm-authconfig: Use choice type where possible

### DIFF
--- a/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/schema.pan
@@ -11,13 +11,13 @@ type authconfig_method_generic_type = {
 include 'components/authconfig/sssd';
 
 type authconfig_pamadditions_line_type = {
-    "order" : string with match(SELF, '^(first|last)$')
+    "order" : choice('first', 'last')
     "entry" : string with match(SELF, '^\s*(required|requisite|sufficient|optional|include|substack)\s+\S+\.so(\s|$)')
 };
 
 type authconfig_pamadditions_type = {
     "conffile" : string = "/etc/pam.d/system_auth"
-    "section" : string with match(SELF, "^(auth|account|password|session)$")
+    "section" : choice('auth', 'account', 'password', 'session')
     "lines" : authconfig_pamadditions_line_type[]
 };
 
@@ -61,7 +61,7 @@ type authconfig_nss_override_attribute_value = {
     "gidNumber" ? long
 };
 
-type connect_policy = string with match(SELF, "^(oneshot|persistent)$");
+type connect_policy = choice('oneshot', 'persistent');
 
 type authconfig_method_ldap_type = {
     include authconfig_method_generic_type
@@ -203,7 +203,7 @@ type authconfig_method_nslcd_type = {
     "basedn" : string
     "base" : authconfig_nslcd_filter
     "scope" ? string
-    "deref" ? string with match(SELF, "^never|searching|finding|always$")
+    "deref" ? choice('never', 'searching', 'finding', 'always')
     "filter" ? authconfig_nslcd_filter
     "map" ? authconfig_nslcd_maps
     "bind_timelimit" ? long
@@ -211,8 +211,8 @@ type authconfig_method_nslcd_type = {
     "idle_timelimit" ? long
     "reconnect_sleeptime" ? long
     "reconnect_retrytime" ? long
-    "ssl" ? string with match(SELF, "^on|off|start_tls$")
-    "tls_reqcert" ? string with match(SELF, "^never|allow|try|demand|hard$")
+    "ssl" ? choice('on', 'off', 'start_tls')
+    "tls_reqcert" ? choice('never', 'allow', 'try', 'demand', 'hard')
     "tls_cacertdir" ? string
     "tls_randfile" ? string
     "tls_ciphers" ? string[]
@@ -236,7 +236,7 @@ type authconfig_method_type = {
     "sssd" ? authconfig_method_sssd_type
 };
 
-type hash_string = string with match(SELF, "^(descrypt|md5|sha256|sha512)$");
+type hash_string = choice('descrypt', 'md5', 'sha256', 'sha512');
 
 type authconfig_component = {
     include structure_component

--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/ipa.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/ipa.pan
@@ -15,7 +15,7 @@ type authconfig_sssd_ipa_krb5 = {
     'validate' ? boolean
     'realm' ? string
     'canonicalize' ? boolean
-    'use_fast' ? string with match(SELF, '^(never|try|demand)$')
+    'use_fast' ? choice('never', 'try', 'demand')
     'confd_path' ? absolute_file_path
     'server' ? type_hostname[]
     'backup_server'? type_hostname[]

--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/ldap.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/ldap.pan
@@ -5,22 +5,7 @@
 @{
     Contains the data structure describing the SSSD LDAP provider
 }
-
 declaration template components/authconfig/sssd/ldap;
-
-type ldap_schema = string with match(SELF, "^(IPA|AD|rfc2307|rfc2307bis)") || error(
-    "LDAP schema must be valid according to sssd-ldap: " + SELF
-);
-
-type ldap_authok = string with match(SELF, "^(obfuscated_)?password") || error(
-    "LDAP authok must be valid according to sssd-ldap: " + SELF
-);
-
-type ldap_deref = string with match(SELF, "^(never|searching|finding|always)$") || error(
-    "Invalid LDAP alias dereferencing method: " + SELF
-);
-
-type ldap_order = string with match(SELF, "^(filter|expire|authorized_service|host)$");
 
 @{
     LDAP chpass fields
@@ -34,7 +19,7 @@ type sssd_chpass = {
 
 type sssd_ldap_defaults = {
     "bind_dn" ? string
-    "authtok_type" : ldap_authok = "password"
+    "authtok_type" : choice('password', 'obfuscated_password') = 'password'
     "authtok" ? string
 };
 
@@ -93,7 +78,7 @@ type authconfig_sssd_ldap = {
     "uri" ? type_absoluteURI[]
     "backup_uri" ? type_absoluteURI[]
     "search_base" ? string
-    "schema" : ldap_schema = "rfc2307"
+    "schema" : choice('IPA', 'AD', 'rfc2307', 'rfc2307bis') = 'rfc2307'
     "service" ? sssd_ldap_service
 
     "krb5_backup_server" ? string
@@ -101,7 +86,7 @@ type authconfig_sssd_ldap = {
     "krb5_realm" ? string
     "krb5_server" ? string
     "access_filter" ? string
-    "access_order" : ldap_order = "filter"
+    "access_order" : choice('filter', 'expire', 'authorized_service', 'host') = 'filter'
     "connection_expire_timeout" : long = 900
     "deref" ? string
     "deref_threshold" ? long
@@ -124,5 +109,5 @@ type authconfig_sssd_ldap = {
     "referrals" ? boolean
     "rootdse_last_usn" ? string
     "search_timeout" : long = 6
-    "account_expire_policy" ? string with match(SELF, "^(shadow|ad|rhds|ipa|389ds|nds)$")
+    "account_expire_policy" ? choice('shadow', 'ad', 'rhds', 'ipa', '389ds', 'nds')
 };

--- a/ncm-authconfig/src/main/pan/components/authconfig/sssd/tls.pan
+++ b/ncm-authconfig/src/main/pan/components/authconfig/sssd/tls.pan
@@ -13,18 +13,13 @@
 
 declaration template components/authconfig/sssd/tls;
 
-type ldap_req_checks = string with match(SELF, "^(never|allow|try|demand|hard)$") || error(
-    "LDAP certificate requests must be valid acording to ssd-ldap: " + SELF
-);
-
-
 type sssd_tls = {
     "cacert" ? string
     "cacertdir" ? string
     "cert" ? string
     "key" ? string
     "cipher_suite" ? string[]
-    "reqcert" : ldap_req_checks = "hard"
+    "reqcert" : choice('never', 'allow', 'try', 'demand', 'hard') = 'hard'
 } with exists(SELF["cacert"]) || exists(SELF["cacertdir"]) || error(
     "LDAP TLS requires at least one of cacert or cacertdir"
 );


### PR DESCRIPTION
This fixes some bugs in the previous regexps and removes a completely unused type.