### PR TITLE
ncm-altlogrotate: global logrotate config fails to be modified in some cases

### DIFF
--- a/ncm-altlogrotate/src/main/perl/altlogrotate.pm
+++ b/ncm-altlogrotate/src/main/perl/altlogrotate.pm
@@ -136,7 +136,7 @@ sub Configure
     }
 
     # Next process global config file
-    if (@globals) {
+    if (@globals || $overallglobal) {
         if ($overallglobal) {
             unshift @globals, 'global';
 


### PR DESCRIPTION
See issue #1657 for more details