### PR TITLE
ncm-opennebula: aii ks-post-reboot hook: acpid package not installed

### DIFF
--- a/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
@@ -3,6 +3,7 @@
 use NCM::Component::OpenNebula::Server qw($ONEADMIN_USER);
 use Readonly;
 use EDG::WP4::CCM::TextRender;
+use NCM::Component::ks qw (ksinstall_rpm);
 
 Readonly my $MINIMAL_ONE_VERSION => version->new("4.8.0");
 Readonly my $AII_OPENNEBULA_CONFIG => "/etc/aii/opennebula.conf";
@@ -278,8 +279,9 @@ sub aii_post_reboot
     my ($self, $config, $path) = @_;
     my $tree = $config->getElement($path)->getTree();
 
+    my @rpmlist = ('acpid');
+    ksinstall_rpm($config, @rpmlist);
     print <<EOF;
-yum -c /var/tmp/aii/yum/yum.conf -y install acpid
 service acpid start
 EOF
 }


### PR DESCRIPTION
This was due to a wrong yum command -> fixed by using the ksinstall_rpm method instead.