### PR TITLE
ncm-network: add option to skip managing interface.

### DIFF
--- a/ncm-network/src/main/pan/components/network/types/network/interface.pan
+++ b/ncm-network/src/main/pan/components/network/types/network/interface.pan
@@ -111,6 +111,8 @@ type network_interface_type = choice(
     network interface
 }
 type network_interface = {
+    @{Set to true to skip managing this interface. Defaults to false.}
+    "ignore" ? boolean
     "ip" ? type_ip
     "gateway" ? type_ip
     "netmask" ? type_ip

--- a/ncm-network/src/main/perl/network.pm
+++ b/ncm-network/src/main/perl/network.pm
@@ -2092,6 +2092,10 @@ sub Configure
     # ifcfg- / route[6]- files
     foreach my $ifacename (sort keys %$ifaces) {
         my $iface = $ifaces->{$ifacename};
+        if ($iface->{ignore}) {
+            $self->verbose("Skipping interface $ifacename: ignore is set to true");
+            next;
+        }
         my $text = $self->make_ifcfg($ifacename, $iface, $ipv6);
 
         my $file_name = $self->iface_filename($ifacename);

--- a/ncm-network/src/main/perl/nmstate.pm
+++ b/ncm-network/src/main/perl/nmstate.pm
@@ -929,6 +929,10 @@ sub Configure
     my $nmifaces = {};
     foreach my $ifacename (sort keys %$ifaces) {
         my $iface = $ifaces->{$ifacename};
+        if ($iface->{ignore}) {
+            $self->verbose("Skipping interface $ifacename: ignore is set to true");
+            next;
+        }
         my ($nm_cfg, $nm_iface) = generate_nmstate_config($self, $ifacename, $net, $ipv6, $nwtree->{routing_table}, $dgw);
         $nmifaces->{$ifacename} = $nm_iface;
         my $file_name = $self->iface_filename($ifacename);


### PR DESCRIPTION
Adding an optional ignore option, if set to true ncm-network will not manage the interface
closes #1858 

* Why the change is necessary.
We have a niche requirement to add interfaces in aq but do not want ncm to manage that interface. If ignore is set then we need ncm to not manage this interface but still appear in /system/network path. 
* What backwards incompatibility it may introduce.
None. This is an optional field, will not impact any existing config.
