### PR TITLE
ncm-metaconfig: add unbound dns module

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/unbound/pan/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/unbound/pan/config.pan
@@ -1,0 +1,13 @@
+unique template metaconfig/unbound/config;
+
+include 'metaconfig/unbound/schema';
+
+bind "/software/components/metaconfig/services/{/etc/unbound/unbound.conf}/contents" = structure_unbound;
+
+prefix  "/software/components/metaconfig/services/{/etc/unbound/unbound.conf}";
+"mode" = 0640;
+"owner" = "root";
+"group" = "root";
+"module" = "unbound/unbound";
+"daemons/unbound" = "restart";
+

--- a/ncm-metaconfig/src/main/metaconfig/unbound/pan/schema.pan
+++ b/ncm-metaconfig/src/main/metaconfig/unbound/pan/schema.pan
@@ -1,0 +1,126 @@
+@{
+    unbound - Schema
+}
+
+declaration template metaconfig/unbound/schema;
+
+include 'pan/types';
+include 'quattor/types/component';
+
+type structure_unbound_server = {
+    'verbosity' : long
+    'statistics-interval' : long
+    'statistics-cumulative' : string = 'no'
+    'extended-statistics' ? string = 'yes'
+    'num-threads' : long
+    'interface' : string
+    'interface-automatic' : string = 'no'
+    'outgoing-interface' ? string
+    'port' ? long
+    'outgoing-range' ? long
+    'msg-cache-size' ? string
+    'msg-cache-slabs' ? long
+    'num-queries-per-thread' ? long
+    'rrset-cache-size'  ? string = '200m'
+    'rrset-cache-slabs' ? long
+    'infra-cache-slabs' ? long
+    'do-ip4' ? choice ('no', 'yes')
+    'do-ip6' ? choice ('no', 'yes')
+    'do-udp' ? choice ('no', 'yes')
+    'do-tcp' ? choice ('no', 'yes')
+    'do-daemonize' ? string = 'no'
+    'chroot' : string = 'yes'
+    'username' ? string
+    'directory' ? string = '/etc/unbound'
+    'use-syslog' : choice ('no', 'yes')
+    'pidfile' ? string
+    'root-hints' ? string
+    'harden-glue' ? string = 'yes'
+    'harden-dnssec-stripped' ? choice ('no', 'yes')
+    'harden-referral-path' ? choice ('no', 'yes')
+    'use-caps-for-id' ? choice ('no', 'yes')
+    'unwanted-reply-threshold' ? long
+    'val-clean-additional' ? choice ('no', 'yes')
+    'val-permissive-mode' ? choice ('no', 'yes')
+    'key-cache-slabs' ? long
+    'log-queries' ? string
+    'tcp-upstream' ? choice ('no', 'yes')
+    'ssl-upstream' ? choice ('no', 'yes')
+    'ssl-service-key' ? string
+    'ssl-service-pem' ? string
+    'ssl-port' ? long
+    'auto-trust-anchor-file' ? string
+    'incoming-num-tcp' ? long(0..)
+    'infra-cache-min-rtt' ? long(0..)
+    'infra-cache-max-rtt' ? long(0..)
+    'infra-keep-probing' ? choice('no', 'yes')
+    'ip-ratelimit' ? long(0..)
+    'prefetch' ? choice('no', 'yes')
+    'prefetch-key' ? choice('no', 'yes')
+    'rrset-roundrobin' ? choice('no', 'yes')
+    'trust-anchor' ? string
+    'trust-anchor-file' ? string
+    'trusted-keys-file' ? string
+    'unblock-lan-zones' ? choice('no', 'yes')
+    'module-config' ?  string
+    'do-not-query-localhost' ? choice('no', 'yes')
+};
+
+type structure_unbound_local_zone = {
+    'nodefault' : list
+    'static' : list
+    'redirect' ? string[]
+};
+
+type structure_unbound_forward_zone = {
+    'forward_addr' ? list
+    'name' ? list
+};
+
+type structure_unbound_odc_forward_zone = {
+    'forward_addr' : string[]
+    'name' : string[]
+};
+
+type structure_unbound_sp_forward_zone = {
+    'forward_addr' ? string[]
+    'forward_host' ? string[]
+    'name' : string[]
+};
+
+type structure_unbound_stub_zone = {
+    'addrs' : string[]
+    'names' : string[]
+};
+
+type structure_unbound_remote_control = {
+    'control-enable' : string with match (SELF, 'yes|no')
+    'control-interface' : string = '127.0.0.1'
+    'control-port' ? long
+    'server-key-file' ? string = 'unbound_server.key'
+    'server-cert-file' ? string = 'unbound_server.pem'
+    'control-key-file' ? string = 'unbound_control.key'
+    'control-cert-file' ? string = 'unbound_server.key'
+};
+
+type structure_unbound_access_control = {
+    'deny' ? list
+    'allow' ? list
+    'allow_snoop' ? list
+};
+
+@{
+desc = Represent the unbound.conf configuration file. See unbound.conf(5) for details of the keys and values.
+}
+type structure_unbound = {
+    'server' : structure_unbound_server
+    'access_control' ? structure_unbound_access_control
+    'local_zone' ? structure_unbound_local_zone
+    'forward_zone' ? structure_unbound_forward_zone
+    'odc_forward_zone' ? structure_unbound_odc_forward_zone[]
+    'sp_forward_zone' ? structure_unbound_sp_forward_zone[]
+    'stub_zones' ? structure_unbound_stub_zone[]
+    'local_data' ? list
+    'remote_control' : structure_unbound_remote_control
+    'default_forwarders' ? list
+};

--- a/ncm-metaconfig/src/main/metaconfig/unbound/tests/profiles/config.pan
+++ b/ncm-metaconfig/src/main/metaconfig/unbound/tests/profiles/config.pan
@@ -1,0 +1,48 @@
+object template config;
+
+include 'metaconfig/unbound/config';
+
+'/software/components/metaconfig/services/{/etc/unbound/unbound.conf}' = {
+    server = dict(
+        'verbosity', 1,
+        'statistics-interval', 0,
+        'incoming-num-tcp', 10,
+        'statistics-cumulative', 'no',
+        'extended-statistics', 'no',
+        'num-threads', 2,
+        'interface-automatic', 'no',
+        'interface', '127.0.0.1',
+        'prefetch', 'yes',
+        'rrset-roundrobin', 'yes',
+        'trusted-keys-file', '""',
+        'trust-anchor-file', '""',
+        'trust-anchor', '""',
+        'auto-trust-anchor-file', '""',
+        'module-config', 'iterator',
+        'use-syslog', 'yes',
+        'chroot', '""',
+        'root-hints', '""',
+        'unblock-lan-zones', 'yes',
+        'ip-ratelimit', 1000,
+    );
+    remote_control = dict(
+        'control-interface', '/run/unbound/unbound-remote-control.sock',
+        'control-enable', 'no',
+    );
+    dict(
+        'module', 'unbound/unbound',
+        'owner', 'root',
+        'group', 'root',
+        'backup', '.old',
+        'mode', 0644,
+        'daemons', dict('unbound', 'restart'),
+        'contents', dict(
+            'server', server,
+            'remote_control', remote_control,
+            'forward_zone', dict(
+                'name', list('.'),
+                'forward_addr', list("10.100.111.112", "10.100.111.113"),
+            ),
+        ),
+    );
+};

--- a/ncm-metaconfig/src/main/metaconfig/unbound/unbound.tt
+++ b/ncm-metaconfig/src/main/metaconfig/unbound/unbound.tt
@@ -1,0 +1,76 @@
+server:
+[% FOREACH key IN server.keys.sort -%]
+        [% key %]: [% server.$key %]
+[% END -%]
+[% FOREACH interface IN interfaces -%]
+        interface: [% interface %]
+[% END -%]
+[% FOREACH source IN access_control.deny -%]
+        access-control: [% source %] deny
+[% END -%]
+[% FOREACH source IN access_control.allow -%]
+        access-control: [% source %] allow
+[% END -%]
+[% FOREACH source IN access_control.allow_snoop -%]
+        access-control: [% source %] allow_snoop
+[% END -%]
+[% FOREACH zone IN local_zone.nodefault -%]
+        local-zone: "[% zone %]" nodefault
+[% END -%]
+[% FOREACH zone IN local_zone.static -%]
+        local-zone: "[% zone %]" static
+[% END -%]
+[% FOREACH zone IN local_zone.redirect -%]
+        local-zone: "[% zone %]" redirect
+[% END -%]
+[% FOREACH record IN local_data -%]
+        local-data: "[% record %]"
+[% END -%]
+remote-control:
+[% FOREACH key IN remote_control.keys.sort -%]
+        [% key %]: [% remote_control.$key %]
+[% END -%]
+[% FOREACH zone IN forward_zone.name -%]
+forward-zone:
+        name: "[% zone %]"
+[% FOREACH addr IN forward_zone.forward_addr -%]
+        forward-addr: [% addr %]
+[% END -%]
+[% END -%]
+[% FOREACH zone IN stub_zones -%]
+[% FOREACH name IN zone.names -%]
+stub-zone:
+        name: "[% name %]"
+[% FOREACH addr IN zone.addrs -%]
+        stub-addr: [% addr %]
+[% END -%]
+[% END -%]
+[% END -%]
+[% FOREACH zone IN odc_forward_zone -%]
+[% FOREACH name IN zone.name -%]
+forward-zone:
+        name: "[% name %]"
+[% FOREACH addr IN zone.forward_addr -%]
+        forward-addr: [% addr %]
+[% END -%]
+[% END -%]
+[% END -%]
+[% FOREACH zone IN sp_forward_zone -%]
+[% FOREACH name IN zone.name -%]
+forward-zone:
+        name: "[% name %]"
+[% FOREACH addr IN zone.forward_addr -%]
+        forward-addr: [% addr %]
+[% END -%]
+[% FOREACH addr IN zone.forward_host -%]
+        forward-host: [% addr %]
+[% END -%]
+[% END -%]
+[% END -%]
+[% IF default_forwarders.defined && default_forwarders.size > 0 -%]
+forward-zone:
+        name: "."
+[% FOREACH addr IN default_forwarders -%]
+        forward-addr: [% addr %]
+[% END -%]
+[% END -%]

--- a/ncm-metaconfig/src/test/perl/service-unbound.t
+++ b/ncm-metaconfig/src/test/perl/service-unbound.t
@@ -1,0 +1,8 @@
+use Test::More;
+use Test::Quattor::TextRender::Metaconfig;
+
+my $u = Test::Quattor::TextRender::Metaconfig->new(
+    service => 'unbound',
+)->test();
+
+done_testing;


### PR DESCRIPTION
Add module to configure unbound dns cache using metaconfig

* Why the change is necessary.
Allow to configure unbound using metaconfig.

* What backwards incompatibility it may introduce.
None, New module.
schema tested on unbound >= 1.16.2 on rhel8 and rhel9.