### PR TITLE
ncm-network: nmstate support for adusting congestion window

### DIFF
--- a/ncm-network/src/main/pan/components/network/types/network/backend/initscripts.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/backend/initscripts.pan
@@ -8,6 +8,9 @@ type structure_network_backend_specific = {
 type structure_network_rule_backend_specific = {
 };
 
+type structure_network_route_backend_specific = {
+};
+
 function network_valid_route = {
     if (exists(SELF['prefix']) && exists(SELF['netmask'])) {
         error("Use either prefix or netmask as route");

--- a/ncm-network/src/main/pan/components/network/types/network/backend/nmstate.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/backend/nmstate.pan
@@ -30,6 +30,15 @@ type structure_network_rule_backend_specific = {
     "fwmask" ? string(1..8) with match(SELF, '^[0-9a-f]{1,8}$')
 };
 
+type structure_network_route_backend_specific = {
+    @{congestion window size}
+    "cwnd" ? long(10..)
+    @{Initial congestion window size, applied to all sockets for the given targets.}
+    "initcwnd" ? long(10..)
+    @{Advertised receive window, applied to all sockets for the given targets.}
+    "initrwnd" ? long(10..)
+};
+
 function network_valid_route = {
     if (exists(SELF['command'])) {
         if (length(SELF) != 1) error("Cannot use command and any of the other attributes as route");

--- a/ncm-network/src/main/pan/components/network/types/network/route.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/route.pan
@@ -26,6 +26,7 @@ function network_valid_prefix = {
     Presence of ':' in any of the values indicates this is IPv6 related.
 }
 type network_route = {
+    include structure_network_route_backend_specific
     @{The ADDRESS in ADDRESS/PREFIX via GATEWAY}
     "address" ? string with {SELF == 'default' || is_ip(SELF)}
     @{The PREFIX in ADDRESS/PREFIX via GATEWAY}

--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -193,6 +193,10 @@ sub make_nm_ip_route
         $rt{'table-id'} = "$routing_table_hash->{$route->{table}}" if $route->{table};
         $rt{'next-hop-interface'} = $device;
         $rt{'next-hop-address'} = $route->{gateway} if $route->{gateway};
+        $rt{'cwnd'} = int($route->{cwnd}) if $route->{cwnd};
+        $rt{'initcwnd'} = int($route->{initcwnd}) if $route->{initcwnd};
+        $rt{'initrwnd'} = int($route->{initrwnd}) if $route->{initrwnd};
+
         push (@rt_entry, \%rt);
 
     }

--- a/ncm-network/src/test/perl/nmstate_advance.t
+++ b/ncm-network/src/test/perl/nmstate_advance.t
@@ -62,6 +62,13 @@ routes:
     next-hop-address: 4.3.2.3
     next-hop-interface: eth0
     table-id: '3'
+  - cwnd: 100
+    destination: 0.0.0.0/0
+    initcwnd: 50
+    initrwnd: 40
+    next-hop-address: 4.3.2.3
+    next-hop-interface: eth0
+    table-id: '3'
 EOF
 
 Readonly my $VLAN_YML => <<EOF;

--- a/ncm-network/src/test/resources/nmstate_advance.pan
+++ b/ncm-network/src/test/resources/nmstate_advance.pan
@@ -26,6 +26,8 @@ prefix "/system/network/interfaces/eth0";
 "route/2" = dict("address", "1.2.3.6", "netmask", "255.0.0.0", "gateway", "4.3.2.1");
 "route/3" = dict("address", "1.2.3.7", "prefix", 16, "gateway", "4.3.2.2");
 "route/4" = dict("address", "default", "gateway", "4.3.2.3", "table", "outside");
+"route/5" = dict("address", "default", "gateway", "4.3.2.3", "table", "outside",
+"cwnd", 100, "initcwnd", 50, "initrwnd", 40);
 
 "rule/0" = dict("to", "1.2.3.4/24", "not", true, "table", "space");
 


### PR DESCRIPTION
Supporrt for adusting congestion window size. cwnd, initcwnd and initrwnd. Special application protocols with specific requirements about the TCP congestion window size may have a valid use-case to override TCP slow-start.


* Why the change is necessary.
Capability for nmstate to set cwnd size.

* What backwards incompatibility it may introduce.
None. but this feature only available with nmstate >= 2.2.45
NOTE: support for this is only provided in nmstate.ppm and not network.pm.