### PR TITLE
ncm-opennebula: Add cpu pinning support

### DIFF
--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -324,9 +324,6 @@ Set OpenNebula hypervisor options and their virtual clusters (if any)
 type opennebula_host = {
     @{set OpenNebula hosts type.}
     'host_hyp' : string = 'kvm' with match (SELF, '^(kvm|xen)$')
-    @{set the network driver in your hosts.
-    This option is not longer used by ONE >= 5.x versions.}
-    'vnm_mad' ? string with match (SELF, '^(dummy|ovswitch|ovswitch_brcompat)$')
     @{Set the hypervisor cluster. Any new hypervisor is always included within
     "Default" cluster.
     Hosts can be in only one cluster at a time.}

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -970,11 +970,8 @@ type opennebula_oneflow = {
     "lcm_interval" : long = 30
     @{default cooldown period after a scale operation, in seconds}
     "default_cooldown" : long = 300
-    @{default shutdown action
-    terminate : OpenNebula >= 5.0.0
-    shutdown : OpenNebula < 5.0.0
-    }
-    "shutdown_action" : string = 'terminate' with match (SELF, '^(shutdown|shutdown-hard|terminate|terminate-hard)$')
+    @{default shutdown action}
+    "shutdown_action" : string = 'terminate' with match (SELF, '^(terminate|terminate-hard)$')
     @{default numner of virtual machines that will receive the given call in each interval
     defined by action_period, when an action is performed on a role}
     "action_number" : long(1..) = 1

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -351,4 +351,8 @@ type opennebula_vmtemplate = {
     https://docs.opennebula.io/6.10/management_and_operations/capacity_planning/overcommitment.html
     }
     "cpuratio" : double(0..1) = 1.0
+    @{The CPU model exposed to the guest. host-passthrough is the same model as the host.
+    Available modes are stored in the host information and obtained through monitor (onehost show <id>).
+    }
+    "cpu_model" : string = "host-passthrough"
 } = dict();

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -182,7 +182,7 @@ In this case to request this IB device we should set:
   class:  0x0c06
 
 For more info:
-http://docs.opennebula.org/5.0/deployment/open_cloud_host_setup/pci_passthrough.html
+https://docs.opennebula.io/6.10/open_cluster_deployment/kvm_node/pci_passthrough.html
 }
 type opennebula_vmtemplate_pci = {
     @{first value from onehost TYPE section}
@@ -214,7 +214,7 @@ Re-scheduling of VMs works as for any other VM, it will look for a different hos
 considering the placement constraints.
 
 For more info:
-https://docs.opennebula.org/5.8/advanced_components/application_flow_and_auto-scaling/vmgroups.html
+https://docs.opennebula.io/6.10/management_and_operations/capacity_planning/affinity.html
 }
 type opennebula_vmtemplate_vmgroup = {
     "vmgroup_name" : string
@@ -223,7 +223,7 @@ type opennebula_vmtemplate_vmgroup = {
 
 @documentation{
 Type that sets placement constraints and preferences for the VM, valid for all hosts
-More info: http://docs.opennebula.org/5.0/operation/references/template.html#placement-section
+More info: https://docs.opennebula.io/6.10/management_and_operations/capacity_planning/scheduling.html
 }
 type opennebula_placements = {
     @{Boolean expression that rules out provisioning hosts from list of machines
@@ -288,12 +288,12 @@ type opennebula_vmtemplate = {
         '/system/opennebula/diskrdmpath/vdd/' = '/dev/sdf';
      will passthrough the block device to the VM as vdd disk. Disk size is ignored in this case.
      It requires a RDM datastore.
-     See: https://docs.opennebula.org/5.8/deployment/open_cloud_storage_setup/dev_ds.html}
+     See: https://docs.opennebula.io/6.10/open_cluster_deployment/storage_setup/dev_ds.html}
     "diskrdmpath" ? opennebula_rdm_disk
     @{Set ignoremac tree to avoid to include MAC values within AR/VM templates}
     "ignoremac" ? opennebula_ignoremac
     @{Set how many queues will be used for the communication between CPUs and virtio drivers.
-    see: https://docs.opennebula.org/5.6/deployment/open_cloud_host_setup/kvm_driver.html}
+    see: https://docs.opennebula.io/6.10/open_cluster_deployment/kvm_node/kvm_driver.html}
     "virtio_queues" ? long(0..)
     @{Set graphics to export VM graphical display (VNC is used by default)}
     "graphics" : string = 'VNC' with match (SELF, '^(VNC|SDL|SPICE)$')

--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -307,9 +307,7 @@ type opennebula_vmtemplate = {
     "pci" ? opennebula_vmtemplate_pci[]
     @{labels is a list of strings to group the VMs under a given name and filter them
     in the admin and cloud views. It is also possible to include in the list
-    sub-labels using a common slash: list("Name", "Name/SubName")
-    This feature is available since OpenNebula 5.x, below this version the change
-    does not take effect.}
+    sub-labels using a common slash: list("Name", "Name/SubName")}
     "labels" ? string[]
     "placements" ? opennebula_placements
     @{The optional memoryBacking element may contain several elements that influence

--- a/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
@@ -4,7 +4,7 @@ use NCM::Component::OpenNebula::Server qw($ONEADMIN_USER);
 use Readonly;
 use EDG::WP4::CCM::TextRender;
 
-Readonly my $MINIMAL_ONE_VERSION => version->new("4.8.0");
+Readonly my $MINIMAL_ONE_VERSION => version->new("5.0.0");
 Readonly my $AII_OPENNEBULA_CONFIG => "/etc/aii/opennebula.conf";
 Readonly my $HOSTNAME => "/system/network/hostname";
 Readonly my $DOMAINNAME => "/system/network/domainname";
@@ -12,7 +12,6 @@ Readonly my $MAXITER => 20;
 Readonly my $TIMEOUT => 30;
 Readonly my $ONE_DEFAULT_URL => 'http://localhost:2633/RPC2';
 Readonly my $ONE_DEFAULT_PORT => 2633;
-Readonly my $BOOT_V4 => [qw(network hd)];
 Readonly my $BOOT_V5 => [qw(nic0 disk0)];
 
 =head1 NAME
@@ -79,9 +78,6 @@ sub process_template_aii
     if ((defined $oneversion) and ($oneversion >= version->new("5.0.0"))) {
         $tree->{system}->{opennebula}->{boot} = $BOOT_V5;
         $self->verbose("BOOT section set to support OpenNebula versions >= 5.0.0");
-    } else {
-        $self->verbose("BOOT section set to support OpenNebula versions < 5.0.0");
-        $tree->{system}->{opennebula}->{boot} = $BOOT_V4;
     };
 
     my $tpl = EDG::WP4::CCM::TextRender->new(

--- a/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
@@ -91,7 +91,6 @@ sub manage_hosts
         $new = $self->update_something($one, "host", $host, "QUATTOR = 1");
         if (defined($hosts->{$host}->{pin_policy})) {
             $new = $self->update_something($one, "host", $host, "PIN_POLICY = $hosts->{$host}->{pin_policy}");
-            $self->verbose("HELLO pin defined: ", $hosts->{$host}->{pin_policy});
         };
         if (defined($new) and defined($hosts->{$host}->{cluster})) {
             $self->verbose("Host $host cluster is set to: ", $hosts->{$host}->{cluster});

--- a/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Host.pm
@@ -89,6 +89,10 @@ sub manage_hosts
         }
         # Update host template and set host cluster if defined
         $new = $self->update_something($one, "host", $host, "QUATTOR = 1");
+        if (defined($hosts->{$host}->{pin_policy})) {
+            $new = $self->update_something($one, "host", $host, "PIN_POLICY = $hosts->{$host}->{pin_policy}");
+            $self->verbose("HELLO pin defined: ", $hosts->{$host}->{pin_policy});
+        };
         if (defined($new) and defined($hosts->{$host}->{cluster})) {
             $self->verbose("Host $host cluster is set to: ", $hosts->{$host}->{cluster});
             $self->set_service_clusters($one, "host", $new, $hosts->{$host}->{cluster});

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -54,7 +54,9 @@ Features that are implemented at this moment:
 
 =item * Updates KVM PCI passthrough filter config file
 
-=item * Cloud resource labels (OpenNebula >= 5.x)
+=item * Cloud resource labels
+
+=item * VMs CPU pinning
 
 =back
 

--- a/ncm-opennebula/src/main/perl/opennebula.pm
+++ b/ncm-opennebula/src/main/perl/opennebula.pm
@@ -86,20 +86,17 @@ To set up the initial cluster, some steps should be taken:
 
 =over
 
-=item 1. First install the required Ruby gems in your OpenNebula server (only for OpenNebula 5.10 or older).
-You can use OpenNebula installgems addon : L<https://github.com/OpenNebula/addon-installgems>.
-
-=item 2. The OpenNebula server(s) should have passwordless ssh access as oneadmin user to all the host hosts of the cluster.
+=item 1. The OpenNebula server(s) should have passwordless ssh access as oneadmin user to all the host hosts of the cluster.
  e.g. by distributing the public key(s) of the OpenNebula host over the cluster.
 
-=item 3. Start OpenNebula services: C<< # for i in '' -econe -gate -novnc -occi -sunstone; do service opennebula$i stop; done >>
+=item 2. Start OpenNebula services: C<< # for i in '' -econe -gate -novnc -occi -sunstone; do service opennebula$i stop; done >>
 
-=item 4. Run the component a first time.
+=item 3. Run the component a first time.
 
-=item 5. The new oneadmin password will be available from C<< /var/lib/one/.one/one_auth >> file.
+=item 4. The new oneadmin password will be available from C<< /var/lib/one/.one/one_auth >> file.
 The old auth files are stored with .quattor.backup extension.
 
-=item 6. It is also possible to change sunstone service password, just include
+=item 5. It is also possible to change sunstone service password, just include
 'serveradmin' user and passwd within opennebula/users tree.
 In that case the component also updates the C<< sunstone_auth >> file.
 

--- a/ncm-opennebula/src/main/resources/raw_level1.tt
+++ b/ncm-opennebula/src/main/resources/raw_level1.tt
@@ -1,5 +1,4 @@
-DATA = "<vcpu>[% vcpus %]</vcpu><cpu mode='host-passthrough'>
-<topology sockets='[% sockets %]' cores='[% cores %]' threads='1'/></cpu>
+DATA = "
 [%- IF system.opennebula.memorybacking.defined %]
 <memoryBacking>
 [%-     FOREACH item IN system.opennebula.memorybacking %]

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -221,3 +221,10 @@ prefix "/system/opennebula";
 "cpuratio" = 1.0;
 "cpu_model" = "Broadwell-noTSX-IBRS";
 
+"topology" = dict(
+    "pin_policy", "NONE",
+    "sockets", 1,
+    "threads", 1,
+    "cores", 1,
+);
+

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -219,4 +219,5 @@ prefix "/system/opennebula";
 ));
 
 "cpuratio" = 1.0;
+"cpu_model" = "Broadwell-noTSX-IBRS";
 

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
@@ -30,7 +30,7 @@ multiline
 ^OS\s?=\s?\[$
 ^\s*BOOT\s?=\s*""\s*$
 ^RAW\s?=\s?\[$
-^\s*DATA\s?=\s*".+$
+^\s*DATA\s?=\s*"$
 ^\s*\<.+\>$
 ^\s*\<.+\>",$
 ^\s*TYPE\s?=\s*".+"\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/vm_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/vm_template
@@ -58,8 +58,7 @@ multiline
 ^\s{4}BOOT\s?=\s?""$
 ^\]$
 ^RAW\s?=\s?\[$
-^\s{4}DATA\s?=\s?"\<vcpu\>4\<\/vcpu\>\<cpu\s{1}mode\=\'host-passthrough\'\>$
-^\s{4}\<topology\s{1}sockets\=\'2\'\s{1}cores\=\'2\'\s{1}threads\=\'1\'\/\>\<\/cpu\>$
+^\s{4}DATA\s?=\s?"$
 ^\s{4}\<memoryBacking\>$
 ^\s{4}\<nosharepages\/\>$
 ^\s{4}\<hugepages\/\>$

--- a/ncm-opennebula/src/main/resources/topology_level1.tt
+++ b/ncm-opennebula/src/main/resources/topology_level1.tt
@@ -1,0 +1,4 @@
+[%- FOR pair IN data.pairs -%]
+[%    pair.key FILTER upper %] = "[% pair.value %]"
+[%-    data.pairs.last.key == pair.key ? "" : "," %]
+[%  END -%]

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -98,6 +98,11 @@ VMGROUP = [% INCLUDE 'opennebula/oned_level1.tt' data=item -%]
 [%- IF system.opennebula.labels.defined %]
 LABELS = "[% system.opennebula.labels.join(',') %]"
 [%- END %]
+[%- IF system.opennebula.topology.pin_policy.defined %]
+TOPOLOGY = [
+[%      INCLUDE 'opennebula/topology_level1.tt' data=system.opennebula.topology FILTER indent -%]
+]
+[%- END %]
 [%- FOREACH sched IN system.opennebula.placements %]
 [%      sched.key FILTER upper %] = "[% sched.value %]"
 [%- END %]

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -34,6 +34,11 @@ TOKEN = "YES"
 ]
 CPU = "[% vcpus * system.opennebula.cpuratio %]"
 VCPU = "[% vcpus %]"
+CPU_MODEL = [
+[%     FILTER indent -%]
+MODEL = "[%- system.opennebula.cpu_model %]"
+[%-    END %]
+]
 DESCRIPTION = "[% hardware.model %] [% fqdn %]"
 [%-    FOR pair IN hardware.harddisks.pairs %]
 DISK = [

--- a/ncm-opennebula/src/test/perl/aii_vmtemplate.t
+++ b/ncm-opennebula/src/test/perl/aii_vmtemplate.t
@@ -20,7 +20,7 @@ $opennebulaaii->mock('read_one_aii_conf', Net::OpenNebula->new(url  => "http://l
                                                       user => "oneadmin",));
 
 my $aii = NCM::Component::opennebula->new();
-my $oneversion = version->new("5.0.0");
+my $oneversion = version->new("6.0.0");
 
 my $ttout = $aii->process_template_aii($cfg, "vmtemplate", $oneversion);
 

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -881,6 +881,10 @@ CONTEXT = [
     TOKEN = "YES"
 ]
 CPU = "4"
+VCPU = "4"
+CPU_MODEL = [
+    MODEL = "Broadwell-noTSX-IBRS"
+]
 DESCRIPTION = "KVM Virtual Machine node630.cubone.os"
 DISK = [
     IMAGE = "node630.cubone.os_vda",
@@ -906,8 +910,7 @@ OS = [
     BOOT = "nic0,disk0"
 ]
 RAW = [
-    DATA = "<vcpu>4</vcpu><cpu mode='host-passthrough'>
-    <topology sockets='2' cores='2' threads='1'/></cpu>
+    DATA = "
     <memoryBacking>
     <nosharepages/>
     <hugepages/>

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -247,8 +247,10 @@ prefix "/software/components/opennebula";
     'hyp101', dict(),
     'hyp102', dict(),
     # Add hyp103 in a different cluster
+    # and CPU pinning policy
     'hyp103', dict(
         "cluster", "red.cluster",
+        "pin_policy", "PINNED",
         ),
     'hyp104', dict(),
 );

--- a/ncm-opennebula/src/test/resources/vm.pan
+++ b/ncm-opennebula/src/test/resources/vm.pan
@@ -183,3 +183,5 @@ prefix "/system/opennebula";
 );
 
 "cpuratio" = 1.0;
+"cpu_model" = "Broadwell-noTSX-IBRS";
+


### PR DESCRIPTION
Include support for VM CPU pinning and CPU topology in OpenNebula.
Removes old legacy code.
This PR is backwards incompatible for older ONE versions < `5.10.0`

Resolves: #1775 
Resolves:  #1745
