### PR TITLE
ncm-opennebula: Add generic quotas support in OpenNebula

### DIFF
--- a/ncm-opennebula/src/main/pan/components/opennebula/monitord.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/monitord.pan
@@ -45,6 +45,8 @@ type opennebula_probes_period = {
     @{When monitor probes have been stopped more than sync_vm_state
     seconds, send a complete VM report}
     "sync_state_vm" : long(1..) = 180
+    @{Time in seconds to send VM command execution result}
+    "exec_vm" : long(1..) = 5
 } = dict();
 
 @documentation{

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -994,6 +994,16 @@ type opennebula_oned = {
         "VCENTER_CCR_REF",
         "VCENTER_INSTANCE_ID",
     )
+    @{QUOTA_VM_ATTRIBUTE is an optional string list to define generic quotas like GPUs.
+     Each generic quota defined with the QUOTA_VM_ATTRIBUTE is automatically
+     included in the VM_RESTRICTED_ATTR set.
+     This inclusion prevents regular users from circumventing the quota system
+     by altering the attributes related to these generic quotas.
+
+     See:
+     https://docs.opennebula.io/7.2/product/cloud_system_administration/capacity_planning/quotas/
+     }
+    "quota_vm_attribute" ? string[]
 };
 
 

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -123,7 +123,7 @@ type opennebula_hook_log_conf = {
 
 type opennebula_auth_mad = {
     "executable" : string = 'one_auth_mad'
-    "authn" : string = 'ssh,x509,ldap,server_cipher,server_x509'
+    "authn" : string = 'ssh,x509,ldap,server_cipher,server_x509,saml'
 } = dict();
 
 type opennebula_tm_mad_conf = {
@@ -132,12 +132,15 @@ type opennebula_tm_mad_conf = {
     "clone_target" : choice('SYSTEM', 'NONE', 'SELF') = "SYSTEM"
     "shared" : boolean = true
     "ds_migrate" ? boolean
-    "driver" ? choice('raw', 'qcow2')
+    "ds_live_migrate" ? boolean
+    "ds_migrate_snap" ? boolean
+    "driver" ? choice('raw', 'qcow2', 'virtiofs')
     "allow_orphans" ? string
     "tm_mad_system" ? string
     "ln_target_ssh" ? string
     "clone_target_ssh" ? string
     "disk_type_ssh" ? string
+    "disk_type" ? choice('filesystem', 'block')
     "ln_target_shared" ? string
     "clone_target_shared" ? string
     "disk_type_shared" ? string
@@ -158,9 +161,14 @@ type opennebula_auth_mad_conf = {
     will be disabled, with the exception of chgrp to one of
     the groups in the list of secondary groups}
     "driver_managed_groups" : boolean = false
+    @{When set to "true" user needs to manage group
+    admin membership manually, when "false" group admin
+    membership is managed by the auth driver}
+    "driver_managed_group_admin" : boolean = false
     @{Limit the maximum token validity, in seconds. Use -1 for
     unlimited maximum, 0 to disable login tokens}
     "max_token_time" : long(-1..) = -1
+    "password_required" ? boolean
 } = dict();
 
 @documentation{
@@ -187,6 +195,7 @@ type opennebula_ds_mad_conf = {
     @{specifies whether the datastore can only manage persistent images}
     "persistent_only" : boolean = false
     "marketplace_actions" ? string
+    "datastore_capacity_check" ? boolean
 } = dict();
 
 @documentation{
@@ -468,6 +477,8 @@ type opennebula_oned = {
     "default_device_prefix" ? opennebula_device_prefix = 'hd'
     "onegate_endpoint" ? string
     "manager_timer" ? long
+    "grpc_port" : type_port = 2634
+    "grpc_listen_address" : type_ipv4 = '0.0.0.0'
     "monitoring_interval" : long = 60
     "monitoring_threads" : long = 50
     @{Time in seconds between each DATASTORE monitoring cycle}
@@ -637,6 +648,25 @@ type opennebula_oned = {
             "disk_type_shared", "FILE",
         ),
         dict("name", "vcenter", "clone_target", "NONE"),
+        dict(
+            "name", "purefa",
+            "clone_target", "SELF",
+            "driver", "raw",
+            "disk_type", "block",
+            "allow_orphans", "yes",
+            "ds_migrate", false,
+            "ds_live_migrate", false,
+            "ds_migrate_snap", false,
+        ),
+        dict(
+            "name", "virtiofs",
+            "clone_target", "NONE",
+            "driver", "virtiofs",
+            "disk_type", "filesystem",
+            "ds_migrate", false,
+            "ds_live_migrate", false,
+            "ds_migrate_snap", false,
+        ),
     )
     "ds_mad_conf" : opennebula_ds_mad_conf[] = list(
         dict(),
@@ -668,6 +698,16 @@ type opennebula_oned = {
             "required_attrs", list('VCENTER_INSTANCE_ID', 'VCENTER_DS_REF', 'VCENTER_DC_REF'),
             "persistent_only", false,
             "marketplace_actions", "export",
+        ),
+        dict(
+            "name", "purefa",
+            "required_attrs", list('PUREFA_HOST', 'PUREFA_API_TOKEN', 'PUREFA_TARGET'),
+            "persistent_only", false,
+        ),
+        dict(
+            "name", "virtiofs",
+            "persistent_only", false,
+            "datastore_capacity_check", false,
         ),
     )
     "market_mad_conf" : opennebula_market_mad_conf[] = list(
@@ -725,6 +765,7 @@ type opennebula_oned = {
         dict(
             "name", "ldap",
             "password_change", true,
+            "password_required", false,
             "driver_managed_groups", true,
             "max_token_time", 86400,
         ),
@@ -735,6 +776,14 @@ type opennebula_oned = {
         dict(
             "name", "server_x509",
             "password_change", false,
+        ),
+        dict(
+            "name", "saml",
+            "password_change", true,
+            "password_required", false,
+            "driver_managed_groups", true,
+            "driver_managed_group_admin", true,
+            "max_token_time", 86400,
         ),
     )
     "vn_mad_conf" : opennebula_vn_mad_conf[] = list(
@@ -875,7 +924,11 @@ type opennebula_oned = {
     )
     "vm_encrypted_attr" : string[] = list("CONTEXT/PASSWORD")
     "vnet_encrypted_attr" : string[] = list("AR/PACKET_TOKEN")
-    "datastore_encrypted_attr" : string[] = list("PROVISION/PACKET_TOKEN")
+    "datastore_encrypted_attr" : string[] = list(
+        "PROVISION/PACKET_TOKEN",
+        "NETAPP_PASS",
+        "PUREFA_API_TOKEN",
+    )
     "cluster_encrypted_attr" : string[] = list("PROVISION/PACKET_TOKEN")
     "inherit_datastore_attr" : string[] = list(
         "CEPH_HOST",
@@ -904,6 +957,8 @@ type opennebula_oned = {
         "DISK_TYPE",
         "VCENTER_ADAPTER_TYPE",
         "VCENTER_DISK_TYPE",
+        "MOUNT_POINT",
+        "MOUNT_TAG",
     )
     "inherit_vnet_attr" : string[] = list(
         "VLAN_TAGGED_ID",

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -14,16 +14,42 @@ include 'components/opennebula/monitord';
 include 'components/opennebula/sched';
 include 'components/opennebula/fireedge';
 
+@documentation{
+Federation & HA configuration attributes.
+Control the federation attributes of oned. Operation in a federated setup
+requires a special DB configuration.
+See:
+https://docs.opennebula.io/7.0/product/control_plane_configuration/high_availability/frontend_ha
+}
 type opennebula_federation = {
-    "mode" : string = 'STANDALONE' with match (SELF, '^(STANDALONE|MASTER|SLAVE)$')
-    "zone_id" : long = 0
+    @{MODE: Operation mode of this oned.
+        STANDALONE no federated.This is the default operational mode
+        MASTER     this oned is the master zone of the federation
+        SLAVE      this oned is a slave zone
+    }
+    "mode" : choice('STANDALONE', 'MASTER', 'SLAVE') = 'STANDALONE'
+    @{The zone ID as returned by onezone command}
+    "zone_id" : long(0..) = 0
+    @{The xml-rpc endpoint of the master oned, e.g:
+        http://master.one.org:2633/RPC2
+    Empty by default without federation setup.}
     "master_oned" : string = ''
+    @{ID identifying this server in the zone as returned by the
+    onezone server-add command. This ID controls the HA configuration of
+    OpenNebula:
+        -1 (default) OpenNebula will operate in "solo" mode no HA
+        <id> Operate in HA (leader election and state replication)
+    }
     "server_id" : long(-1..) = -1
 } = dict();
 
 @documentation{
 Since 5.12.x Opennebula uses the Raft algorithm.
-It can be tuned by several parameters in the configuration file
+It can be tuned by several parameters in the configuration file.
+
+NOTE: Timeout tunning depends on the latency of the servers (network and load)
+as well as the max downtime tolerated by the system. Timeouts needs to be
+greater than 10ms.
 }
 type opennebula_raft = {
     @{Number of DB log records that will be deleted on each purge}
@@ -44,6 +70,21 @@ type opennebula_raft = {
     "xmlrpc_timeout_ms" : long(0..) = 1000
 } = dict();
 
+@documentation{
+Executed when a server transits from follower->leader
+or from leader->follower.
+The purpose of this hook is to configure the Virtual IP.
+}
+type opennebula_raft_hook = {
+    @{raft/vip.sh is a fully working script, this should not be changed}
+    "command" : string = 'raft/vip.sh'
+    @{Arguments: leader/follower interface ip_cidr [interface ip_cidr ...]
+    For example, as follower:
+        "follower ens1 10.0.0.2/24"
+    or for a leader hook:
+        "leader ens1 10.0.0.2/24"}
+    "arguments" : string
+} = dict();
 
 type opennebula_vm_mad_kvm = {
     include opennebula_vm
@@ -502,6 +543,8 @@ type opennebula_oned = {
     "log" : opennebula_log
     "federation" : opennebula_federation
     "raft" : opennebula_raft
+    "raft_leader_hook" ? opennebula_raft_hook
+    "raft_follower_hook" ? opennebula_raft_hook
     "port" : type_port = 2633
     "vnc_base_port" : long = 5900
     "network_size" : long = 254

--- a/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
+++ b/ncm-opennebula/src/main/pan/components/opennebula/schema.pan
@@ -99,6 +99,11 @@ type opennebula_vm_mad = {
     "xen" ? opennebula_vm_mad_xen
 } = dict();
 
+type opennebula_ipam_mad = {
+    "executable" : string = 'one_ipam'
+    "arguments" : string = '-t 1 -i dummy,aws,equinix,vultr'
+} = dict();
+
 type opennebula_tm_mad = {
     "executable" : string = 'one_tm'
     "arguments" : string = '-t 15 -d dummy,lvm,shared,fs_lvm,qcow2,ssh,ceph,dev,vcenter,iscsi_libvirt'
@@ -404,6 +409,9 @@ type opennebula_user = {
     in the admin and cloud views. It is also possible to include in the list
     sub-labels using a common slash: list("Name", "Name/SubName")}
     "labels" ? string[]
+    @{The driver that will be used to authenticate the user.
+    core is always used by default if you do not define any driver.}
+    "driver" ? choice('core', 'ssh', 'x509', 'server_cipher', 'server_x509', 'saml', 'public')
 } = dict();
 
 @documentation{
@@ -582,6 +590,7 @@ type opennebula_oned = {
             "threads", 8,
         ),
     )
+    "ipam_mad" : opennebula_ipam_mad
     "vm_mad" : opennebula_vm_mad
     "tm_mad" : opennebula_tm_mad
     "datastore_mad" : opennebula_datastore_mad

--- a/ncm-opennebula/src/main/perl/OpenNebula/Account.pm
+++ b/ncm-opennebula/src/main/perl/OpenNebula/Account.pm
@@ -74,7 +74,8 @@ sub manage_consumers
                 $self->info("Creating new $type: ", $consumer);
                 if (exists $data->{$consumer}->{password}) {
                     # Create new user
-                    $one->$createmethod($consumer, $data->{$consumer}->{password}, $CORE_AUTH_DRIVER);
+                    my $driver = $data->{$consumer}->{driver} // $CORE_AUTH_DRIVER;
+                    $one->$createmethod($consumer, $data->{$consumer}->{password}, $driver);
                     $self->set_user_primary_group($one, $consumer, $data->{$consumer}->{group}) if (exists $data->{$consumer}->{group});
                 } else {
                     # Create new group/cluster

--- a/ncm-opennebula/src/main/resources/oned.tt
+++ b/ncm-opennebula/src/main/resources/oned.tt
@@ -1,6 +1,6 @@
 [%- oned_section = ['db', 'log', 'federation', 'datastore_mad', 'tm_mad', 'hm_mad',
                     'auth_mad', 'default_cost', 'vnc_ports', 'vlan_ids', 'vxlan_ids',
-                    'market_mad', 'raft', 'hook_log_conf'] -%]
+                    'market_mad', 'raft', 'hook_log_conf', 'raft_leader_hook', 'raft_follower_hook'] -%]
 [%- booleans = ['datastore_capacity_check', 'compare_binary'] -%]
 [%- digits = ['monitoring_interval', 'monitoring_threads', 'monitoring_interval_datastore',
               'monitoring_interval_market', 'monitoring_interval_db_update',

--- a/ncm-opennebula/src/main/resources/oned.tt
+++ b/ncm-opennebula/src/main/resources/oned.tt
@@ -9,7 +9,7 @@
 [%- oned_attr_list = ['vm_restricted_attr', 'inherit_datastore_attr', 'inherit_vnet_attr', 'user_restricted_attr',
                       'image_restricted_attr', 'vnet_restricted_attr', 'inherit_image_attr', 'group_restricted_attr',
                       'host_encrypted_attr', 'vm_encrypted_attr', 'vnet_encrypted_attr', 'datastore_encrypted_attr',
-                      'cluster_encrypted_attr'] -%]
+                      'cluster_encrypted_attr', 'quota_vm_attribute'] -%]
 [%- mad_conf_section = ['tm_mad_conf', 'ds_mad_conf', 'market_mad_conf', 'auth_mad_conf', 'vn_mad_conf', 'im_mad'] -%]
 [%- op_list_attrs = ['vm_admin_operations', 'vm_manage_operations', 'vm_use_operations'] -%]
 [%- FOR pair IN oned.pairs -%]

--- a/ncm-opennebula/src/main/resources/oned.tt
+++ b/ncm-opennebula/src/main/resources/oned.tt
@@ -1,4 +1,4 @@
-[%- oned_section = ['db', 'log', 'federation', 'datastore_mad', 'tm_mad', 'hm_mad',
+[%- oned_section = ['db', 'log', 'federation', 'datastore_mad', 'tm_mad', 'hm_mad', 'ipam_mad',
                     'auth_mad', 'default_cost', 'vnc_ports', 'vlan_ids', 'vxlan_ids',
                     'market_mad', 'raft', 'hook_log_conf', 'raft_leader_hook', 'raft_follower_hook'] -%]
 [%- booleans = ['datastore_capacity_check', 'compare_binary'] -%]

--- a/ncm-opennebula/src/main/resources/oned_level1.tt
+++ b/ncm-opennebula/src/main/resources/oned_level1.tt
@@ -1,9 +1,10 @@
 [%- digits = ['port', 'debug_level', 'zone_id', 'cpu_cost', 'memory_cost', 'disk_cost', 'start',
               'broadcast_timeout_ms', 'election_timeout_ms', 'limit_purge', 'log_purge_timeout',
-              'log_retention', 'xmlrpc_timeout_ms', 'threads', 'connections',
+              'log_retention', 'xmlrpc_timeout_ms', 'threads', 'connections', 'exec_vm',
               'beacon_host', 'monitor_host', 'monitor_vm', 'state_vm', 'sync_state_vm', 'system_host'] -%]
 [%- booleans = ['shared', 'persistent_only', 'keep_snapshots', 'ds_migrate', 'public', 'password_change',
-                'driver_managed_groups', 'compare_binary'] -%]
+                'password_required', 'datastore_capacity_check', 'ds_live_migrate', 'ds_migrate_snap',
+                'driver_managed_groups', 'driver_managed_group_admin', 'compare_binary'] -%]
 [%- comma_list_attrs = ['imported_vms_actions', 'required_attrs', 'app_actions', 'host_affined', 'host_anti_affined'] -%]
 [
 [% FILTER indent -%]

--- a/ncm-opennebula/src/main/resources/tests/profiles/oned.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/oned.pan
@@ -15,6 +15,12 @@ prefix "/metaconfig/contents/oned";
     "passwd", "my-fancy-pass",
     "db_name", "opennebula",
 );
+"raft_leader_hook" = dict(
+    "arguments", "leader ens1 10.0.0.2/24",
+);
+"raft_follower_hook" = dict(
+    "arguments", "follower ens1 10.0.0.2/24",
+);
 "log" = dict(
     "system", "syslog",
     "debug_level", 3,

--- a/ncm-opennebula/src/main/resources/tests/profiles/oned.pan
+++ b/ncm-opennebula/src/main/resources/tests/profiles/oned.pan
@@ -25,5 +25,6 @@ prefix "/metaconfig/contents/oned";
     "system", "syslog",
     "debug_level", 3,
 );
+"quota_vm_attribute" = list("GPU_L40", "GPU_A20");
 "default_device_prefix" = "vd";
 "onegate_endpoint" = "http://hyp004.cubone.os:5030";

--- a/ncm-opennebula/src/main/resources/tests/regexps/monitord/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/monitord/simple
@@ -22,6 +22,7 @@ multiline
 ^\s*threads\s?=\s*\d+\s*$
 ^PROBES_PERIOD\s?=\s?\[$
 ^\s*beacon_host\s?=\s*\d+,\s*$
+^\s*exec_vm\s?=\s*\d+,\s*$
 ^\s*monitor_host\s?=\s*\d+,\s*$
 ^\s*monitor_vm\s?=\s*\d+,\s*$
 ^\s*state_vm\s?=\s*\d+,\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/oned/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/oned/simple
@@ -97,6 +97,7 @@ multiline
 ^NETWORK_SIZE\s?=\s*\d+\s*$
 ^ONEGATE_ENDPOINT\s?=\s?".+"\s*$
 ^PORT\s?=\s*\d+\s*$
+^QUOTA_VM_ATTRIBUTE\s?=\s*".+"\s*$
 ^RAFT\s?=\s?\[$
 ^\s*broadcast_timeout_ms\s?=\s*\d+,\s*$
 ^\s*election_timeout_ms\s?=\s*\d+,\s*$

--- a/ncm-opennebula/src/main/resources/tests/regexps/oned/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/oned/simple
@@ -100,6 +100,12 @@ multiline
 ^\s*log_purge_timeout\s?=\s*\d+,\s*$
 ^\s*log_retention\s?=\s*\d+,\s*$
 ^\s*xmlrpc_timeout_ms\s?=\s*\d+\s*$
+^RAFT_FOLLOWER_HOOK\s?=\s?\[$
+^\s*arguments\s?=\s*".+",\s*$
+^\s*command\s?=\s*".+"\s*$
+^RAFT_LEADER_HOOK\s?=\s?\[$
+^\s*arguments\s?=\s*".+",\s*$
+^\s*command\s?=\s*".+"\s*$
 ^SCRIPTS_REMOTE_DIR\s?=\s?".+"\s*$
 ^SESSION_EXPIRATION_TIME\s?=\s*\d+\s*$
 ^TM_MAD\s?=\s?\[$

--- a/ncm-opennebula/src/main/resources/tests/regexps/oned/simple
+++ b/ncm-opennebula/src/main/resources/tests/regexps/oned/simple
@@ -71,6 +71,10 @@ multiline
 ^INHERIT_DATASTORE_ATTR\s?=\s?".+"\s*$
 ^INHERIT_IMAGE_ATTR\s?=\s?".+"\s*$
 ^INHERIT_VNET_ATTR\s?=\s?".+"\s*$
+^IPAM_MAD\s?=\s?\[$
+^\s*arguments\s?=\s*".+",\s*$
+^\s*executable\s?=\s*".+"\s*$
+^\]$
 ^LISTEN_ADDRESS\s?=\s?".+"\s*$
 ^LOG\s?=\s?\[$
 ^\s*debug_level\s?=\s*\d+,\s*$

--- a/ncm-opennebula/src/test/perl/rpcdata.pm
+++ b/ncm-opennebula/src/test/perl/rpcdata.pm
@@ -32,7 +32,7 @@ $cmds{rpc_create_newuser}{params} = ["lsimngar", "my_fancy_pass", "core"];
 $cmds{rpc_create_newuser}{method} = "one.user.allocate";
 $cmds{rpc_create_newuser}{out} = 3;
 
-$cmds{rpc_create_newuser2}{params} = ["stdweird", "another_fancy_pass", "core"];
+$cmds{rpc_create_newuser2}{params} = ["stdweird", "another_fancy_pass", "public"];
 $cmds{rpc_create_newuser2}{method} = "one.user.allocate";
 $cmds{rpc_create_newuser2}{out} = 4;
 
@@ -67,7 +67,7 @@ EOF
 $cmds{rpc_list_user2}{params} = [4];
 $cmds{rpc_list_user2}{method} = "one.user.info";
 $cmds{rpc_list_user2}{out} = <<'EOF';
-<USER><ID>4</ID><GID>1</GID><GROUPS><ID>1</ID></GROUPS><GNAME>users</GNAME><NAME>stdweird</NAME><PASSWORD>954f663ba92466ccdc74a605f975904f59682dbc</PASSWORD><AUTH_DRIVER>core</AUTH_DRIVER><ENABLED>1</ENABLED><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR><TOKEN_PASSWORD><![CDATA[4a782c2aec2b95bf97701d4a57f7cc9032d7331b]]></TOKEN_PASSWORD></TEMPLATE><DATASTORE_QUOTA></DATASTORE_QUOTA><NETWORK_QUOTA></NETWORK_QUOTA><VM_QUOTA></VM_QUOTA><IMAGE_QUOTA></IMAGE_QUOTA><DEFAULT_USER_QUOTAS><DATASTORE_QUOTA></DATASTORE_QUOTA><NETWORK_QUOTA></NETWORK_QUOTA><VM_QUOTA></VM_QUOTA><IMAGE_QUOTA></IMAGE_QUOTA></DEFAULT_USER_QUOTAS></USER>
+<USER><ID>4</ID><GID>1</GID><GROUPS><ID>1</ID></GROUPS><GNAME>users</GNAME><NAME>stdweird</NAME><PASSWORD>954f663ba92466ccdc74a605f975904f59682dbc</PASSWORD><AUTH_DRIVER>public</AUTH_DRIVER><ENABLED>1</ENABLED><TEMPLATE><QUATTOR><![CDATA[1]]></QUATTOR><TOKEN_PASSWORD><![CDATA[4a782c2aec2b95bf97701d4a57f7cc9032d7331b]]></TOKEN_PASSWORD></TEMPLATE><DATASTORE_QUOTA></DATASTORE_QUOTA><NETWORK_QUOTA></NETWORK_QUOTA><VM_QUOTA></VM_QUOTA><IMAGE_QUOTA></IMAGE_QUOTA><DEFAULT_USER_QUOTAS><DATASTORE_QUOTA></DATASTORE_QUOTA><NETWORK_QUOTA></NETWORK_QUOTA><VM_QUOTA></VM_QUOTA><IMAGE_QUOTA></IMAGE_QUOTA></DEFAULT_USER_QUOTAS></USER>
 EOF
 
 $cmds{rpc_list_user3}{params} = [0];

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -23,6 +23,14 @@ prefix "/software/components/opennebula/oned";
     "passwd", "my-fancy-pass",
     "db_name", "opennebula",
 );
+
+"raft_leader_hook" = dict(
+    "arguments", "leader ens1 10.0.0.2/24",
+);
+"raft_follower_hook" = dict(
+    "arguments", "follower ens1 10.0.0.2/24",
+);
+
 "log" = dict(
     "system", "syslog",
     "debug_level", 3,

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -273,6 +273,7 @@ prefix "/software/components/opennebula";
     ),
     "stdweird", dict(
         "password", "another_fancy_pass",
+        "driver", "public",
     ),
     "serveradmin", dict(
         "password", "yet_another_fancy_pass",

--- a/ncm-opennebula/src/test/resources/one.pan
+++ b/ncm-opennebula/src/test/resources/one.pan
@@ -31,6 +31,8 @@ prefix "/software/components/opennebula/oned";
     "arguments", "follower ens1 10.0.0.2/24",
 );
 
+"quota_vm_attribute" = list("GPU_L40", "GPU_A20");
+
 "log" = dict(
     "system", "syslog",
     "debug_level", 3,


### PR DESCRIPTION
Includes generic quotas support in OpenNebula >= 7.2
These changes are backwards compatible with older versions.
See: 
https://docs.opennebula.io/7.2/product/cloud_system_administration/capacity_planning/quotas/#defining-usergroup-quotas

NOTE: #1873  should be reviewed/merged first.

Resolves: #1879 