### PR TITLE
Update maven build tools to 1.63

### DIFF
--- a/ncm-accounts/pom.xml
+++ b/ncm-accounts/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-afsclt/pom.xml
+++ b/ncm-afsclt/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-aiiserver/pom.xml
+++ b/ncm-aiiserver/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-altlogrotate/pom.xml
+++ b/ncm-altlogrotate/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-amandaserver/pom.xml
+++ b/ncm-amandaserver/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-authconfig/pom.xml
+++ b/ncm-authconfig/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-autofs/pom.xml
+++ b/ncm-autofs/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ccm/pom.xml
+++ b/ncm-ccm/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-cdp/pom.xml
+++ b/ncm-cdp/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ceph/pom.xml
+++ b/ncm-ceph/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-chkconfig/pom.xml
+++ b/ncm-chkconfig/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-cron/pom.xml
+++ b/ncm-cron/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-cups/pom.xml
+++ b/ncm-cups/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-dirperm/pom.xml
+++ b/ncm-dirperm/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-download/pom.xml
+++ b/ncm-download/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-etcservices/pom.xml
+++ b/ncm-etcservices/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-filecopy/pom.xml
+++ b/ncm-filecopy/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-filesystems/pom.xml
+++ b/ncm-filesystems/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-fmonagent/pom.xml
+++ b/ncm-fmonagent/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-freeipa/pom.xml
+++ b/ncm-freeipa/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-fstab/pom.xml
+++ b/ncm-fstab/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ganglia/pom.xml
+++ b/ncm-ganglia/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-gmetad/pom.xml
+++ b/ncm-gmetad/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-gmond/pom.xml
+++ b/ncm-gmond/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-gpfs/pom.xml
+++ b/ncm-gpfs/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-grub/pom.xml
+++ b/ncm-grub/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-hostsaccess/pom.xml
+++ b/ncm-hostsaccess/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-hostsfile/pom.xml
+++ b/ncm-hostsfile/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-icinga/pom.xml
+++ b/ncm-icinga/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-interactivelimits/pom.xml
+++ b/ncm-interactivelimits/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ipmi/pom.xml
+++ b/ncm-ipmi/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-iptables/pom.xml
+++ b/ncm-iptables/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ldconf/pom.xml
+++ b/ncm-ldconf/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-libvirtd/pom.xml
+++ b/ncm-libvirtd/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-metaconfig/pom.xml
+++ b/ncm-metaconfig/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-modprobe/pom.xml
+++ b/ncm-modprobe/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-mysql/pom.xml
+++ b/ncm-mysql/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-nagios/pom.xml
+++ b/ncm-nagios/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-named/pom.xml
+++ b/ncm-named/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-network/pom.xml
+++ b/ncm-network/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-nfs/pom.xml
+++ b/ncm-nfs/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-nrpe/pom.xml
+++ b/ncm-nrpe/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-nsca/pom.xml
+++ b/ncm-nsca/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-nscd/pom.xml
+++ b/ncm-nscd/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-nss/pom.xml
+++ b/ncm-nss/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ntpd/pom.xml
+++ b/ncm-ntpd/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ofed/pom.xml
+++ b/ncm-ofed/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-openldap/pom.xml
+++ b/ncm-openldap/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-opennebula/pom.xml
+++ b/ncm-opennebula/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-openvpn/pom.xml
+++ b/ncm-openvpn/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-pam/pom.xml
+++ b/ncm-pam/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-path/pom.xml
+++ b/ncm-path/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-pnp4nagios/pom.xml
+++ b/ncm-pnp4nagios/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-postfix/pom.xml
+++ b/ncm-postfix/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-postgresql/pom.xml
+++ b/ncm-postgresql/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-profile/pom.xml
+++ b/ncm-profile/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-puppet/pom.xml
+++ b/ncm-puppet/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-resolver/pom.xml
+++ b/ncm-resolver/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-sendmail/pom.xml
+++ b/ncm-sendmail/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-shorewall/pom.xml
+++ b/ncm-shorewall/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-spma/pom.xml
+++ b/ncm-spma/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-ssh/pom.xml
+++ b/ncm-ssh/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-sudo/pom.xml
+++ b/ncm-sudo/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-symlink/pom.xml
+++ b/ncm-symlink/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-sysconfig/pom.xml
+++ b/ncm-sysconfig/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-sysctl/pom.xml
+++ b/ncm-sysctl/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-syslog/pom.xml
+++ b/ncm-syslog/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-syslogng/pom.xml
+++ b/ncm-syslogng/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-systemd/pom.xml
+++ b/ncm-systemd/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>

--- a/ncm-useraccess/pom.xml
+++ b/ncm-useraccess/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.62</version>
+    <version>1.63</version>
     <relativePath />
   </parent>
   <licenses>


### PR DESCRIPTION
Mostly for verification as 1.63 is the first version using the new Maven portal.
We should probably do a 1.64 for the next release.