### PR TITLE
Reuse shared workflow to run all standard tests

### DIFF
--- a/.ci-scripts/indent
+++ b/.ci-scripts/indent
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-rm -f /tmp/indent.py
-wget -q https://raw.githubusercontent.com/stfc/Pan-Indenter/master/pan_indent_checker.py -O /tmp/indent.py
-chmod u+x /tmp/indent.py
-
-git diff --name-only --diff-filter=d HEAD^ | grep '\.pan$' | xargs -rn1 /tmp/indent.py check || exit 1

--- a/.ci-scripts/panlint
+++ b/.ci-scripts/panlint
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-rm -f /tmp/panlint.py
-wget -q https://raw.githubusercontent.com/quattor/pan/master/panc/src/main/scripts/panlint/panlint.py -O /tmp/panlint.py
-chmod u+x /tmp/panlint.py
-
-git diff --name-only --diff-filter=d HEAD^ | grep '\.pan$' | xargs -r /tmp/panlint.py --allow_mvn_templates || exit 1

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -3,64 +3,7 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  runtests:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/quattor/quattor-test-container:latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Determine hash for caching key
-      id: cachekeystep
-      run: echo "pomcachekey=${{ hashFiles('**/pom.xml') }}" >> $GITHUB_ENV
-    - name: Cache Maven packages
-      uses: actions/cache@v4
-      with:
-        path: /tmp/m2
-        key: ${{ runner.os }}-m2-${{ env.pomcachekey }}
-        restore-keys: ${{ runner.os }}-m2-
-    - name: run tests
-      run: |
-        # make sure it exists before chown
-        mkdir -p /tmp/m2
-        chown -R quattortest:quattortest . /tmp/m2
-        # we have to run as a non-root user to pass the spma tests
-        # secondly, we first download all maven dependencies and then run the tests because it fails with hanging downloads otherwise.
-        runuser --shell /bin/bash --preserve-environment --command "source /usr/bin/mvn_test.sh && mvn_run \"dependency:resolve-plugins dependency:go-offline $MVN_ARGS\" && mvn_test" quattortest
-      env:
-        MVN_ARGS: -Dmaven.repo.local=/tmp/m2
-
-  panlint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          # we need the full repo or HEAD^ does not work
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3
-      - name: Install dependencies
-        run: pip install colorama prettytable six
-      - name: run panlint
-        run: .ci-scripts/panlint
-
-  indentation:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          # we need the full repo or HEAD^ does not work
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3
-      - name: Install dependencies
-        run: pip install colorama
-      - name: run indent checker
-        run: .ci-scripts/indent
-
+  standard-maven:
+    uses: quattor/release/.github/workflows/maven-tests.yaml@main
+  standard-pan:
+    uses: quattor/release/.github/workflows/pan-template-tests.yaml@main


### PR DESCRIPTION
Move to defining the standard actions in the release repository and reuse them rather than trying to keep the workflows up-to-date and in sync with other across all repos.