### PR TITLE
ncm-metaconfig: Make `paths` optional in beats schema

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_7.0.pan
+++ b/ncm-metaconfig/src/main/metaconfig/beats/pan/schema_7.0.pan
@@ -180,7 +180,7 @@ type beats_filebeat_input_multiline = {
     Configure a input (source of certain class of data, can come multiple paths)
 }
 type beats_filebeat_input = {
-    'paths' : absolute_file_path[]
+    'paths' ? absolute_file_path[]
     'encoding' ? choice(
         'big5',
         'euc-jp',


### PR DESCRIPTION
# Why the change is necessary.
- not all filebeat inputs need to defne `paths`, for example it is sufficient to define `containers`. See https://github.com/quattor/configuration-modules-core/pull/1810

# What backwards incompatibility it may introduce.
I don't believe this will cause any backwards incompatibility as no default was previously defined. I.e. if you failed to define `paths`, you got a compilation error.
