### PR TITLE
ncm-systemd: allow to force unit start/stop activation and skip chkconfig configuration

### DIFF
--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -672,6 +672,8 @@ type ${project.artifactId}_component = {
     "unconfigured" : choice('ignore', 'enabled', 'disabled', 'on', 'off') = 'ignore' # harmless default
     # escaped full unitnames are allowed (or use shortnames and type)
     "unit" ? ${project.artifactId}_unit_type{}
+    @{Ignore chkconfig component configuration}
+    "ignore_chkconfig" : boolean = false
 } with {
     if (is_defined(SELF["unit"])) {
         foreach(name; unit; SELF["unit"]) {

--- a/ncm-systemd/src/main/pan/components/systemd/schema.pan
+++ b/ncm-systemd/src/main/pan/components/systemd/schema.pan
@@ -658,6 +658,8 @@ type ${project.artifactId}_unit_type = {
     "targets" : ${project.artifactId}_target[] = list("multi-user")
     "type" : choice('service', 'target', 'sysv', 'socket', 'mount', 'automount', 'timer', 'slice', 'path') = 'service'
     "startstop" : boolean = true
+    @{force startstop even if target is not active}
+    "force" ? boolean
     "state" : choice('enabled', 'disabled', 'masked') = 'enabled'
     @{unitfile configuration}
     "file" ? ${project.artifactId}_unitfile

--- a/ncm-systemd/src/main/perl/Systemd/Service.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service.pm
@@ -104,9 +104,13 @@ sub configure
 {
     my ($self, $config) = @_;
 
-    my $unconfigured = $self->set_unconfigured_default($config);
+    my $tree = $config->getTree($self->{BASE});
+    my $ignore_chkconfig = $tree->{ignore_chkconfig} || 0;
+    $self->verbose("Ignore chkconfig $ignore_chkconfig");
 
-    my $configured = $self->gather_configured_units($config);
+    my $unconfigured = $self->set_unconfigured_default($config, $ignore_chkconfig);
+
+    my $configured = $self->gather_configured_units($config, $ignore_chkconfig);
 
     my $current = $self->gather_current_units($configured, $unconfigured);
 
@@ -133,7 +137,7 @@ and legacy C<ncm-chkconfig>.
 
 sub set_unconfigured_default
 {
-    my ($self, $config)= @_;
+    my ($self, $config, $ignore_chkconfig) = @_;
 
     # The default w.r.t. handling unconfigured units.
     my $unconfigured_default = $UNCONFIGURED_IGNORE;
@@ -150,13 +154,15 @@ sub set_unconfigured_default
         ignore => $UNCONFIGURED_IGNORE,
     };
 
-    # TODO add code to select.
+    # Always assume chkconfig is other.
     my $pref = 'unit';
     my $other = 'chkconfig';
 
     my $found;
-    if($config->elementExists($path->{$pref})) {
+    if ($config->elementExists($path->{$pref})) {
         $found = $pref;
+    } elsif ($ignore_chkconfig) {
+        $self->verbose("Ignoring chkconfig component configuration for unconfigured default");
     } elsif ($config->elementExists($path->{$other})) {
         $found = $other;
     } else {
@@ -234,7 +240,7 @@ sub _get_tree
 
 sub gather_configured_units
 {
-    my ($self, $config) = @_;
+    my ($self, $config, $ignore_chkconfig) = @_;
 
     my $chkconfig = {
         path => "$LEGACY_BASE/service",
@@ -248,16 +254,21 @@ sub gather_configured_units
         type => 'unit',
     };
 
-    # TODO: add code to select which one is preferred.
+    # Always assume chkconfig is other.
     my $pref = $unit;
     my $other = $chkconfig;
 
     my $units = {};
 
     # Gather the other units first (if any)
-    my $tree = $self->_get_tree($config, $other);
-    if ($tree) {
-        $units = $other->{instance}->configured_units($tree);
+    my $tree;
+    if ($ignore_chkconfig) {
+        $self->verbose("Ignoring chkconfig component configuration to gather configured units");
+    } else {
+        $tree = $self->_get_tree($config, $other);
+        if ($tree) {
+            $units = $other->{instance}->configured_units($tree);
+        }
     }
 
     # Update with preferred units (if any)

--- a/ncm-systemd/src/main/perl/Systemd/Service.pm
+++ b/ncm-systemd/src/main/perl/Systemd/Service.pm
@@ -510,8 +510,9 @@ sub process
             };
         }
         if ($addact) {
-            push(@{$acts->{$expected_act}}, $unit);
-            $msg .= ($expected_act ? '' : 'de') . "activation";
+            my $force = $detail->{force} || 0;
+            $msg .= ($expected_act ? '' : 'de') . "activation force=$force";
+            push(@{$acts->{$expected_act}}, [$unit, $force]);
         }
         $self->verbose($msg ? "process: unit $unit scheduled for $msg" :
                               "process: nothing to do for unit $unit");
@@ -562,7 +563,8 @@ sub process
                 my $current_act = $self->{unit}->is_active($unit);
                 my $addact = ! (defined($current_act) && ($act eq $current_act));
                 if ($addact) {
-                    push(@{$acts->{$act}}, $unit);
+                    # never force for unconfigured units
+                    push(@{$acts->{$act}}, [$unit, 0]);
                     $msg .= ($act ? ' ' : ' de') . "activation";
                 }
             }
@@ -623,18 +625,35 @@ sub change
     # services which are already queued to be stopped may cause deadlocks.
     # Trying to start services which were just stopped may lead to unexpected
     # behavior and data loss.
+    my $change = 0;
     if ($multi_user_active eq 'active') {
-        # TODO: same TODOs as with states
-        foreach my $act (sort keys %$acts) {
-            my @units = @{$acts->{$act}};
-
-            # TODO: process units wrt dependencies?
-            if (@units) {
-                systemctl_command_units($self, $change_activation->{$act}, @units);
-            }
-        }
+        $change = 1;
     } else {
-        $self->info("$TARGET_MULTIUSER.target is not active, not starting or stopping any services.");
+        $self->info("$TARGET_MULTIUSER.target is not active (found is-active $multi_user_active), ",
+                    "not starting or stopping any services unless forced.");
+    }
+    # TODO: same TODOs as with states
+    foreach my $act (sort keys %$acts) {
+        my @units;
+        foreach my $unit_force (@{$acts->{$act}}) {
+            my $unit = $unit_force->[0];
+            my $force = $unit_force->[1];
+
+            my $add_unit = $change;
+            if (!$add_unit && $force) {
+                $add_unit = 1;
+                $self->info("$TARGET_MULTIUSER.target is not active, but found $unit forced. Will change activation.")
+            };
+
+            if ($add_unit) {
+                push(@units, $unit);
+            };
+        };
+
+        # TODO: process units wrt dependencies?
+        if (@units) {
+            systemctl_command_units($self, $change_activation->{$act}, @units);
+        }
     }
 
 }

--- a/ncm-systemd/src/test/perl/service.t
+++ b/ncm-systemd/src/test/perl/service.t
@@ -238,6 +238,7 @@ is_deeply($configured->{'rbdmap.service'}, { # sysv, not in chkconfig
     type => $TYPE_SERVICE,
     shortname => "rbdmap",
     possible_missing => 0,
+    force => 1,
 }, "configured rbdmap service for ceph021");
 
 # not installed, and we don't want it running
@@ -380,8 +381,8 @@ is_deeply($states, {
     'unmask' => ['cups.service'],
 }, "State changes to be made");
 is_deeply($acts, {
-    0 => ['missing_disabled.service'],
-    1 => ['netconsole.service', 'network.service', 'rbdmap.service'],
+    0 => [['missing_disabled.service', 0]],
+    1 => [['netconsole.service', 0], ['network.service', 0], ['rbdmap.service', 1]],
 }, "Activations to be made");
 
 
@@ -402,19 +403,29 @@ sub check_uu
     }
 }
 
+sub units_from_acts
+{
+    my $_acts = shift;
+    my @units;
+    foreach my $act (@$_acts) {
+        push(@units, $act->[0]);
+    };
+    return \@units;
+}
+
 foreach my $unconf (@$unconfs) {
     next if $unconf eq $UNCONFIGURED_IGNORE;
     # use unconfigred current value (ie all units, not only relevant ones)
     my ($ustates, $uacts) = $svc->process($configured, $ucurrent, $unconf);
-    diag "ustates uacts $unconf", explain $ustates, explain $uacts;
+    diag "ustates uacts $unconf ", explain $ustates, explain $uacts;
     # check for unconfigured enabled/disabled/running/non-running units
     # check that all others are not modified
     my $same_start = $unconf ne $UNCONFIGURED_ON;
-    check_uu($same_start, $uacts->{1}, $acts->{1}, "start actions for $unconf",
+    check_uu($same_start, units_from_acts($uacts->{1}), units_from_acts($acts->{1}), "start actions for $unconf",
              'syslog.service', 'syslog.target');
 
     my $same_stop = $unconf ne $UNCONFIGURED_OFF;
-    check_uu($same_stop, $uacts->{0}, $acts->{0}, "stop actions for $unconf",
+    check_uu($same_stop, units_from_acts($uacts->{0}), units_from_acts($acts->{0}), "stop actions for $unconf",
              '-.mount', 'timers.target',);
 
     my $same_enabled = $same_start && $unconf ne $UNCONFIGURED_ENABLED;
@@ -480,10 +491,12 @@ ok(command_history_ok([
     "$SYSTEMCTL disable -- missing_disabled.service",
     "$SYSTEMCTL enable -- netconsole.service",
     "$SYSTEMCTL enable -- rbdmap.service",
+    "$SYSTEMCTL start -- rbdmap.service",  # forced
     # 2 activity
 ], [
-    "systemctl stop",
-    "systemctl start",
+    "$SYSTEMCTL stop",
+    "$SYSTEMCTL start -- (?!rbdmap)",
+    "$SYSTEMCTL start -- network.service",
 ]), "no stop/start commands during shutdown");
 
 =pod
@@ -513,7 +526,7 @@ ok(command_history_ok([
     "$SYSTEMCTL stop -- missing_disabled.service",
     "$SYSTEMCTL start -- netconsole.service",
     "$SYSTEMCTL start -- network.service",
-    "$SYSTEMCTL start -- rbdmap.service",
+    "$SYSTEMCTL start -- rbdmap.service",  # forced, but would run start either anyway
 ]), "expected commands for change");
 
 

--- a/ncm-systemd/src/test/perl/service.t
+++ b/ncm-systemd/src/test/perl/service.t
@@ -58,15 +58,15 @@ Test set_unconfigured_default
 
 # Only tests the systemd setting.
 $cmp->{ERROR} = 0;
-is($svc->set_unconfigured_default($cfg), $UNCONFIGURED_IGNORE,
+is($svc->set_unconfigured_default($cfg, 0), $UNCONFIGURED_IGNORE,
     "Set unconfigured to ignore");
 is($cmp->{ERROR}, 0, "No errors logged");
 
 =pod
 
-=head2 gather_configured_services
+=head2 gather_configured_units
 
-Test gather_configured_services
+Test gather_configured_units
 
 =cut
 
@@ -81,7 +81,7 @@ $mockuf->mock("write", sub {
     return 1;
 });
 
-my $gathered_configured_units = $svc->gather_configured_units($cfg);
+my $gathered_configured_units = $svc->gather_configured_units($cfg, 0);
 #diag explain $gathered_configured_units;
 is_deeply($gathered_configured_units, {
     'test_on.service' => {
@@ -179,6 +179,14 @@ ok($gathered_configured_units->{$uf_write[0]->[0]}, "service with file/only=0 is
 ok(! defined($gathered_configured_units->{$uf_write[0]->[1]}),
    "service with file/only=1 is not added to the configured units");
 
+
+my $gathered_configured_units_nochkconfig = $svc->gather_configured_units($cfg, 1);
+diag "no chkconfig", sort keys %$gathered_configured_units_nochkconfig;
+is_deeply([sort keys %$gathered_configured_units_nochkconfig],
+          [qw(othername2.service test2_add.target test2_on.service test_4_no_restart.service test_del.service test_off.service)],
+          "gather configured units from systemd component only",
+    );
+
 =pod
 
 =head2 gather_current_units
@@ -199,7 +207,7 @@ set_output('gen_full_el7_ceph021_systemctl_is_enabled_cups.service_unit-files');
 
 $cfg = get_config_for_profile('service_ceph021');
 
-my $configured = $svc->gather_configured_units($cfg, $UNCONFIGURED_IGNORE);
+my $configured = $svc->gather_configured_units($cfg, 0);
 is_deeply($configured->{'network.service'}, { # sysv, on
     name => "network.service",
     startstop => 1,

--- a/ncm-systemd/src/test/resources/service_ceph021.pan
+++ b/ncm-systemd/src/test/resources/service_ceph021.pan
@@ -5,6 +5,7 @@ include 'service_services_ceph021';
 prefix "/software/components/systemd/unit";
 "{missing_masked.service}" = dict("state", "masked", "targets", list("multi-user"), "startstop", true);
 "{missing_disabled.service}" = dict("state", "disabled", "targets", list("multi-user"), "startstop", true);
+"rbdmap/force" = true;
 
 prefix "/software/components/chkconfig/service";
 "{missing_disabled_chkconfig}" = dict("off", "", "startstop", true);

--- a/ncm-systemd/src/test/resources/service_services.pan
+++ b/ncm-systemd/src/test/resources/service_services.pan
@@ -5,4 +5,3 @@ object template service_services;
 include 'service-unit_simple_services';
 
 include 'service-chkconfig_simple_services';
-


### PR DESCRIPTION
Add support for: 

- Allow to force start/stop activation for selected units. As the comment mentions, this is potentially dangerous; but there are cases where it might be welcome. The underlying problem is that ncm-cdispd and ks-post-reboot get started as unit with multi-user.target possibly not yet finished by the time this runs. And that is ok; unless you really need certain services to run, eg have openvswitch running to let ncm-network configure the network. Because reaching multi-user.target and running ncm-ncd by the mentioned services is a race condition, we need the predictability.

- Allow to ignore chkconfig configuration:  usefull when making limited clones of ncm-systemd that can be used to control limited specific units.