### PR TITLE
ncm-metaconfig: support Include for sshd_config

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/ssh/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ssh/pan/schema.pan
@@ -197,6 +197,7 @@ type sshd_config_match_opts = {
     'HostbasedAcceptedKeyTypes' ? temp_ssh_hostkeyalgorithms[]
     'HostbasedAuthentication' ? boolean
     'HostbasedUsesNameFromPacketOnly' ? boolean
+    'Include' ? string[]
     'IPQoS' ? string[] with length(SELF) == 1 || length(SELF) == 2
     'KbdInteractiveAuthentication' ? boolean
     'KerberosAuthentication' ? boolean

--- a/ncm-metaconfig/src/main/metaconfig/ssh/server_attrs.tt
+++ b/ncm-metaconfig/src/main/metaconfig/ssh/server_attrs.tt
@@ -1,5 +1,5 @@
 [% # different forms of list handling, default for list type is space separated
-    commalist = ['Ciphers', 'HostKeyAlgorithms', 'HostbasedAcceptedKeyTypes', 'KexAlgorithms', 'MACs', 'PubkeyAcceptedKeyTypes' ];
+    commalist = ['Ciphers', 'HostKeyAlgorithms', 'HostbasedAcceptedKeyTypes', 'Include', 'KexAlgorithms', 'MACs', 'PubkeyAcceptedKeyTypes' ];
     multilinelist = ['HostKey', 'ListenAddress', 'Port' ]
     -%]
 [%- FOREACH pair IN data.pairs -%]

--- a/ncm-metaconfig/src/main/metaconfig/ssh/tests/profiles/server_config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/ssh/tests/profiles/server_config.pan
@@ -14,6 +14,7 @@ prefix "/software/components/metaconfig/services/{/etc/ssh/sshd_config}/contents
 "main/Ciphers" = list("aes128-ctr", "aes192-ctr", "aes256-ctr");
 "main/PasswordAuthentication" = false;
 "main/Subsystem" = dict("sftp", "internal-sftp");
+"main/Include" = list("sshd_config.d/*.conf");
 
 "Match/0/criteria" = dict(
     "User", list("testuser2"),

--- a/ncm-metaconfig/src/main/metaconfig/ssh/tests/regexps/server_config/base
+++ b/ncm-metaconfig/src/main/metaconfig/ssh/tests/regexps/server_config/base
@@ -4,6 +4,7 @@ Base test for ssh server config
 ---
 ^AddressFamily\sany$
 ^Ciphers\saes128-ctr,aes192-ctr,aes256-ctr$
+^Include\ssshd_config\.d/\*\.conf$
 ^PasswordAuthentication\sno$
 ^Match\sAddress\s192.168.0.0/16,!192.168.10.0/24\sUser\stestuser2$
 ^\s{4}PasswordAuthentication\syes$


### PR DESCRIPTION
Add support for the 'Include' directive in the sshd_config file. This allows you to include files from another directory in your sshd config.
