### PR TITLE
ncm-metaconfig: kerberos: domain_realm wrongly configured

### DIFF
--- a/ncm-metaconfig/src/main/metaconfig/kerberos/client.tt
+++ b/ncm-metaconfig/src/main/metaconfig/kerberos/client.tt
@@ -19,7 +19,7 @@
 }
 [%- END %]
 
-[domain_realms]
+[domain_realm]
 [% FOREACH r IN domain_realms.pairs %]
 .[% r.key %] = [% r.value %]
 [% END %]

--- a/ncm-metaconfig/src/main/metaconfig/kerberos/tests/regexps/krb5-client/default_realms
+++ b/ncm-metaconfig/src/main/metaconfig/kerberos/tests/regexps/krb5-client/default_realms
@@ -4,5 +4,5 @@ multiline
 ---
 ^\[libdefaults\]$
 ^default_realm\s=\sKDC\.REALM$
-^\[domain_realms\]$
+^\[domain_realm\]$
 ^\.DEFAULT_DOMAIN\s=\sKDC\.REALM$

--- a/ncm-metaconfig/src/main/metaconfig/kerberos/tests/regexps/krb5_conf
+++ b/ncm-metaconfig/src/main/metaconfig/kerberos/tests/regexps/krb5_conf
@@ -6,4 +6,4 @@ metaconfigservice=/etc/krb5.conf
 ^\[logging\]$
 ^\[libdefaults\]$
 ^\[realms\]$
-^\[domain_realms\]$
+^\[domain_realm\]$

--- a/ncm-metaconfig/src/main/metaconfig/kerberos/tests/regexps/simple-client
+++ b/ncm-metaconfig/src/main/metaconfig/kerberos/tests/regexps/simple-client
@@ -5,4 +5,4 @@ multiline
 ^\[logging\]$
 ^\[libdefaults\]$
 ^\[realms\]$
-^\[domain_realms\]$
+^\[domain_realm\]$


### PR DESCRIPTION
the config option is called domain_realm, without the trailing s