### PR TITLE
ncm-opennebula: add libvirt hw machine type option

### DIFF
--- a/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/quattor/aii/opennebula/schema.pan
@@ -354,4 +354,10 @@ type opennebula_vmtemplate = {
     Available modes are stored in the host information and obtained through monitor (onehost show <id>).
     }
     "cpu_model" : string = "host-passthrough"
+    @{Libvirt machine type.
+    Check libvirt hyp capabilities for the list of available machine types (KVM_MACHINES list from "onehost show <id>").
+    Required to use the new KVM machine types for RHEL>=9 (like q35 82Q35 chipset) with PCI passthrough:
+    https://github.com/OpenNebula/one/issues/6492
+    }
+    "machine" ? string
 } = dict();

--- a/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/AII.pm
@@ -75,7 +75,7 @@ sub process_template_aii
     my ($self, $config, $tt_name, $oneversion) = @_;
 
     my $tree = $config->getElement('/')->getTree();
-    if ((defined $oneversion) and ($oneversion >= version->new("5.0.0"))) {
+    if (defined $oneversion) {
         $tree->{system}->{opennebula}->{boot} = $BOOT_V5;
         $self->verbose("BOOT section set to support OpenNebula versions >= 5.0.0");
     };

--- a/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/vm.pan
@@ -230,3 +230,5 @@ prefix "/system/opennebula";
     "cores", 1,
 );
 
+"machine" = "pc-q35-rhel9.4.0";
+

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/simple
@@ -28,6 +28,7 @@ multiline
 ^\s*TYPE\s?=\s*".+"\s*$
 ^MEMORY\s?=\s*"\d+"\s*$
 ^OS\s?=\s?\[$
+^\s*MACHINE\s?=\s*".+"\s*,\s*$
 ^\s*BOOT\s?=\s*""\s*$
 ^RAW\s?=\s?\[$
 ^\s*DATA\s?=\s*"$

--- a/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/vm_template
+++ b/ncm-opennebula/src/main/resources/tests/regexps/aii_vmtemplate/vm_template
@@ -55,6 +55,7 @@ multiline
 ^\]$
 ^MEMORY\s?=\s?"4096"$
 ^OS\s?=\s?\[$
+^\s{4}MACHINE\s?=\s?"pc-q35-rhel9.4.0",$
 ^\s{4}BOOT\s?=\s?""$
 ^\]$
 ^RAW\s?=\s?\[$

--- a/ncm-opennebula/src/main/resources/vmtemplate.tt
+++ b/ncm-opennebula/src/main/resources/vmtemplate.tt
@@ -67,6 +67,9 @@ TYPE = "[% system.opennebula.graphics %]"
 MEMORY = "[% memory %]"
 OS = [
 [%     FILTER indent -%]
+[%        IF system.opennebula.machine.defined -%]
+MACHINE = "[% system.opennebula.machine %]",
+[%        END -%]
 BOOT = "[% system.opennebula.boot.join(',') %]"
 [%    END -%]
 ]

--- a/ncm-opennebula/src/test/resources/vm.pan
+++ b/ncm-opennebula/src/test/resources/vm.pan
@@ -187,3 +187,5 @@ prefix "/system/opennebula";
 "cpuratio" = 1.0;
 "cpu_model" = "Broadwell-noTSX-IBRS";
 
+"machine" = "pc-q35-rhel9.4.0";
+


### PR DESCRIPTION
Required to add q35 hw machine types

#1776 must be merged first 

Resolves:  #1821
